### PR TITLE
refactor(handler): deduplicate session cookie handling

### DIFF
--- a/internal/handler/device.go
+++ b/internal/handler/device.go
@@ -70,11 +70,11 @@ func (h *DeviceHandler) HandleDeviceCallback(w http.ResponseWriter, r *http.Requ
 	result := h.deviceService.HandleDeviceCallback(r.Context(), code, userCode, r.RemoteAddr, r.UserAgent())
 
 	switch result.Action {
-		case service.DeviceRedirectBack:
-			if result.SessionID != "" {
-				h.setSessionCookie(w, result.SessionID)
-			}
-			http.Redirect(w, r, "/device?user_code="+result.UserCode, http.StatusFound)
+	case service.DeviceRedirectBack:
+		if result.SessionID != "" {
+			setSessionCookie(w, result.SessionID, h.devMode)
+		}
+		http.Redirect(w, r, "/device?user_code="+result.UserCode, http.StatusFound)
 
 	case service.DeviceError:
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -129,15 +129,4 @@ func generateCSRFToken() string {
 		panic("crypto/rand failed: " + err.Error())
 	}
 	return hex.EncodeToString(b)
-}
-
-func (h *DeviceHandler) setSessionCookie(w http.ResponseWriter, sessionID string) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     sessionCookieName,
-		Value:    sessionID,
-		Path:     "/",
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-		Secure:   !h.devMode,
-	})
 }

--- a/internal/handler/login.go
+++ b/internal/handler/login.go
@@ -7,8 +7,6 @@ import (
 	"github.com/kangheeyong/authgate/internal/service"
 )
 
-const sessionCookieName = "authgate_session"
-
 type LoginHandler struct {
 	loginService *service.LoginService
 	devMode      bool
@@ -73,7 +71,7 @@ func (h *LoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	result := h.loginService.HandleCallback(r.Context(), code, authRequestID, ipAddress, userAgent)
 
 	if result.SessionID != "" {
-		h.setSessionCookie(w, result.SessionID)
+		setSessionCookie(w, result.SessionID, h.devMode)
 	}
 
 	switch result.Action {
@@ -95,7 +93,7 @@ func (h *LoginHandler) HandleMCPCallback(w http.ResponseWriter, r *http.Request)
 	result := h.loginService.HandleMCPCallback(r.Context(), code, authRequestID, ipAddress, userAgent)
 
 	if result.SessionID != "" {
-		h.setSessionCookie(w, result.SessionID)
+		setSessionCookie(w, result.SessionID, h.devMode)
 	}
 
 	switch result.Action {
@@ -114,23 +112,4 @@ func (h *LoginHandler) renderError(w http.ResponseWriter, code int, message stri
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(code)
 	pages.RenderError(w, pages.ErrorData{Code: code, Message: message})
-}
-
-func (h *LoginHandler) setSessionCookie(w http.ResponseWriter, sessionID string) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     sessionCookieName,
-		Value:    sessionID,
-		Path:     "/",
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-		Secure:   !h.devMode,
-	})
-}
-
-func getSessionCookie(r *http.Request) string {
-	c, err := r.Cookie(sessionCookieName)
-	if err != nil {
-		return ""
-	}
-	return c.Value
 }

--- a/internal/handler/login_test.go
+++ b/internal/handler/login_test.go
@@ -67,9 +67,8 @@ func TestMCPCallback_MissingCodeOrState_ReturnsBadRequest(t *testing.T) {
 
 func TestSetSessionCookie_SecureDependsOnDevMode(t *testing.T) {
 	t.Run("prod mode uses Secure", func(t *testing.T) {
-		h := newTestLoginHandler(false)
 		w := httptest.NewRecorder()
-		h.setSessionCookie(w, "sess-prod")
+		setSessionCookie(w, "sess-prod", false)
 
 		resp := w.Result()
 		cookies := resp.Cookies()
@@ -89,9 +88,8 @@ func TestSetSessionCookie_SecureDependsOnDevMode(t *testing.T) {
 	})
 
 	t.Run("dev mode disables Secure", func(t *testing.T) {
-		h := newTestLoginHandler(true)
 		w := httptest.NewRecorder()
-		h.setSessionCookie(w, "sess-dev")
+		setSessionCookie(w, "sess-dev", true)
 
 		resp := w.Result()
 		cookies := resp.Cookies()

--- a/internal/handler/session_cookie.go
+++ b/internal/handler/session_cookie.go
@@ -1,0 +1,24 @@
+package handler
+
+import "net/http"
+
+const sessionCookieName = "authgate_session"
+
+func setSessionCookie(w http.ResponseWriter, sessionID string, devMode bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    sessionID,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   !devMode,
+	})
+}
+
+func getSessionCookie(r *http.Request) string {
+	c, err := r.Cookie(sessionCookieName)
+	if err != nil {
+		return ""
+	}
+	return c.Value
+}


### PR DESCRIPTION
## Summary
- extract shared session cookie helpers into internal/handler/session_cookie.go
- remove duplicated setSessionCookie methods from LoginHandler and DeviceHandler
- keep cookie behavior unchanged (HttpOnly/Lax/Secure by devMode)

## Validation
- go test ./internal/handler
