### PR TITLE
test(handler): add spec guard coverage for login/device/account

### DIFF
--- a/internal/handler/account_test.go
+++ b/internal/handler/account_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/kangheeyong/authgate/internal/service"
 )
 
 // newTestAccountHandler creates an AccountHandler with nil service.
@@ -73,4 +75,25 @@ func TestDeleteAccount_OriginMatch_PassesOriginCheck(t *testing.T) {
 	}
 	// Either panicked at service call or returned normally; both confirm origin check passed
 	_ = panicked
+}
+
+func TestDeleteAccount_NoSession_Unauthorized(t *testing.T) {
+	svc := service.NewAccountService(nil)
+	h := NewAccountHandler(svc, "http://authgate.example.com")
+
+	req := httptest.NewRequest(http.MethodDelete, "/account", nil)
+	w := httptest.NewRecorder()
+	h.HandleDeleteAccount(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+	if body["error"] == "" {
+		t.Fatal("error field should be present")
+	}
 }

--- a/internal/handler/device_test.go
+++ b/internal/handler/device_test.go
@@ -100,3 +100,19 @@ func TestDevicePage_NoUserCode_Renders200HTML(t *testing.T) {
 		t.Errorf("Content-Type = %q, want text/html", ct)
 	}
 }
+
+// /device/auth/callback에서 code/state 누락 시 400 에러 페이지를 반환해야 한다.
+func TestDeviceCallback_MissingCodeOrState_ReturnsBadRequest(t *testing.T) {
+	h := newTestDeviceHandler()
+	req := httptest.NewRequest(http.MethodGet, "/device/auth/callback", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleDeviceCallback(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+		t.Fatalf("Content-Type = %q, want text/html", ct)
+	}
+}

--- a/internal/handler/login_test.go
+++ b/internal/handler/login_test.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kangheeyong/authgate/internal/service"
+)
+
+func newTestLoginHandler(devMode bool) *LoginHandler {
+	svc := service.NewLoginService(nil, nil, nil, 0)
+	return NewLoginHandler(svc, devMode)
+}
+
+func TestLogin_MissingAuthRequestID_ReturnsBadRequest(t *testing.T) {
+	h := newTestLoginHandler(true)
+	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+		t.Fatalf("Content-Type = %q, want text/html", ct)
+	}
+}
+
+func TestMCPLogin_MissingAuthRequestID_ReturnsBadRequest(t *testing.T) {
+	h := newTestLoginHandler(true)
+	req := httptest.NewRequest(http.MethodGet, "/mcp/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleMCPLogin(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestLoginCallback_MissingCodeOrState_ReturnsBadRequest(t *testing.T) {
+	h := newTestLoginHandler(true)
+	req := httptest.NewRequest(http.MethodGet, "/login/callback", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleCallback(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestMCPCallback_MissingCodeOrState_ReturnsBadRequest(t *testing.T) {
+	h := newTestLoginHandler(true)
+	req := httptest.NewRequest(http.MethodGet, "/mcp/callback", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleMCPCallback(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestSetSessionCookie_SecureDependsOnDevMode(t *testing.T) {
+	t.Run("prod mode uses Secure", func(t *testing.T) {
+		h := newTestLoginHandler(false)
+		w := httptest.NewRecorder()
+		h.setSessionCookie(w, "sess-prod")
+
+		resp := w.Result()
+		cookies := resp.Cookies()
+		if len(cookies) != 1 {
+			t.Fatalf("cookies = %d, want 1", len(cookies))
+		}
+		c := cookies[0]
+		if !c.Secure {
+			t.Fatalf("Secure = false, want true")
+		}
+		if !c.HttpOnly {
+			t.Fatalf("HttpOnly = false, want true")
+		}
+		if c.Path != "/" {
+			t.Fatalf("Path = %q, want /", c.Path)
+		}
+	})
+
+	t.Run("dev mode disables Secure", func(t *testing.T) {
+		h := newTestLoginHandler(true)
+		w := httptest.NewRecorder()
+		h.setSessionCookie(w, "sess-dev")
+
+		resp := w.Result()
+		cookies := resp.Cookies()
+		if len(cookies) != 1 {
+			t.Fatalf("cookies = %d, want 1", len(cookies))
+		}
+		if cookies[0].Secure {
+			t.Fatalf("Secure = true, want false")
+		}
+	})
+}
+
+func TestGetSessionCookie(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "abc123"})
+
+	if got := getSessionCookie(req); got != "abc123" {
+		t.Fatalf("cookie value = %q, want abc123", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add new handler tests for login and mcp missing-parameter guards
- add cookie security behavior test for login session cookie (dev vs prod)
- add device callback missing code/state guard test
- add account delete no-session unauthorized guard test

## Validation
- mkdir -p .gocache && GOCACHE=/Users/kangheeyong/project/authgate/.gocache go test ./internal/handler -count=1
