### PR TITLE
test(upstream): cover invalid issuer parsing and multi-redirect providers

### DIFF
--- a/internal/upstream/oidc.go
+++ b/internal/upstream/oidc.go
@@ -124,6 +124,9 @@ func deriveProviderName(issuer string) string {
 		return "unknown"
 	}
 	host := u.Hostname()
+	if host == "" {
+		return "unknown"
+	}
 	parts := strings.Split(host, ".")
 	if len(parts) >= 2 {
 		return parts[len(parts)-2]

--- a/internal/upstream/oidc_test.go
+++ b/internal/upstream/oidc_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -163,6 +164,12 @@ func TestDeriveProviderName_Localhost(t *testing.T) {
 func TestDeriveProviderName_Microsoft(t *testing.T) {
 	if got := deriveProviderName("https://login.microsoftonline.com"); got != "microsoftonline" {
 		t.Errorf("got %q, want %q", got, "microsoftonline")
+	}
+}
+
+func TestDeriveProviderName_InvalidURL(t *testing.T) {
+	if got := deriveProviderName("not-a-url"); got != "unknown" {
+		t.Errorf("got %q, want %q", got, "unknown")
 	}
 }
 
@@ -378,5 +385,36 @@ func TestOIDCProvider_FullPath(t *testing.T) {
 	}
 	if info.Sub == "" || info.Email == "" {
 		t.Errorf("incomplete UserInfo after full path: sub=%q email=%q", info.Sub, info.Email)
+	}
+}
+
+func TestOIDCProvider_MultiRedirectURIs(t *testing.T) {
+	idp := newFakeIdP(t)
+
+	tests := []struct {
+		name        string
+		redirectURI string
+	}{
+		{name: "browser", redirectURI: "http://localhost:8080/login/callback"},
+		{name: "mcp", redirectURI: "http://localhost:8080/mcp/callback"},
+		{name: "device", redirectURI: "http://localhost:8080/device/auth/callback"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewOIDCProvider(context.Background(), idp.srv.URL, testClientID, testClientSecret, tt.redirectURI)
+			if err != nil {
+				t.Fatalf("NewOIDCProvider: %v", err)
+			}
+
+			authURL := p.AuthURL("state-" + tt.name)
+			u, err := url.Parse(authURL)
+			if err != nil {
+				t.Fatalf("parse authURL: %v", err)
+			}
+			if got := u.Query().Get("redirect_uri"); got != tt.redirectURI {
+				t.Fatalf("redirect_uri = %q, want %q", got, tt.redirectURI)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- fix deriveProviderName to return unknown when issuer host is empty
- add oidc-name-004 test for invalid issuer input (not-a-url)
- add oidc-e2e-002 style test validating redirect_uri per provider callback path (browser/mcp/device)

## Validation
- mkdir -p .gocache && GOCACHE=/Users/kangheeyong/project/authgate/.gocache go test -c ./internal/upstream

## Note
- existing local .github/workflows/ci.yml change is intentionally excluded
