### PR TITLE
chore(ci): opt into Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - VERSION
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to `ci.yml` and `release.yml`
- Suppresses Node.js 20 deprecation warnings
- Prepares for mandatory Node.js 24 migration on **June 2, 2026**

## Test plan

- [x] CI runs clean without Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)