### PR TITLE
fix(revoke): keep RFC7009 200 response when CIMD metadata fetch fails

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -194,6 +195,20 @@ func main() {
 	mux.Handle("/oauth/token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resource := storage.ResourceFromRequest(r)
 		provider.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
+	}))
+	mux.Handle("/oauth/revoke", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// RFC 7009: revocation endpoint should still return 200 even if a CIMD
+		// client metadata document is temporarily unavailable.
+		if err := r.ParseForm(); err == nil {
+			clientID := strings.TrimSpace(r.Form.Get("client_id"))
+			if storage.IsCIMDClientID(clientID) {
+				if _, err := store.GetClientByClientID(r.Context(), clientID); err != nil {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+			}
+		}
+		provider.ServeHTTP(w, r)
 	}))
 
 	// zitadel provider handles all OIDC routes (including /.well-known/openid-configuration)

--- a/internal/integration/integration_token_test.go
+++ b/internal/integration/integration_token_test.go
@@ -246,3 +246,26 @@ func TestIntegration_Revocation_UnknownToken_Returns200(t *testing.T) {
 		t.Fatalf("status=%d, want 200; body=%s", resp.StatusCode, body)
 	}
 }
+
+// RFC7009 + CIMD: revocation must return 200 even when CIMD client lookup/fetch fails.
+func TestIntegration_Revocation_CIMDFetchFailure_Returns200(t *testing.T) {
+	ts := SetupTestServer(t)
+
+	// .invalid TLD is reserved and should fail DNS resolution.
+	invalidCIMDClientID := "https://cimd-client.invalid/oauth/client.json"
+	form := url.Values{
+		"token":           {"not-a-real-token"},
+		"token_type_hint": {"refresh_token"},
+		"client_id":       {invalidCIMDClientID},
+	}
+	resp, err := http.Post(ts.BaseURL+"/oauth/revoke", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("revoke with invalid CIMD client_id: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d, want 200; body=%s", resp.StatusCode, body)
+	}
+}

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -150,6 +151,18 @@ func SetupTestServer(t *testing.T) *TestServer {
 	mux.Handle("/oauth/token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resource := storage.ResourceFromRequest(r)
 		provider.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
+	}))
+	mux.Handle("/oauth/revoke", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			clientID := strings.TrimSpace(r.Form.Get("client_id"))
+			if storage.IsCIMDClientID(clientID) {
+				if _, err := store.GetClientByClientID(r.Context(), clientID); err != nil {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+			}
+		}
+		provider.ServeHTTP(w, r)
 	}))
 	mux.Handle("/", provider)
 	mux.HandleFunc("/login", loginHandler.HandleLogin)

--- a/internal/storage/cimd.go
+++ b/internal/storage/cimd.go
@@ -273,6 +273,11 @@ func isCIMDClientID(clientID string) bool {
 	return true
 }
 
+// IsCIMDClientID reports whether a client_id is a CIMD URL.
+func IsCIMDClientID(clientID string) bool {
+	return isCIMDClientID(clientID)
+}
+
 // isPrivateIP checks if an IP is private/loopback/link-local.
 func isPrivateIP(ip net.IP) bool {
 	if ip == nil {


### PR DESCRIPTION
## Summary
- add integration test for revocation with CIMD client_id when metadata fetch fails
- make /oauth/revoke return 200 for CIMD metadata fetch failures (RFC7009 behavior)
- apply same behavior in integration test server route wiring

## Why
- spec states revocation should not leak client/token existence and should return 200
- CIMD temporary failures should not change this revocation contract

## Validation
- go test ./internal/storage
- go test -tags integration ./internal/integration -run Revocation -count=1