### PR TITLE
ci: enforce sqlc-only runtime db access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,20 @@ jobs:
       - name: Install sqlc
         run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.28.0
 
+      - name: Enforce sqlc-only runtime DB access
+        run: |
+          if rg -n 'ExecContext\(|QueryRowContext\(|QueryContext\(|PrepareContext\(' \
+            internal/storage \
+            --glob '!**/storeq/**' \
+            --glob '!**/*_test.go'; then
+            echo "Direct SQL calls are not allowed in runtime storage code. Use sqlc queries in internal/storage/queries and generated storeq."
+            exit 1
+          fi
+          if rg -n 'parsePostgresArray|func \(a \*?StringArray\) (Scan|Value)\(' internal/storage; then
+            echo "Manual postgres array parsers/scanners are not allowed. Use sqlc/driver array handling."
+            exit 1
+          fi
+
       - name: sqlc generate
         run: $(go env GOPATH)/bin/sqlc generate
 


### PR DESCRIPTION
## Summary
- add CI guard to block direct SQL calls (`ExecContext`, `QueryRowContext`, etc.) in runtime storage code
- add CI guard to block manual postgres array parser/scanner reintroduction
- keep `storeq` generated layer as the only runtime SQL execution path

## Why
- lock in sqlc migration outcome and prevent regression to manual SQL/parsing
- keep maintenance focused on `internal/storage/queries/*.sql` + generated code

## Validation
- go test ./...
