### PR TITLE
refactor(service): use small storage interfaces per service

### DIFF
--- a/internal/service/account.go
+++ b/internal/service/account.go
@@ -8,10 +8,16 @@ import (
 )
 
 type AccountService struct {
-	store *storage.Storage
+	store AccountStore
 }
 
-func NewAccountService(store *storage.Storage) *AccountService {
+type AccountStore interface {
+	GetValidSession(ctx context.Context, sessionID string) (*storage.User, error)
+	RequestDeletion(ctx context.Context, userID string) error
+	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+}
+
+func NewAccountService(store AccountStore) *AccountService {
 	return &AccountService{store: store}
 }
 

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -12,14 +12,24 @@ import (
 )
 
 type DeviceService struct {
-	store      *storage.Storage
+	store      DeviceStore
 	provider   upstream.Provider
 	sessionTTL time.Duration
 	publicURL  string
 	clock      clock.Clock
 }
 
-func NewDeviceService(store *storage.Storage, provider upstream.Provider, publicURL string, sessionTTL time.Duration, clk clock.Clock) *DeviceService {
+type DeviceStore interface {
+	GetDeviceCodeByUserCode(ctx context.Context, userCode string) (*storage.DeviceCodeModel, error)
+	GetValidSession(ctx context.Context, sessionID string) (*storage.User, error)
+	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+	GetUserByProviderIdentity(ctx context.Context, provider, providerUserID string) (*storage.User, error)
+	CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error)
+	DenyDeviceCode(ctx context.Context, userCode string) error
+	ApproveDeviceCode(ctx context.Context, userCode, subject string) error
+}
+
+func NewDeviceService(store DeviceStore, provider upstream.Provider, publicURL string, sessionTTL time.Duration, clk clock.Clock) *DeviceService {
 	return &DeviceService{
 		store:      store,
 		provider:   provider,

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -12,13 +12,24 @@ import (
 )
 
 type LoginService struct {
-	store           *storage.Storage
+	store           LoginStore
 	browserProvider upstream.Provider
 	mcpProvider     upstream.Provider
 	sessionTTL      time.Duration
 }
 
-func NewLoginService(store *storage.Storage, browserProvider, mcpProvider upstream.Provider, sessionTTL time.Duration) *LoginService {
+type LoginStore interface {
+	GetValidSession(ctx context.Context, sessionID string) (*storage.User, error)
+	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+	RecoverUser(ctx context.Context, userID string) error
+	CompleteAuthRequest(ctx context.Context, authRequestID, userID string) error
+	GetUserByProviderIdentity(ctx context.Context, provider, providerUserID string) (*storage.User, error)
+	CreateUserWithIdentity(ctx context.Context, email string, emailVerified bool, name, avatarURL, provider, providerUserID, providerEmail string) (*storage.User, error)
+	GetUserByID(ctx context.Context, userID string) (*storage.User, error)
+	CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error)
+}
+
+func NewLoginService(store LoginStore, browserProvider, mcpProvider upstream.Provider, sessionTTL time.Duration) *LoginService {
 	if mcpProvider == nil {
 		mcpProvider = browserProvider
 	}


### PR DESCRIPTION
## Summary
- introduce service-local small interfaces:
  - `LoginStore` in `login.go`
  - `DeviceStore` in `device.go`
  - `AccountStore` in `account.go`
- change service constructors and struct fields to depend on those interfaces instead of `*storage.Storage`
- keep behavior and call sites unchanged (`*storage.Storage` still satisfies all interfaces)

## Why
- reduce coupling between service layer and concrete storage implementation
- improve testability and future refactor safety with consumer-defined interfaces

## Validation
- go test ./...
