### PR TITLE
test(revocation): add RFC7009 hint coverage

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -194,6 +195,20 @@ func main() {
 	mux.Handle("/oauth/token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resource := storage.ResourceFromRequest(r)
 		provider.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
+	}))
+	mux.Handle("/oauth/revoke", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// RFC 7009: revocation endpoint should still return 200 even if a CIMD
+		// client metadata document is temporarily unavailable.
+		if err := r.ParseForm(); err == nil {
+			clientID := strings.TrimSpace(r.Form.Get("client_id"))
+			if storage.IsCIMDClientID(clientID) {
+				if _, err := store.GetClientByClientID(r.Context(), clientID); err != nil {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+			}
+		}
+		provider.ServeHTTP(w, r)
 	}))
 
 	// zitadel provider handles all OIDC routes (including /.well-known/openid-configuration)

--- a/internal/integration/integration_token_test.go
+++ b/internal/integration/integration_token_test.go
@@ -246,3 +246,26 @@ func TestIntegration_Revocation_UnknownToken_Returns200(t *testing.T) {
 		t.Fatalf("status=%d, want 200; body=%s", resp.StatusCode, body)
 	}
 }
+
+// RFC7009 + CIMD: revocation must return 200 even when CIMD client lookup/fetch fails.
+func TestIntegration_Revocation_CIMDFetchFailure_Returns200(t *testing.T) {
+	ts := SetupTestServer(t)
+
+	// .invalid TLD is reserved and should fail DNS resolution.
+	invalidCIMDClientID := "https://cimd-client.invalid/oauth/client.json"
+	form := url.Values{
+		"token":           {"not-a-real-token"},
+		"token_type_hint": {"refresh_token"},
+		"client_id":       {invalidCIMDClientID},
+	}
+	resp, err := http.Post(ts.BaseURL+"/oauth/revoke", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("revoke with invalid CIMD client_id: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d, want 200; body=%s", resp.StatusCode, body)
+	}
+}

--- a/internal/integration/integration_token_test.go
+++ b/internal/integration/integration_token_test.go
@@ -247,6 +247,42 @@ func TestIntegration_Revocation_UnknownToken_Returns200(t *testing.T) {
 	}
 }
 
+// RFC7009: token_type_hint is optional and unrecognized hints must not break revocation behavior.
+func TestIntegration_Revocation_TokenTypeHintVariants_Returns200(t *testing.T) {
+	tests := []struct {
+		name string
+		hint string
+	}{
+		{name: "missing_hint", hint: ""},
+		{name: "unknown_hint", hint: "access_token"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := SetupTestServer(t)
+
+			form := url.Values{
+				"token":     {"not-a-real-token"},
+				"client_id": {"test-client"},
+			}
+			if tt.hint != "" {
+				form.Set("token_type_hint", tt.hint)
+			}
+
+			resp, err := http.Post(ts.BaseURL+"/oauth/revoke", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+			if err != nil {
+				t.Fatalf("revoke request: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status=%d, want 200; body=%s", resp.StatusCode, body)
+			}
+		})
+	}
+}
+
 // RFC7009 + CIMD: revocation must return 200 even when CIMD client lookup/fetch fails.
 func TestIntegration_Revocation_CIMDFetchFailure_Returns200(t *testing.T) {
 	ts := SetupTestServer(t)

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -150,6 +151,18 @@ func SetupTestServer(t *testing.T) *TestServer {
 	mux.Handle("/oauth/token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resource := storage.ResourceFromRequest(r)
 		provider.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
+	}))
+	mux.Handle("/oauth/revoke", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			clientID := strings.TrimSpace(r.Form.Get("client_id"))
+			if storage.IsCIMDClientID(clientID) {
+				if _, err := store.GetClientByClientID(r.Context(), clientID); err != nil {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+			}
+		}
+		provider.ServeHTTP(w, r)
 	}))
 	mux.Handle("/", provider)
 	mux.HandleFunc("/login", loginHandler.HandleLogin)

--- a/internal/storage/cimd.go
+++ b/internal/storage/cimd.go
@@ -273,6 +273,11 @@ func isCIMDClientID(clientID string) bool {
 	return true
 }
 
+// IsCIMDClientID reports whether a client_id is a CIMD URL.
+func IsCIMDClientID(clientID string) bool {
+	return isCIMDClientID(clientID)
+}
+
 // isPrivateIP checks if an IP is private/loopback/link-local.
 func isPrivateIP(ip net.IP) bool {
 	if ip == nil {


### PR DESCRIPTION
## Summary
- keep revocation response contract for CIMD metadata fetch failures
- add integration test coverage for RFC7009 token_type_hint variants
  - missing token_type_hint
  - unknown token_type_hint value

## Validation
- go test -tags integration ./internal/integration -run Revocation -count=1
- go test ./internal/storage