### PR TITLE
refactor(storage): migrate remaining user writes to sqlc

### DIFF
--- a/internal/storage/queries/users.sql
+++ b/internal/storage/queries/users.sql
@@ -28,3 +28,60 @@ WHERE id = $1;
 SELECT id, email, email_verified, name
 FROM users
 WHERE id = $1;
+
+-- name: CompleteAuthRequestByID :execrows
+UPDATE auth_requests
+SET subject = $1, auth_time = $2, done = true
+WHERE id = $3 AND expires_at > $2;
+
+-- name: SetUserStatusByID :exec
+UPDATE users
+SET status = $1, updated_at = $2
+WHERE id = $3;
+
+-- name: RecoverPendingDeletionUserByID :exec
+UPDATE users
+SET status = 'active',
+    deletion_requested_at = NULL,
+    deletion_scheduled_at = NULL,
+    updated_at = $1
+WHERE id = $2 AND status = 'pending_deletion';
+
+-- name: MarkUserPendingDeletionByID :exec
+UPDATE users
+SET status = 'pending_deletion',
+    deletion_requested_at = $1,
+    deletion_scheduled_at = $2,
+    updated_at = $1
+WHERE id = $3;
+
+-- name: RevokeActiveRefreshTokensByUserID :exec
+UPDATE refresh_tokens
+SET revoked_at = $1
+WHERE user_id = $2 AND revoked_at IS NULL;
+
+-- name: InsertTestAuthRequest :exec
+INSERT INTO auth_requests (
+  id,
+  client_id,
+  redirect_uri,
+  scopes,
+  state,
+  nonce,
+  code_challenge,
+  code_challenge_method,
+  expires_at,
+  created_at
+)
+VALUES (
+  $1,
+  'test-app',
+  'http://localhost/callback',
+  '{openid}',
+  $2,
+  'test-nonce',
+  'E9Melhoa2OwvFrEMT',
+  'S256',
+  $3,
+  $4
+);

--- a/internal/storage/storeq/querier.go
+++ b/internal/storage/storeq/querier.go
@@ -13,6 +13,7 @@ import (
 type Querier interface {
 	AnonymizeAuditLogBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	ApproveDeviceCodeByUserCode(ctx context.Context, arg ApproveDeviceCodeByUserCodeParams) (int64, error)
+	CompleteAuthRequestByID(ctx context.Context, arg CompleteAuthRequestByIDParams) (int64, error)
 	DeleteAuthRequestByID(ctx context.Context, id string) error
 	DeleteExpiredAuthRequestsBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteExpiredDeviceCodesBefore(ctx context.Context, cutoff time.Time) (int64, error)
@@ -41,15 +42,20 @@ type Querier interface {
 	InsertDeviceCode(ctx context.Context, arg InsertDeviceCodeParams) error
 	InsertRefreshToken(ctx context.Context, arg InsertRefreshTokenParams) error
 	InsertSession(ctx context.Context, arg InsertSessionParams) error
+	InsertTestAuthRequest(ctx context.Context, arg InsertTestAuthRequestParams) error
 	InsertUser(ctx context.Context, arg InsertUserParams) error
 	InsertUserIdentity(ctx context.Context, arg InsertUserIdentityParams) error
 	ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff sql.NullTime) ([]string, error)
 	MarkRefreshTokenUsedAndRevokedByID(ctx context.Context, arg MarkRefreshTokenUsedAndRevokedByIDParams) error
 	MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedByIDParams) error
+	MarkUserPendingDeletionByID(ctx context.Context, arg MarkUserPendingDeletionByIDParams) error
+	RecoverPendingDeletionUserByID(ctx context.Context, arg RecoverPendingDeletionUserByIDParams) error
+	RevokeActiveRefreshTokensByUserID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDParams) error
 	RevokeRefreshFamily(ctx context.Context, arg RevokeRefreshFamilyParams) error
 	RevokeRefreshTokenByHash(ctx context.Context, arg RevokeRefreshTokenByHashParams) (int64, error)
 	RevokeRefreshTokenByIDText(ctx context.Context, arg RevokeRefreshTokenByIDTextParams) error
 	RevokeSessionsByUserID(ctx context.Context, arg RevokeSessionsByUserIDParams) error
+	SetUserStatusByID(ctx context.Context, arg SetUserStatusByIDParams) error
 	UpdateAuthRequestCode(ctx context.Context, arg UpdateAuthRequestCodeParams) error
 	UpdateDeviceCodeStateConsumedByID(ctx context.Context, id string) error
 }

--- a/internal/storage/storeq/users.sql.go
+++ b/internal/storage/storeq/users.sql.go
@@ -11,6 +11,26 @@ import (
 	"time"
 )
 
+const completeAuthRequestByID = `-- name: CompleteAuthRequestByID :execrows
+UPDATE auth_requests
+SET subject = $1, auth_time = $2, done = true
+WHERE id = $3 AND expires_at > $2
+`
+
+type CompleteAuthRequestByIDParams struct {
+	Subject  sql.NullString
+	AuthTime sql.NullTime
+	ID       string
+}
+
+func (q *Queries) CompleteAuthRequestByID(ctx context.Context, arg CompleteAuthRequestByIDParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, completeAuthRequestByID, arg.Subject, arg.AuthTime, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const getUserByID = `-- name: GetUserByID :one
 SELECT id, email, email_verified, name, avatar_url, status,
        created_at, updated_at
@@ -137,6 +157,50 @@ func (q *Queries) GetUserInfoFieldsByID(ctx context.Context, id string) (GetUser
 	return i, err
 }
 
+const insertTestAuthRequest = `-- name: InsertTestAuthRequest :exec
+INSERT INTO auth_requests (
+  id,
+  client_id,
+  redirect_uri,
+  scopes,
+  state,
+  nonce,
+  code_challenge,
+  code_challenge_method,
+  expires_at,
+  created_at
+)
+VALUES (
+  $1,
+  'test-app',
+  'http://localhost/callback',
+  '{openid}',
+  $2,
+  'test-nonce',
+  'E9Melhoa2OwvFrEMT',
+  'S256',
+  $3,
+  $4
+)
+`
+
+type InsertTestAuthRequestParams struct {
+	ID        string
+	State     sql.NullString
+	ExpiresAt time.Time
+	CreatedAt time.Time
+}
+
+func (q *Queries) InsertTestAuthRequest(ctx context.Context, arg InsertTestAuthRequestParams) error {
+	_, err := q.db.ExecContext(ctx, insertTestAuthRequest,
+		arg.ID,
+		arg.State,
+		arg.ExpiresAt,
+		arg.CreatedAt,
+	)
+	return err
+}
+
 const insertUser = `-- name: InsertUser :exec
 INSERT INTO users (id, email, email_verified, name, avatar_url, status, created_at, updated_at)
 VALUES ($1, $2, $3, $4, $5, 'active', $6, $6)
@@ -186,5 +250,77 @@ func (q *Queries) InsertUserIdentity(ctx context.Context, arg InsertUserIdentity
 		arg.ProviderEmail,
 		arg.CreatedAt,
 	)
+	return err
+}
+
+const markUserPendingDeletionByID = `-- name: MarkUserPendingDeletionByID :exec
+UPDATE users
+SET status = 'pending_deletion',
+    deletion_requested_at = $1,
+    deletion_scheduled_at = $2,
+    updated_at = $1
+WHERE id = $3
+`
+
+type MarkUserPendingDeletionByIDParams struct {
+	DeletionRequestedAt sql.NullTime
+	DeletionScheduledAt sql.NullTime
+	ID                  string
+}
+
+func (q *Queries) MarkUserPendingDeletionByID(ctx context.Context, arg MarkUserPendingDeletionByIDParams) error {
+	_, err := q.db.ExecContext(ctx, markUserPendingDeletionByID, arg.DeletionRequestedAt, arg.DeletionScheduledAt, arg.ID)
+	return err
+}
+
+const recoverPendingDeletionUserByID = `-- name: RecoverPendingDeletionUserByID :exec
+UPDATE users
+SET status = 'active',
+    deletion_requested_at = NULL,
+    deletion_scheduled_at = NULL,
+    updated_at = $1
+WHERE id = $2 AND status = 'pending_deletion'
+`
+
+type RecoverPendingDeletionUserByIDParams struct {
+	UpdatedAt time.Time
+	ID        string
+}
+
+func (q *Queries) RecoverPendingDeletionUserByID(ctx context.Context, arg RecoverPendingDeletionUserByIDParams) error {
+	_, err := q.db.ExecContext(ctx, recoverPendingDeletionUserByID, arg.UpdatedAt, arg.ID)
+	return err
+}
+
+const revokeActiveRefreshTokensByUserID = `-- name: RevokeActiveRefreshTokensByUserID :exec
+UPDATE refresh_tokens
+SET revoked_at = $1
+WHERE user_id = $2 AND revoked_at IS NULL
+`
+
+type RevokeActiveRefreshTokensByUserIDParams struct {
+	RevokedAt sql.NullTime
+	UserID    string
+}
+
+func (q *Queries) RevokeActiveRefreshTokensByUserID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDParams) error {
+	_, err := q.db.ExecContext(ctx, revokeActiveRefreshTokensByUserID, arg.RevokedAt, arg.UserID)
+	return err
+}
+
+const setUserStatusByID = `-- name: SetUserStatusByID :exec
+UPDATE users
+SET status = $1, updated_at = $2
+WHERE id = $3
+`
+
+type SetUserStatusByIDParams struct {
+	Status    string
+	UpdatedAt time.Time
+	ID        string
+}
+
+func (q *Queries) SetUserStatusByID(ctx context.Context, arg SetUserStatusByIDParams) error {
+	_, err := q.db.ExecContext(ctx, setUserStatusByID, arg.Status, arg.UpdatedAt, arg.ID)
 	return err
 }

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -128,44 +128,23 @@ func (s *Storage) GetUserByID(ctx context.Context, userID string) (*User, error)
 // RecoverUser atomically recovers a pending_deletion user to active.
 // Uses SELECT FOR UPDATE to prevent race conditions.
 func (s *Storage) RecoverUser(ctx context.Context, userID string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
-	now := s.clock.Now()
-	var status string
-	err = tx.QueryRowContext(ctx,
-		`SELECT status FROM users WHERE id = $1 FOR UPDATE`, userID,
-	).Scan(&status)
-	if err != nil {
-		return err
-	}
-	if status != "pending_deletion" {
-		return tx.Commit() // Not pending_deletion, nothing to do
-	}
-
-	_, err = tx.ExecContext(ctx,
-		`UPDATE users SET status = 'active', deletion_requested_at = NULL, deletion_scheduled_at = NULL, updated_at = $1
-		 WHERE id = $2`, now, userID,
-	)
-	if err != nil {
-		return err
-	}
-	return tx.Commit()
+	return storeq.New(s.db).RecoverPendingDeletionUserByID(ctx, storeq.RecoverPendingDeletionUserByIDParams{
+		UpdatedAt: s.clock.Now(),
+		ID:        userID,
+	})
 }
 
 func (s *Storage) CompleteAuthRequest(ctx context.Context, authRequestID, userID string) error {
 	now := s.clock.Now()
-	res, err := s.db.ExecContext(ctx,
-		`UPDATE auth_requests SET subject = $1, auth_time = $2, done = true WHERE id = $3 AND expires_at > $4`,
-		userID, now, authRequestID, now,
-	)
+	rows, err := storeq.New(s.db).CompleteAuthRequestByID(ctx, storeq.CompleteAuthRequestByIDParams{
+		Subject:  sql.NullString{String: userID, Valid: true},
+		AuthTime: sql.NullTime{Time: now, Valid: true},
+		ID:       authRequestID,
+	})
 	if err != nil {
 		return err
 	}
-	if n, _ := res.RowsAffected(); n == 0 {
+	if rows == 0 {
 		return ErrNotFound
 	}
 	return nil
@@ -202,11 +181,11 @@ func (s *Storage) setUserinfo(ctx context.Context, userinfo *oidc.UserInfo, user
 
 // SetUserStatus sets a user's status directly. For testing and admin operations.
 func (s *Storage) SetUserStatus(ctx context.Context, userID, status string) error {
-	_, err := s.db.ExecContext(ctx,
-		`UPDATE users SET status = $1, updated_at = $2 WHERE id = $3`,
-		status, s.clock.Now(), userID,
-	)
-	return err
+	return storeq.New(s.db).SetUserStatusByID(ctx, storeq.SetUserStatusByIDParams{
+		Status:    status,
+		UpdatedAt: s.clock.Now(),
+		ID:        userID,
+	})
 }
 
 // RequestDeletion sets a user to pending_deletion and revokes all refresh tokens. Single TX.
@@ -220,16 +199,21 @@ func (s *Storage) RequestDeletion(ctx context.Context, userID string) error {
 	}
 	defer tx.Rollback()
 
-	_, err = tx.ExecContext(ctx,
-		`UPDATE users SET status = 'pending_deletion', deletion_requested_at = $1, deletion_scheduled_at = $2, updated_at = $1
-		 WHERE id = $3`, now, scheduledAt, userID)
+	qtx := storeq.New(tx)
+
+	err = qtx.MarkUserPendingDeletionByID(ctx, storeq.MarkUserPendingDeletionByIDParams{
+		DeletionRequestedAt: sql.NullTime{Time: now, Valid: true},
+		DeletionScheduledAt: sql.NullTime{Time: scheduledAt, Valid: true},
+		ID:                  userID,
+	})
 	if err != nil {
 		return err
 	}
 
-	_, err = tx.ExecContext(ctx,
-		`UPDATE refresh_tokens SET revoked_at = $1 WHERE user_id = $2 AND revoked_at IS NULL`,
-		now, userID)
+	err = qtx.RevokeActiveRefreshTokensByUserID(ctx, storeq.RevokeActiveRefreshTokensByUserIDParams{
+		RevokedAt: sql.NullTime{Time: now, Valid: true},
+		UserID:    userID,
+	})
 	if err != nil {
 		return err
 	}
@@ -239,22 +223,23 @@ func (s *Storage) RequestDeletion(ctx context.Context, userID string) error {
 
 // DisableUser sets a user's status to disabled.
 func (s *Storage) DisableUser(ctx context.Context, userID string) error {
-	_, err := s.db.ExecContext(ctx,
-		`UPDATE users SET status = 'disabled', updated_at = $1 WHERE id = $2`,
-		s.clock.Now(), userID,
-	)
-	return err
+	return storeq.New(s.db).SetUserStatusByID(ctx, storeq.SetUserStatusByIDParams{
+		Status:    "disabled",
+		UpdatedAt: s.clock.Now(),
+		ID:        userID,
+	})
 }
 
 // CreateTestAuthRequest creates a minimal auth request for testing purposes.
 // Returns the UUID id assigned to the auth request.
 func (s *Storage) CreateTestAuthRequest(ctx context.Context, label string) (string, error) {
 	id := s.idgen.NewUUID()
-	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO auth_requests (id, client_id, redirect_uri, scopes, state, nonce, code_challenge, code_challenge_method, expires_at, created_at)
-		 VALUES ($1, 'test-app', 'http://localhost/callback', '{openid}', $2, 'test-nonce', 'E9Melhoa2OwvFrEMT', 'S256', $3, $4)`,
-		id, label, s.clock.Now().Add(10*time.Minute), s.clock.Now(),
-	)
+	err := storeq.New(s.db).InsertTestAuthRequest(ctx, storeq.InsertTestAuthRequestParams{
+		ID:        id,
+		State:     sql.NullString{String: label, Valid: true},
+		ExpiresAt: s.clock.Now().Add(10 * time.Minute),
+		CreatedAt: s.clock.Now(),
+	})
 	return id, err
 }
 

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -125,8 +125,8 @@ func (s *Storage) GetUserByID(ctx context.Context, userID string) (*User, error)
 	}, nil
 }
 
-// RecoverUser atomically recovers a pending_deletion user to active.
-// Uses SELECT FOR UPDATE to prevent race conditions.
+// RecoverUser recovers a pending_deletion user to active.
+// If the user is not pending_deletion, it is a no-op.
 func (s *Storage) RecoverUser(ctx context.Context, userID string) error {
 	return storeq.New(s.db).RecoverPendingDeletionUserByID(ctx, storeq.RecoverPendingDeletionUserByIDParams{
 		UpdatedAt: s.clock.Now(),


### PR DESCRIPTION
## Summary
- migrate remaining manual SQL in internal/storage/users.go to sqlc queries
- add query definitions for auth request completion, user status transitions, pending deletion flow, and test auth request insert
- regenerate storeq (querier.go, users.sql.go)

## Why
- remove direct ExecContext/QueryRowContext usage from user-state write paths
- keep DB access contracts centralized in internal/storage/queries/*.sql for maintainability

## Validation
- go test ./...
