### PR TITLE
test(service): fill remaining spec gaps for MCP/Device/Cleanup

### DIFF
--- a/internal/service/cleanup_test.go
+++ b/internal/service/cleanup_test.go
@@ -187,3 +187,39 @@ func TestE2E8_CleanupRollback(t *testing.T) {
 		t.Errorf("audit count = %d, want 0 after rollback", auditCount)
 	}
 }
+
+// E2E 6: cleanup job idempotency
+func TestCleanup_DeletionPIIScrub_Idempotent(t *testing.T) {
+	db, store, clk := setupCleanupTest(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateUserWithIdentity(ctx, "cleanup-idem@test.com", true, "Idem", "", "google", "cleanup-idem-sub", "cleanup-idem@test.com")
+	db.ExecContext(ctx,
+		`UPDATE users SET status = 'pending_deletion', deletion_scheduled_at = $1 WHERE id = $2`,
+		clk.Now().Add(-1*time.Hour), user.ID,
+	)
+	store.CreateSession(ctx, user.ID, 24*time.Hour)
+
+	svc := NewCleanupService(db, clk, time.Hour)
+	svc.RunOnce(ctx)
+	svc.RunOnce(ctx)
+
+	var status string
+	db.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
+	if status != "deleted" {
+		t.Fatalf("status = %q, want deleted", status)
+	}
+
+	var identityCount, sessionCount, refreshCount, auditCount int
+	db.QueryRowContext(ctx, `SELECT count(*) FROM user_identities WHERE user_id = $1`, user.ID).Scan(&identityCount)
+	db.QueryRowContext(ctx, `SELECT count(*) FROM sessions WHERE user_id = $1`, user.ID).Scan(&sessionCount)
+	db.QueryRowContext(ctx, `SELECT count(*) FROM refresh_tokens WHERE user_id = $1`, user.ID).Scan(&refreshCount)
+	db.QueryRowContext(ctx, `SELECT count(*) FROM audit_log WHERE user_id = $1 AND event_type = 'auth.deletion_completed'`, user.ID).Scan(&auditCount)
+
+	if identityCount != 0 || sessionCount != 0 || refreshCount != 0 {
+		t.Fatalf("child rows should remain deleted, got identities=%d sessions=%d refresh=%d", identityCount, sessionCount, refreshCount)
+	}
+	if auditCount != 1 {
+		t.Fatalf("deletion_completed audit count = %d, want 1", auditCount)
+	}
+}

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -217,6 +217,23 @@ func TestDevice006_InactiveCallback_Rejected(t *testing.T) {
 	}
 }
 
+// device-004: deleted callback -> account_inactive
+func TestDeviceCallback_DeletedUser_Rejected(t *testing.T) {
+	svc, store, _ := setupDeviceExtTest(t, "dev-deleted-sub")
+	ctx := context.Background()
+
+	user, _ := store.CreateUserWithIdentity(ctx, "dev-deleted@test.com", true, "Deleted", "", "google", "dev-deleted-sub", "dev-deleted@test.com")
+	_ = store.SetUserStatus(ctx, user.ID, "deleted")
+
+	result := svc.HandleDeviceCallback(ctx, "fake-code", "DELD-CODE", "127.0.0.1", "test")
+	if result.Action != DeviceError {
+		t.Errorf("action = %v, want DeviceError (deleted on device)", result.Action)
+	}
+	if result.ErrorCode != 403 {
+		t.Errorf("errorCode = %d, want 403", result.ErrorCode)
+	}
+}
+
 // device-011: approve 직전 inactive로 변경 → account_inactive
 func TestDevice011_ApproveAfterDisable(t *testing.T) {
 	svc, store, clk := setupDeviceExtTest(t, "dev-approve-dis-sub")
@@ -235,5 +252,40 @@ func TestDevice011_ApproveAfterDisable(t *testing.T) {
 	}
 	if result.Message != "account_inactive" {
 		t.Errorf("message = %q, want account_inactive", result.Message)
+	}
+}
+
+// device-008 확장: approve 직전 pending/deleted 변경 시 account_inactive
+func TestDeviceApprove_AfterStatusTransition_Rejected(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{name: "pending_deletion", status: "pending_deletion"},
+		{name: "deleted", status: "deleted"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, store, clk := setupDeviceExtTest(t, "dev-approve-"+tt.status)
+			ctx := context.Background()
+
+			user, _ := store.CreateUserWithIdentity(ctx, "dev-approve-"+tt.status+"@test.com", true, "Test", "", "google", "dev-approve-"+tt.status, "dev-approve-"+tt.status+"@test.com")
+			sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
+			insertDeviceCode(t, store, "ASTA-"+tt.status, clk)
+
+			_ = store.SetUserStatus(ctx, user.ID, tt.status)
+
+			result := svc.HandleDeviceApprove(ctx, "ASTA-"+tt.status, "approve", sessionID, "127.0.0.1", "test")
+			if result.Success {
+				t.Fatalf("expected rejection after status transition to %s", tt.status)
+			}
+			if result.ErrorCode != 403 {
+				t.Fatalf("errorCode = %d, want 403", result.ErrorCode)
+			}
+			if result.Message != "account_inactive" {
+				t.Fatalf("message = %q, want account_inactive", result.Message)
+			}
+		})
 	}
 }

--- a/internal/service/mcp_test.go
+++ b/internal/service/mcp_test.go
@@ -96,3 +96,62 @@ func TestMCP005_Recoverable_Rejected(t *testing.T) {
 		t.Errorf("errorCode = %d, want 403", result.ErrorCode)
 	}
 }
+
+// channel-005: pending_deletion + mcp(login with session) -> account_inactive
+func TestMCPLogin_PendingDeletionSession_Rejected(t *testing.T) {
+	svc, store := setupMCPTest(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateUserWithIdentity(ctx, "mcp-login-pending@test.com", true, "MCP Pending", "", "google", "mcp-login-pending-sub", "mcp-login-pending@test.com")
+	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
+	_ = store.SetUserStatus(ctx, user.ID, "pending_deletion")
+	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-login-pending")
+
+	result := svc.HandleMCPLogin(ctx, arID, sessionID, "127.0.0.1", "mcp-client")
+
+	if result.Action != ActionError {
+		t.Errorf("action = %v, want Error", result.Action)
+	}
+	if result.ErrorCode != 403 {
+		t.Errorf("errorCode = %d, want 403", result.ErrorCode)
+	}
+}
+
+// channel-005: deleted + mcp(login with session) -> account_inactive
+func TestMCPLogin_DeletedSession_Rejected(t *testing.T) {
+	svc, store := setupMCPTest(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateUserWithIdentity(ctx, "mcp-login-deleted@test.com", true, "MCP Deleted", "", "google", "mcp-login-deleted-sub", "mcp-login-deleted@test.com")
+	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
+	_ = store.SetUserStatus(ctx, user.ID, "deleted")
+	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-login-deleted")
+
+	result := svc.HandleMCPLogin(ctx, arID, sessionID, "127.0.0.1", "mcp-client")
+
+	if result.Action != ActionError {
+		t.Errorf("action = %v, want Error", result.Action)
+	}
+	if result.ErrorCode != 403 {
+		t.Errorf("errorCode = %d, want 403", result.ErrorCode)
+	}
+}
+
+// mcp-004: deleted user callback -> account_inactive
+func TestMCP_DeletedUser_Rejected(t *testing.T) {
+	svc, store := setupMCPExtTest(t, "mcp-deleted-sub")
+	ctx := context.Background()
+
+	user, _ := store.CreateUserWithIdentity(ctx, "mcp-deleted@test.com", true, "MCP", "", "google", "mcp-deleted-sub", "mcp-deleted@test.com")
+	_ = store.SetUserStatus(ctx, user.ID, "deleted")
+	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-deleted")
+
+	result := svc.HandleMCPCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
+
+	if result.Action != ActionError {
+		t.Errorf("action = %v, want Error (deleted user)", result.Action)
+	}
+	if result.ErrorCode != 403 {
+		t.Errorf("errorCode = %d, want 403", result.ErrorCode)
+	}
+}


### PR DESCRIPTION
## Summary
- add MCP session-path guard tests for pending_deletion and deleted users (HandleMCPLogin)
- add MCP callback guard test for deleted users
- add Device callback guard test for deleted users
- add Device approve-time guard tests for status transitions (pending_deletion, deleted)
- add cleanup idempotency test to ensure second run is no-op and audit is not duplicated

## Validation
- mkdir -p .gocache && GOCACHE=/Users/kangheeyong/project/authgate/.gocache go test ./internal/service -count=1
- mkdir -p .gocache && GOCACHE=/Users/kangheeyong/project/authgate/.gocache go test -c -tags integration ./internal/service
