### PR TITLE
test(spec): cover deleted-state gaps in integration/account/refresh

### DIFF
--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -344,6 +344,7 @@ func TestIntegration_BrowserCodeExchange_StateChange_InvalidGrant(t *testing.T) 
 	}{
 		{name: "pending_deletion", mutateSQL: `UPDATE users SET status = 'pending_deletion' WHERE id = $1`},
 		{name: "disabled", mutateSQL: `UPDATE users SET status = 'disabled' WHERE id = $1`},
+		{name: "deleted", mutateSQL: `UPDATE users SET status = 'deleted' WHERE id = $1`},
 	}
 
 	for _, tt := range tests {
@@ -380,6 +381,7 @@ func TestIntegration_MCPCodeExchange_StateChange_InvalidGrant(t *testing.T) {
 	}{
 		{name: "pending_deletion", mutateSQL: `UPDATE users SET status = 'pending_deletion' WHERE id = $1`},
 		{name: "disabled", mutateSQL: `UPDATE users SET status = 'disabled' WHERE id = $1`},
+		{name: "deleted", mutateSQL: `UPDATE users SET status = 'deleted' WHERE id = $1`},
 	}
 
 	for _, tt := range tests {

--- a/internal/service/account_test.go
+++ b/internal/service/account_test.go
@@ -79,20 +79,31 @@ func TestDeleteAccount_Idempotent(t *testing.T) {
 }
 
 func TestDeleteAccount_InactiveUser_Rejected(t *testing.T) {
-	accountSvc, _, store, _, _ := setupAccountTest(t)
-	ctx := context.Background()
-
-	_, sessionID := createUserWithSession(t, store, "disabled-del@test.com", "dis-del-sub")
-	// Disable user after session creation (session still valid but user is disabled)
-	user, _ := store.GetValidSession(ctx, sessionID)
-	store.DisableUser(ctx, user.ID)
-
-	result := accountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
-	if result.Success {
-		t.Error("expected failure for disabled user")
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{name: "disabled", status: "disabled"},
+		{name: "deleted", status: "deleted"},
 	}
-	if result.ErrorCode != 403 {
-		t.Errorf("errorCode = %d, want 403", result.ErrorCode)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accountSvc, _, store, _, _ := setupAccountTest(t)
+			ctx := context.Background()
+
+			_, sessionID := createUserWithSession(t, store, tt.name+"-del@test.com", tt.name+"-del-sub")
+			user, _ := store.GetValidSession(ctx, sessionID)
+			_ = store.SetUserStatus(ctx, user.ID, tt.status)
+
+			result := accountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
+			if result.Success {
+				t.Fatalf("expected failure for %s user", tt.status)
+			}
+			if result.ErrorCode != 403 {
+				t.Fatalf("errorCode = %d, want 403", result.ErrorCode)
+			}
+		})
 	}
 }
 

--- a/internal/storage/refresh_state_test.go
+++ b/internal/storage/refresh_state_test.go
@@ -101,6 +101,14 @@ func TestRefreshStateCheck_AllStates(t *testing.T) {
 			wantError: true,
 			wantState: "inactive",
 		},
+		{
+			name: "inactive (deleted) - reject",
+			setup: func(id string) {
+				store.SetUserStatus(ctx, id, "deleted")
+			},
+			wantError: true,
+			wantState: "inactive",
+		},
 	}
 
 	for i, tt := range tests {
@@ -177,6 +185,14 @@ func TestAuthCodeStateCheck_AllStates(t *testing.T) {
 			name: "inactive (disabled) - reject",
 			setup: func(id string) {
 				store.SetUserStatus(ctx, id, "disabled")
+			},
+			wantError: true,
+			wantState: "inactive",
+		},
+		{
+			name: "inactive (deleted) - reject",
+			setup: func(id string) {
+				store.SetUserStatus(ctx, id, "deleted")
 			},
 			wantError: true,
 			wantState: "inactive",


### PR DESCRIPTION
## Summary
- add deleted-state coverage to browser/mcp code-exchange invalid_grant integration tests
- extend account inactive deletion test to include deleted status
- extend storage refresh/auth-code state checks to include deleted status rejection

## Note
- excluded unrelated .github/workflows/ci.yml changes as requested

## Validation
- mkdir -p .gocache && GOCACHE=/Users/kangheeyong/project/authgate/.gocache go test ./internal/service -count=1
- mkdir -p .gocache && GOCACHE=/Users/kangheeyong/project/authgate/.gocache go test ./internal/storage -run TestRefreshStateCheck_AllStates -count=1
- mkdir -p .gocache && GOCACHE=/Users/kangheeyong/project/authgate/.gocache go test -c -tags integration ./internal/integration
