### PR TITLE
test(spec): add revocation idempotency and MCP inactive audit matrix

### DIFF
--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -782,3 +782,57 @@ func TestIntegration_RefreshTokenRevocation_RejectsReuse(t *testing.T) {
 		t.Fatalf("expected invalid_grant/invalid_refresh_token, got body=%s", refresh.RawBody)
 	}
 }
+
+// revocation 멱등성: 동일 refresh token을 두 번 revoke해도 200이어야 한다.
+func TestIntegration_RefreshTokenRevocation_Idempotent(t *testing.T) {
+	ts := SetupTestServer(t)
+
+	client := NewOAuthClient(t, ts.BaseURL)
+	code := completeLoginFlowToCode(t, ts, client)
+	tokens := client.ExchangeCode(code)
+	if tokens.StatusCode != http.StatusOK || tokens.RefreshToken == "" {
+		t.Fatalf("initial token exchange failed: status=%d body=%s", tokens.StatusCode, tokens.RawBody)
+	}
+
+	revoke := func(token string) int {
+		form := url.Values{
+			"token":           {token},
+			"token_type_hint": {"refresh_token"},
+			"client_id":       {client.ClientID},
+		}
+		resp, err := http.Post(ts.BaseURL+"/oauth/revoke", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+		if err != nil {
+			t.Fatalf("revoke request: %v", err)
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	if code := revoke(tokens.RefreshToken); code != http.StatusOK {
+		t.Fatalf("first revoke status=%d, want 200", code)
+	}
+	if code := revoke(tokens.RefreshToken); code != http.StatusOK {
+		t.Fatalf("second revoke status=%d, want 200", code)
+	}
+}
+
+// RFC7009: 존재하지 않는 token revoke 요청도 200으로 응답해야 한다.
+func TestIntegration_Revocation_UnknownToken_Returns200(t *testing.T) {
+	ts := SetupTestServer(t)
+
+	form := url.Values{
+		"token":           {"not-a-real-token"},
+		"token_type_hint": {"refresh_token"},
+		"client_id":       {"test-client"},
+	}
+	resp, err := http.Post(ts.BaseURL+"/oauth/revoke", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("revoke unknown token: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d, want 200; body=%s", resp.StatusCode, body)
+	}
+}

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -306,4 +306,44 @@ func TestAuditSecurity_DevicePendingDeletionInactiveUser(t *testing.T) {
 	}
 }
 
+func TestAuditSecurity_MCPInactiveUser_Metadata(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{name: "pending_deletion", status: "pending_deletion"},
+		{name: "disabled", status: "disabled"},
+		{name: "deleted", status: "deleted"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, store := setupMCPExtTest(t, "audit-mcp-"+tt.name+"-sub")
+			ctx := context.Background()
+
+			user, err := store.CreateUserWithIdentity(ctx, "audit-mcp-"+tt.name+"@test.com", true, "MCP Inactive", "", "google", "audit-mcp-"+tt.name+"-sub", "audit-mcp-"+tt.name+"@test.com")
+			if err != nil {
+				t.Fatalf("create user: %v", err)
+			}
+			if err := store.SetUserStatus(ctx, user.ID, tt.status); err != nil {
+				t.Fatalf("set status %s: %v", tt.status, err)
+			}
+			arID, _ := store.CreateTestAuthRequest(ctx, "audit-mcp-"+tt.name)
+
+			result := svc.HandleMCPCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-agent")
+			if result.Action != ActionError {
+				t.Fatalf("action = %v, want ActionError", result.Action)
+			}
+
+			event := requireSingleAuditEvent(t, store.DB(), user.ID, "auth.inactive_user")
+			if event.Metadata["status"] != tt.status {
+				t.Fatalf("status = %v, want %s", event.Metadata["status"], tt.status)
+			}
+			if event.Metadata["channel"] != "mcp" {
+				t.Fatalf("channel = %v, want mcp", event.Metadata["channel"])
+			}
+		})
+	}
+}
+
 var _ = storage.ErrNotFound


### PR DESCRIPTION
## Summary
- add integration revocation edge tests:
  - revoking same refresh token twice returns 200 (idempotent)
  - revoking unknown token returns 200 (RFC7009 behavior)
- add service audit test matrix for MCP inactive_user metadata across statuses:
  - pending_deletion
  - disabled
  - deleted

## Validation
- mkdir -p .gocache && GOCACHE=/Users/kangheeyong/project/authgate/.gocache go test ./internal/service -count=1
- mkdir -p .gocache && GOCACHE=/Users/kangheeyong/project/authgate/.gocache go test -c -tags integration ./internal/service
- mkdir -p .gocache && GOCACHE=/Users/kangheeyong/project/authgate/.gocache go test -c -tags integration ./internal/integration
