### PR TITLE
refactor(storage): centralize db errors and null mappers

### DIFF
--- a/internal/storage/dberr.go
+++ b/internal/storage/dberr.go
@@ -1,0 +1,23 @@
+package storage
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+const pgUniqueViolationCode = "23505"
+
+func isUniqueViolation(err error, constraintName string) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	if pgErr.Code != pgUniqueViolationCode {
+		return false
+	}
+	if constraintName == "" {
+		return true
+	}
+	return pgErr.ConstraintName == constraintName
+}

--- a/internal/storage/mappers.go
+++ b/internal/storage/mappers.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"database/sql"
+	"time"
+)
+
+func nullStringToString(v sql.NullString) string {
+	if !v.Valid {
+		return ""
+	}
+	return v.String
+}
+
+func nullStringToPtr(v sql.NullString) *string {
+	if !v.Valid {
+		return nil
+	}
+	s := v.String
+	return &s
+}
+
+func nullTimePtr(v sql.NullTime) *time.Time {
+	if !v.Valid {
+		return nil
+	}
+	t := v.Time
+	return &t
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -415,14 +415,6 @@ func (s *Storage) GetRefreshTokenInfo(ctx context.Context, clientID string, toke
 	return row.UserID, row.ID, nil
 }
 
-func nullTimePtr(v sql.NullTime) *time.Time {
-	if !v.Valid {
-		return nil
-	}
-	t := v.Time
-	return &t
-}
-
 func authRequestModelFromRowByID(row storeq.GetAuthRequestByIDRow) *AuthRequestModel {
 	return &AuthRequestModel{
 		ID:                  row.ID,

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/kangheeyong/authgate/internal/storage/storeq"
@@ -199,27 +198,6 @@ func (s *Storage) setUserinfo(ctx context.Context, userinfo *oidc.UserInfo, user
 		}
 	}
 	return nil
-}
-
-// isUniqueViolation checks if a PostgreSQL error is a unique constraint violation.
-func isUniqueViolation(err error, constraintName string) bool {
-	msg := err.Error()
-	return strings.Contains(msg, "23505") || strings.Contains(msg, constraintName)
-}
-
-func nullStringToString(v sql.NullString) string {
-	if !v.Valid {
-		return ""
-	}
-	return v.String
-}
-
-func nullStringToPtr(v sql.NullString) *string {
-	if !v.Valid {
-		return nil
-	}
-	s := v.String
-	return &s
 }
 
 // SetUserStatus sets a user's status directly. For testing and admin operations.


### PR DESCRIPTION
## Summary
- centralize PostgreSQL error mapping and nullable field mappers in storage package
- replace string-based unique violation detection with pg error code plus constraint matching
- remove duplicated nullable conversion helpers from individual files

## Changes
- add internal/storage/dberr.go
  - isUniqueViolation now uses pgconn.PgError (23505 + constraint name)
- add internal/storage/mappers.go
  - nullStringToString
  - nullStringToPtr
  - nullTimePtr
- update internal/storage/users.go
  - remove inline isUniqueViolation and duplicate null mapper helpers
- update internal/storage/storage.go
  - remove duplicate nullTimePtr and use shared mapper

## Validation
- go test ./... -count=1