### PR TITLE
test(spec): extend coverage for revocation, recovery retry, and pending audit

### DIFF
--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -741,3 +741,44 @@ func TestIntegration_DeleteAccount_ResponseShape(t *testing.T) {
 		t.Error("message field should not be empty")
 	}
 }
+
+// refresh/revocation: refresh token revoke 후 재사용은 실패해야 한다.
+func TestIntegration_RefreshTokenRevocation_RejectsReuse(t *testing.T) {
+	ts := SetupTestServer(t)
+
+	client := NewOAuthClient(t, ts.BaseURL)
+	code := completeLoginFlowToCode(t, ts, client)
+	tokens := client.ExchangeCode(code)
+	if tokens.StatusCode != http.StatusOK {
+		t.Fatalf("initial token exchange failed: status=%d body=%s", tokens.StatusCode, tokens.RawBody)
+	}
+	if tokens.RefreshToken == "" {
+		t.Fatal("refresh_token should not be empty")
+	}
+
+	revokeForm := url.Values{
+		"token":           {tokens.RefreshToken},
+		"token_type_hint": {"refresh_token"},
+		"client_id":       {client.ClientID},
+	}
+	revokeResp, err := http.Post(ts.BaseURL+"/oauth/revoke", "application/x-www-form-urlencoded", strings.NewReader(revokeForm.Encode()))
+	if err != nil {
+		t.Fatalf("revoke request: %v", err)
+	}
+	defer revokeResp.Body.Close()
+
+	// RFC7009: revocation endpoint는 성공 시 200
+	if revokeResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(revokeResp.Body)
+		t.Fatalf("revoke status=%d, want 200; body=%s", revokeResp.StatusCode, body)
+	}
+
+	// revoked refresh token 재사용은 실패해야 한다.
+	refresh := client.RefreshToken(tokens.RefreshToken)
+	if refresh.StatusCode == http.StatusOK {
+		t.Fatalf("refresh with revoked token should fail, got 200 body=%s", refresh.RawBody)
+	}
+	if !strings.Contains(refresh.RawBody, "invalid_grant") && !strings.Contains(refresh.RawBody, "invalid_refresh_token") {
+		t.Fatalf("expected invalid_grant/invalid_refresh_token, got body=%s", refresh.RawBody)
+	}
+}

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -280,4 +280,30 @@ func TestAuditSecurity003_DeviceInactiveUser(t *testing.T) {
 	}
 }
 
+func TestAuditSecurity_DevicePendingDeletionInactiveUser(t *testing.T) {
+	svc, store, _ := setupDeviceExtTest(t, "audit-device-pending-sub")
+	ctx := context.Background()
+
+	user, err := store.CreateUserWithIdentity(ctx, "audit-device-pending@test.com", true, "Pending Device", "", "google", "audit-device-pending-sub", "audit-device-pending@test.com")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := store.SetUserStatus(ctx, user.ID, "pending_deletion"); err != nil {
+		t.Fatalf("set pending_deletion: %v", err)
+	}
+
+	result := svc.HandleDeviceCallback(ctx, "fake-code", "AUDT-PEND", "127.0.0.1", "device-pending-agent")
+	if result.Action != DeviceError {
+		t.Fatalf("action = %v, want DeviceError", result.Action)
+	}
+
+	event := requireSingleAuditEvent(t, store.DB(), user.ID, "auth.inactive_user")
+	if event.Metadata["status"] != "pending_deletion" {
+		t.Fatalf("status = %v, want pending_deletion", event.Metadata["status"])
+	}
+	if event.Metadata["channel"] != "device" {
+		t.Fatalf("channel = %v, want device", event.Metadata["channel"])
+	}
+}
+
 var _ = storage.ErrNotFound

--- a/internal/service/e2e_test.go
+++ b/internal/service/e2e_test.go
@@ -192,3 +192,38 @@ func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
 		t.Fatalf("step 5: mcp should succeed after recovery, got action=%v", mcpResult2.Action)
 	}
 }
+
+// E2E 5: 복구 후 로그인 완료 실패가 발생해도 다음 재시도에서 정상 완료되어야 한다.
+func TestE2E5_RecoveryThenAuthRequestRetry(t *testing.T) {
+	loginSvc, _, accountSvc, store, db, _ := setupE2ETest(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateUserWithIdentity(ctx, "e2e5-retry@test.com", true, "Retry User", "", "google", "e2e-sub", "e2e5-retry@test.com")
+	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
+
+	// 1) pending_deletion 전환
+	del := accountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
+	if !del.Success {
+		t.Fatalf("deletion request failed: %s", del.Message)
+	}
+
+	// 2) Browser callback 시도하되 존재하지 않는 authRequestID로 완료 단계 실패 유도
+	first := loginSvc.HandleCallback(ctx, "fake-code", "missing-auth-request", "127.0.0.1", "browser")
+	if first.Action != ActionError {
+		t.Fatalf("first action = %v, want ActionError", first.Action)
+	}
+
+	// 복구는 선행되므로 status는 active여야 한다.
+	var status string
+	db.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
+	if status != "active" {
+		t.Fatalf("status after failed completion = %q, want active", status)
+	}
+
+	// 3) 정상 authRequest로 재시도 시 성공해야 한다.
+	arID, _ := store.CreateTestAuthRequest(ctx, "e2e5-retry")
+	second := loginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "browser")
+	if second.Action != ActionAutoApprove {
+		t.Fatalf("second action = %v, want ActionAutoApprove", second.Action)
+	}
+}


### PR DESCRIPTION
## Summary
- add integration test for refresh-token revocation and rejected reuse
- add E2E5 test for browser recovery followed by failed completion then successful retry
- add audit test for pending_deletion inactive_user metadata on device callback

## Validation
- mkdir -p .gocache && GOCACHE=/Users/kangheeyong/project/authgate/.gocache go test ./internal/service -count=1
- mkdir -p .gocache && GOCACHE=/Users/kangheeyong/project/authgate/.gocache go test -c -tags integration ./internal/service
- mkdir -p .gocache && GOCACHE=/Users/kangheeyong/project/authgate/.gocache go test -c -tags integration ./internal/integration
