### PR TITLE
test(service): add unit tests with fake stores

### DIFF
--- a/internal/service/account_unit_test.go
+++ b/internal/service/account_unit_test.go
@@ -1,0 +1,110 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kangheeyong/authgate/internal/storage"
+)
+
+type fakeAccountStore struct {
+	getValidSessionFn func(ctx context.Context, sessionID string) (*storage.User, error)
+	requestDeletionFn func(ctx context.Context, userID string) error
+	auditLogFn        func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+}
+
+func (f *fakeAccountStore) GetValidSession(ctx context.Context, sessionID string) (*storage.User, error) {
+	return f.getValidSessionFn(ctx, sessionID)
+}
+
+func (f *fakeAccountStore) RequestDeletion(ctx context.Context, userID string) error {
+	return f.requestDeletionFn(ctx, userID)
+}
+
+func (f *fakeAccountStore) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+	if f.auditLogFn == nil {
+		return nil
+	}
+	return f.auditLogFn(ctx, userID, eventType, ipAddress, userAgent, metadata)
+}
+
+func TestAccount_RequestDeletion_PendingDeletion_IsIdempotent(t *testing.T) {
+	calledDelete := false
+	store := &fakeAccountStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return &storage.User{ID: "u1", Status: "pending_deletion"}, nil
+		},
+		requestDeletionFn: func(context.Context, string) error {
+			calledDelete = true
+			return nil
+		},
+	}
+	svc := NewAccountService(store)
+
+	result := svc.RequestDeletion(context.Background(), "sess-1", "127.0.0.1", "ua")
+
+	if !result.Success {
+		t.Fatal("pending_deletion should be idempotent success")
+	}
+	if !strings.Contains(result.Message, "Already pending deletion") {
+		t.Fatalf("unexpected message: %q", result.Message)
+	}
+	if calledDelete {
+		t.Fatal("RequestDeletion should not be called for pending_deletion")
+	}
+}
+
+func TestAccount_RequestDeletion_ActiveUser_Success(t *testing.T) {
+	calledDelete := false
+	calledAudit := false
+	store := &fakeAccountStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return &storage.User{ID: "u1", Status: "active"}, nil
+		},
+		requestDeletionFn: func(context.Context, string) error {
+			calledDelete = true
+			return nil
+		},
+		auditLogFn: func(context.Context, *string, string, string, string, map[string]any) error {
+			calledAudit = true
+			return nil
+		},
+	}
+	svc := NewAccountService(store)
+
+	result := svc.RequestDeletion(context.Background(), "sess-1", "127.0.0.1", "ua")
+
+	if !result.Success {
+		t.Fatalf("expected success, got message=%q", result.Message)
+	}
+	if !calledDelete {
+		t.Fatal("RequestDeletion should be called")
+	}
+	if !calledAudit {
+		t.Fatal("AuditLog should be called")
+	}
+}
+
+func TestAccount_RequestDeletion_InvalidSession(t *testing.T) {
+	store := &fakeAccountStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return nil, errors.New("invalid")
+		},
+		requestDeletionFn: func(context.Context, string) error {
+			return nil
+		},
+	}
+	svc := NewAccountService(store)
+
+	result := svc.RequestDeletion(context.Background(), "sess-1", "127.0.0.1", "ua")
+
+	if result.Success {
+		t.Fatal("invalid session should fail")
+	}
+	if result.ErrorCode != 401 {
+		t.Fatalf("errorCode = %d, want 401", result.ErrorCode)
+	}
+}
+

--- a/internal/service/device_unit_test.go
+++ b/internal/service/device_unit_test.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kangheeyong/authgate/internal/clock"
+	"github.com/kangheeyong/authgate/internal/storage"
+	"github.com/kangheeyong/authgate/internal/upstream"
+)
+
+type fakeDeviceStore struct {
+	getDeviceCodeByUserCodeFn func(ctx context.Context, userCode string) (*storage.DeviceCodeModel, error)
+	getValidSessionFn         func(ctx context.Context, sessionID string) (*storage.User, error)
+	auditLogFn                func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+	getUserByProviderIdentity func(ctx context.Context, provider, providerUserID string) (*storage.User, error)
+	createSessionFn           func(ctx context.Context, userID string, ttl time.Duration) (string, error)
+	denyDeviceCodeFn          func(ctx context.Context, userCode string) error
+	approveDeviceCodeFn       func(ctx context.Context, userCode, subject string) error
+}
+
+func (f *fakeDeviceStore) GetDeviceCodeByUserCode(ctx context.Context, userCode string) (*storage.DeviceCodeModel, error) {
+	return f.getDeviceCodeByUserCodeFn(ctx, userCode)
+}
+
+func (f *fakeDeviceStore) GetValidSession(ctx context.Context, sessionID string) (*storage.User, error) {
+	return f.getValidSessionFn(ctx, sessionID)
+}
+
+func (f *fakeDeviceStore) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+	if f.auditLogFn == nil {
+		return nil
+	}
+	return f.auditLogFn(ctx, userID, eventType, ipAddress, userAgent, metadata)
+}
+
+func (f *fakeDeviceStore) GetUserByProviderIdentity(ctx context.Context, provider, providerUserID string) (*storage.User, error) {
+	return f.getUserByProviderIdentity(ctx, provider, providerUserID)
+}
+
+func (f *fakeDeviceStore) CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error) {
+	return f.createSessionFn(ctx, userID, ttl)
+}
+
+func (f *fakeDeviceStore) DenyDeviceCode(ctx context.Context, userCode string) error {
+	return f.denyDeviceCodeFn(ctx, userCode)
+}
+
+func (f *fakeDeviceStore) ApproveDeviceCode(ctx context.Context, userCode, subject string) error {
+	return f.approveDeviceCodeFn(ctx, userCode, subject)
+}
+
+func TestDevice_HandleDevicePage_NoSession_Redirects(t *testing.T) {
+	clk := &clock.FixedClock{T: time.Date(2026, 4, 3, 0, 0, 0, 0, time.UTC)}
+	store := &fakeDeviceStore{
+		getDeviceCodeByUserCodeFn: func(context.Context, string) (*storage.DeviceCodeModel, error) {
+			return &storage.DeviceCodeModel{
+				UserCode:  "UCODE",
+				State:     "pending",
+				ExpiresAt: clk.Now().Add(5 * time.Minute),
+			}, nil
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
+	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clk)
+
+	result := svc.HandleDevicePage(context.Background(), "UCODE", "")
+
+	if result.Action != DeviceRedirectIdP {
+		t.Fatalf("action = %v, want %v", result.Action, DeviceRedirectIdP)
+	}
+}
+
+func TestDevice_HandleDeviceApprove_Deny(t *testing.T) {
+	denyCalled := false
+	store := &fakeDeviceStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return &storage.User{ID: "u1", Status: "active"}, nil
+		},
+		denyDeviceCodeFn: func(context.Context, string) error {
+			denyCalled = true
+			return nil
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
+	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clock.RealClock{})
+
+	result := svc.HandleDeviceApprove(context.Background(), "UCODE", "deny", "sess", "127.0.0.1", "ua")
+
+	if result.Success {
+		t.Fatal("deny action should return success=false")
+	}
+	if !denyCalled {
+		t.Fatal("DenyDeviceCode should be called")
+	}
+}
+
+func TestDevice_HandleDeviceApprove_ApproveError(t *testing.T) {
+	store := &fakeDeviceStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return &storage.User{ID: "u1", Status: "active"}, nil
+		},
+		approveDeviceCodeFn: func(context.Context, string, string) error {
+			return errors.New("expired")
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
+	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clock.RealClock{})
+
+	result := svc.HandleDeviceApprove(context.Background(), "UCODE", "approve", "sess", "127.0.0.1", "ua")
+
+	if result.Success {
+		t.Fatal("approve with error should fail")
+	}
+	if result.ErrorCode != 400 {
+		t.Fatalf("errorCode = %d, want 400", result.ErrorCode)
+	}
+}
+

--- a/internal/service/login_unit_test.go
+++ b/internal/service/login_unit_test.go
@@ -1,0 +1,137 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kangheeyong/authgate/internal/storage"
+	"github.com/kangheeyong/authgate/internal/upstream"
+)
+
+type fakeLoginStore struct {
+	getValidSessionFn         func(ctx context.Context, sessionID string) (*storage.User, error)
+	auditLogFn                func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+	recoverUserFn             func(ctx context.Context, userID string) error
+	completeAuthRequestFn     func(ctx context.Context, authRequestID, userID string) error
+	getUserByProviderIdentity func(ctx context.Context, provider, providerUserID string) (*storage.User, error)
+	createUserWithIdentityFn  func(ctx context.Context, email string, emailVerified bool, name, avatarURL, provider, providerUserID, providerEmail string) (*storage.User, error)
+	getUserByIDFn             func(ctx context.Context, userID string) (*storage.User, error)
+	createSessionFn           func(ctx context.Context, userID string, ttl time.Duration) (string, error)
+}
+
+func (f *fakeLoginStore) GetValidSession(ctx context.Context, sessionID string) (*storage.User, error) {
+	return f.getValidSessionFn(ctx, sessionID)
+}
+
+func (f *fakeLoginStore) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+	if f.auditLogFn == nil {
+		return nil
+	}
+	return f.auditLogFn(ctx, userID, eventType, ipAddress, userAgent, metadata)
+}
+
+func (f *fakeLoginStore) RecoverUser(ctx context.Context, userID string) error {
+	return f.recoverUserFn(ctx, userID)
+}
+
+func (f *fakeLoginStore) CompleteAuthRequest(ctx context.Context, authRequestID, userID string) error {
+	return f.completeAuthRequestFn(ctx, authRequestID, userID)
+}
+
+func (f *fakeLoginStore) GetUserByProviderIdentity(ctx context.Context, provider, providerUserID string) (*storage.User, error) {
+	return f.getUserByProviderIdentity(ctx, provider, providerUserID)
+}
+
+func (f *fakeLoginStore) CreateUserWithIdentity(ctx context.Context, email string, emailVerified bool, name, avatarURL, provider, providerUserID, providerEmail string) (*storage.User, error) {
+	return f.createUserWithIdentityFn(ctx, email, emailVerified, name, avatarURL, provider, providerUserID, providerEmail)
+}
+
+func (f *fakeLoginStore) GetUserByID(ctx context.Context, userID string) (*storage.User, error) {
+	return f.getUserByIDFn(ctx, userID)
+}
+
+func (f *fakeLoginStore) CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error) {
+	return f.createSessionFn(ctx, userID, ttl)
+}
+
+func TestLogin_HandleLogin_RecoversPendingDeletionSession(t *testing.T) {
+	calledRecover := false
+	calledComplete := false
+
+	store := &fakeLoginStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return &storage.User{ID: "u1", Status: "pending_deletion"}, nil
+		},
+		recoverUserFn: func(context.Context, string) error {
+			calledRecover = true
+			return nil
+		},
+		completeAuthRequestFn: func(context.Context, string, string) error {
+			calledComplete = true
+			return nil
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "s1"}}
+	svc := NewLoginService(store, provider, provider, 24*time.Hour)
+
+	result := svc.HandleLogin(context.Background(), "ar-1", "sess-1", "127.0.0.1", "ua")
+
+	if result.Action != ActionAutoApprove {
+		t.Fatalf("action = %v, want %v", result.Action, ActionAutoApprove)
+	}
+	if !calledRecover {
+		t.Fatal("RecoverUser should be called for pending_deletion")
+	}
+	if !calledComplete {
+		t.Fatal("CompleteAuthRequest should be called")
+	}
+}
+
+func TestLogin_HandleCallback_EmailConflict(t *testing.T) {
+	store := &fakeLoginStore{
+		getUserByProviderIdentity: func(context.Context, string, string) (*storage.User, error) {
+			return nil, storage.ErrNotFound
+		},
+		createUserWithIdentityFn: func(context.Context, string, bool, string, string, string, string, string) (*storage.User, error) {
+			return nil, storage.ErrEmailConflict
+		},
+	}
+	provider := &upstream.FakeProvider{
+		ProviderName: "google",
+		User: &upstream.UserInfo{
+			Sub:           "sub-1",
+			Email:         "dup@example.com",
+			EmailVerified: true,
+			Name:          "Dup",
+		},
+	}
+	svc := NewLoginService(store, provider, provider, 24*time.Hour)
+
+	result := svc.HandleCallback(context.Background(), "code", "ar-1", "127.0.0.1", "ua")
+
+	if result.Action != ActionError {
+		t.Fatalf("action = %v, want %v", result.Action, ActionError)
+	}
+	if result.ErrorCode != 409 {
+		t.Fatalf("errorCode = %d, want 409", result.ErrorCode)
+	}
+}
+
+func TestLogin_HandleLogin_NoSession_Redirect(t *testing.T) {
+	store := &fakeLoginStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return nil, errors.New("no session")
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "s1"}}
+	svc := NewLoginService(store, provider, provider, 24*time.Hour)
+
+	result := svc.HandleLogin(context.Background(), "ar-1", "sess-1", "127.0.0.1", "ua")
+
+	if result.Action != ActionRedirectToIdP {
+		t.Fatalf("action = %v, want %v", result.Action, ActionRedirectToIdP)
+	}
+}
+


### PR DESCRIPTION
## Summary
- add non-integration unit tests for service layer using fake store implementations
  - `internal/service/login_unit_test.go`
  - `internal/service/device_unit_test.go`
  - `internal/service/account_unit_test.go`
- cover key branch behavior without real DB setup

## Why
- leverage newly introduced service-side interfaces
- improve service test speed and branch isolation while keeping existing integration tests unchanged

## Validation
- go test ./internal/service ./...
