### PR TITLE
refactor(cleanup): route sqlc access through storage layer

### DIFF
--- a/internal/service/cleanup.go
+++ b/internal/service/cleanup.go
@@ -7,18 +7,24 @@ import (
 	"time"
 
 	"github.com/kangheeyong/authgate/internal/clock"
-	"github.com/kangheeyong/authgate/internal/storage/storeq"
+	"github.com/kangheeyong/authgate/internal/storage"
 )
 
 type CleanupService struct {
 	db             *sql.DB
+	runner         *storage.CleanupRunner
 	clock          clock.Clock
 	interval       time.Duration
 	deleteUserHook func(ctx context.Context, tx *sql.Tx, userID string) error
 }
 
 func NewCleanupService(db *sql.DB, clk clock.Clock, interval time.Duration) *CleanupService {
-	return &CleanupService{db: db, clock: clk, interval: interval}
+	return &CleanupService{
+		db:       db,
+		runner:   storage.NewCleanupRunner(db),
+		clock:    clk,
+		interval: interval,
+	}
 }
 
 // Start runs cleanup jobs periodically until ctx is cancelled.
@@ -42,44 +48,43 @@ func (c *CleanupService) Start(ctx context.Context) {
 
 func (c *CleanupService) runAll(ctx context.Context) {
 	now := c.clock.Now()
-	q := storeq.New(c.db)
 
 	// 1. Token cleanup: revoked/expired refresh_tokens after 30 days
-	if n, err := q.DeleteRevokedRefreshTokensBefore(ctx, sql.NullTime{Time: now.Add(-30 * 24 * time.Hour), Valid: true}); err != nil {
+	if n, err := c.runner.DeleteRevokedRefreshTokensBefore(ctx, sql.NullTime{Time: now.Add(-30 * 24 * time.Hour), Valid: true}); err != nil {
 		slog.Error("token cleanup (revoked)", "error", err)
 	} else if n > 0 {
 		slog.Info("token cleanup (revoked)", "deleted", n)
 	}
 
-	if n, err := q.DeleteExpiredRefreshTokensBefore(ctx, now.Add(-30*24*time.Hour)); err != nil {
+	if n, err := c.runner.DeleteExpiredRefreshTokensBefore(ctx, now.Add(-30*24*time.Hour)); err != nil {
 		slog.Error("token cleanup (expired)", "error", err)
 	} else if n > 0 {
 		slog.Info("token cleanup (expired)", "deleted", n)
 	}
 
 	// 2. Session cleanup: expired or revoked sessions
-	if n, err := q.DeleteExpiredOrRevokedSessions(ctx, now); err != nil {
+	if n, err := c.runner.DeleteExpiredOrRevokedSessions(ctx, now); err != nil {
 		slog.Error("session cleanup", "error", err)
 	} else if n > 0 {
 		slog.Info("session cleanup", "deleted", n)
 	}
 
 	// 3. Temp data cleanup: auth_requests expired > 1 hour
-	if n, err := q.DeleteExpiredAuthRequestsBefore(ctx, now.Add(-1*time.Hour)); err != nil {
+	if n, err := c.runner.DeleteExpiredAuthRequestsBefore(ctx, now.Add(-1*time.Hour)); err != nil {
 		slog.Error("auth_requests cleanup", "error", err)
 	} else if n > 0 {
 		slog.Info("auth_requests cleanup", "deleted", n)
 	}
 
 	// 4. Temp data cleanup: device_codes expired > 1 hour
-	if n, err := q.DeleteExpiredDeviceCodesBefore(ctx, now.Add(-1*time.Hour)); err != nil {
+	if n, err := c.runner.DeleteExpiredDeviceCodesBefore(ctx, now.Add(-1*time.Hour)); err != nil {
 		slog.Error("device_codes cleanup", "error", err)
 	} else if n > 0 {
 		slog.Info("device_codes cleanup", "deleted", n)
 	}
 
 	// 5. Deletion cleanup: pending_deletion users past scheduled date → PII scrub
-	userIDs, err := q.ListPendingDeletionUserIDsBefore(ctx, sql.NullTime{Time: now, Valid: true})
+	userIDs, err := c.runner.ListPendingDeletionUserIDsBefore(ctx, sql.NullTime{Time: now, Valid: true})
 	if err != nil {
 		slog.Error("deletion cleanup query", "error", err)
 	} else {
@@ -93,7 +98,7 @@ func (c *CleanupService) runAll(ctx context.Context) {
 	}
 
 	// 6. Audit log anonymization: user_id NULL after 3 years (Spec 007)
-	if n, err := q.AnonymizeAuditLogBefore(ctx, now.Add(-3*365*24*time.Hour)); err != nil {
+	if n, err := c.runner.AnonymizeAuditLogBefore(ctx, now.Add(-3*365*24*time.Hour)); err != nil {
 		slog.Error("audit_log anonymization", "error", err)
 	} else if n > 0 {
 		slog.Info("audit_log anonymization", "anonymized", n)
@@ -103,47 +108,7 @@ func (c *CleanupService) runAll(ctx context.Context) {
 // deleteUser performs Spec 006 stage 3: explicit DELETE of child records + PII scrub.
 // CASCADE is NOT triggered because we UPDATE (not DELETE) the users row.
 func (c *CleanupService) deleteUser(ctx context.Context, userID string, now time.Time) error {
-	tx, err := c.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-	qtx := storeq.New(tx)
-
-	// Delete child records explicitly (UPDATE doesn't trigger CASCADE)
-	if err := qtx.DeleteUserIdentitiesByUserID(ctx, userID); err != nil {
-		return err
-	}
-	if err := qtx.DeleteSessionsByUserID(ctx, userID); err != nil {
-		return err
-	}
-	if err := qtx.DeleteRefreshTokensByUserID(ctx, userID); err != nil {
-		return err
-	}
-	if c.deleteUserHook != nil {
-		if err := c.deleteUserHook(ctx, tx, userID); err != nil {
-			return err
-		}
-	}
-
-	// PII scrub + status transition (defense-in-depth: also check deletion_scheduled_at)
-	if err := qtx.MarkUserDeletedByID(ctx, storeq.MarkUserDeletedByIDParams{
-		DeletedAt: sql.NullTime{Time: now, Valid: true},
-		UserID:    userID,
-	}); err != nil {
-		return err
-	}
-
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-
-	// Audit after successful commit
-	_ = storeq.New(c.db).InsertDeletionCompletedAudit(ctx, storeq.InsertDeletionCompletedAuditParams{
-		UserID:    userID,
-		CreatedAt: now,
-	})
-	return nil
+	return c.runner.DeleteUser(ctx, userID, now, c.deleteUserHook)
 }
 
 // RunOnce executes all cleanup jobs once. For testing.

--- a/internal/storage/cleanup_runner.go
+++ b/internal/storage/cleanup_runner.go
@@ -1,0 +1,92 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/kangheeyong/authgate/internal/storage/storeq"
+)
+
+// CleanupRunner encapsulates sqlc-backed cleanup queries.
+type CleanupRunner struct {
+	db *sql.DB
+}
+
+func NewCleanupRunner(db *sql.DB) *CleanupRunner {
+	return &CleanupRunner{db: db}
+}
+
+func (r *CleanupRunner) DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff sql.NullTime) (int64, error) {
+	return storeq.New(r.db).DeleteRevokedRefreshTokensBefore(ctx, cutoff)
+}
+
+func (r *CleanupRunner) DeleteExpiredRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	return storeq.New(r.db).DeleteExpiredRefreshTokensBefore(ctx, cutoff)
+}
+
+func (r *CleanupRunner) DeleteExpiredOrRevokedSessions(ctx context.Context, cutoff time.Time) (int64, error) {
+	return storeq.New(r.db).DeleteExpiredOrRevokedSessions(ctx, cutoff)
+}
+
+func (r *CleanupRunner) DeleteExpiredAuthRequestsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	return storeq.New(r.db).DeleteExpiredAuthRequestsBefore(ctx, cutoff)
+}
+
+func (r *CleanupRunner) DeleteExpiredDeviceCodesBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	return storeq.New(r.db).DeleteExpiredDeviceCodesBefore(ctx, cutoff)
+}
+
+func (r *CleanupRunner) ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff sql.NullTime) ([]string, error) {
+	return storeq.New(r.db).ListPendingDeletionUserIDsBefore(ctx, cutoff)
+}
+
+func (r *CleanupRunner) AnonymizeAuditLogBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	return storeq.New(r.db).AnonymizeAuditLogBefore(ctx, cutoff)
+}
+
+func (r *CleanupRunner) DeleteUser(
+	ctx context.Context,
+	userID string,
+	now time.Time,
+	hook func(ctx context.Context, tx *sql.Tx, userID string) error,
+) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	qtx := storeq.New(tx)
+
+	if err := qtx.DeleteUserIdentitiesByUserID(ctx, userID); err != nil {
+		return err
+	}
+	if err := qtx.DeleteSessionsByUserID(ctx, userID); err != nil {
+		return err
+	}
+	if err := qtx.DeleteRefreshTokensByUserID(ctx, userID); err != nil {
+		return err
+	}
+	if hook != nil {
+		if err := hook(ctx, tx, userID); err != nil {
+			return err
+		}
+	}
+
+	if err := qtx.MarkUserDeletedByID(ctx, storeq.MarkUserDeletedByIDParams{
+		DeletedAt: sql.NullTime{Time: now, Valid: true},
+		UserID:    userID,
+	}); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	_ = storeq.New(r.db).InsertDeletionCompletedAudit(ctx, storeq.InsertDeletionCompletedAuditParams{
+		UserID:    userID,
+		CreatedAt: now,
+	})
+	return nil
+}


### PR DESCRIPTION
## Summary
- remove direct `storeq` dependency from `internal/service/cleanup.go`
- introduce `internal/storage/cleanup_runner.go` to encapsulate sqlc-backed cleanup operations
- keep `CleanupService` constructor and test hook signatures unchanged (behavior-preserving refactor)

## Why
- enforce consistent layering: `service -> storage -> storeq`
- prepare for directory/package refactors without touching test contracts first

## Validation
- go test ./...
