### PR TITLE
refactor(cleanup): tighten service-storage boundary

### DIFF
--- a/internal/service/cleanup.go
+++ b/internal/service/cleanup.go
@@ -10,17 +10,26 @@ import (
 	"github.com/kangheeyong/authgate/internal/storage"
 )
 
+type cleanupRunner interface {
+	DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteExpiredRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteExpiredOrRevokedSessions(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteExpiredAuthRequestsBefore(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteExpiredDeviceCodesBefore(ctx context.Context, cutoff time.Time) (int64, error)
+	ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff time.Time) ([]string, error)
+	AnonymizeAuditLogBefore(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteUser(ctx context.Context, userID string, now time.Time, hook func(ctx context.Context, userID string) error) error
+}
+
 type CleanupService struct {
-	db             *sql.DB
-	runner         *storage.CleanupRunner
+	runner         cleanupRunner
 	clock          clock.Clock
 	interval       time.Duration
-	deleteUserHook func(ctx context.Context, tx *sql.Tx, userID string) error
+	deleteUserHook func(ctx context.Context, userID string) error
 }
 
 func NewCleanupService(db *sql.DB, clk clock.Clock, interval time.Duration) *CleanupService {
 	return &CleanupService{
-		db:       db,
 		runner:   storage.NewCleanupRunner(db),
 		clock:    clk,
 		interval: interval,
@@ -50,7 +59,7 @@ func (c *CleanupService) runAll(ctx context.Context) {
 	now := c.clock.Now()
 
 	// 1. Token cleanup: revoked/expired refresh_tokens after 30 days
-	if n, err := c.runner.DeleteRevokedRefreshTokensBefore(ctx, sql.NullTime{Time: now.Add(-30 * 24 * time.Hour), Valid: true}); err != nil {
+	if n, err := c.runner.DeleteRevokedRefreshTokensBefore(ctx, now.Add(-30*24*time.Hour)); err != nil {
 		slog.Error("token cleanup (revoked)", "error", err)
 	} else if n > 0 {
 		slog.Info("token cleanup (revoked)", "deleted", n)
@@ -84,7 +93,7 @@ func (c *CleanupService) runAll(ctx context.Context) {
 	}
 
 	// 5. Deletion cleanup: pending_deletion users past scheduled date → PII scrub
-	userIDs, err := c.runner.ListPendingDeletionUserIDsBefore(ctx, sql.NullTime{Time: now, Valid: true})
+	userIDs, err := c.runner.ListPendingDeletionUserIDsBefore(ctx, now)
 	if err != nil {
 		slog.Error("deletion cleanup query", "error", err)
 	} else {

--- a/internal/service/cleanup_test.go
+++ b/internal/service/cleanup_test.go
@@ -156,7 +156,7 @@ func TestE2E8_CleanupRollback(t *testing.T) {
 
 	simulatedErr := errors.New("simulated cleanup failure")
 	svc := NewCleanupService(db, clk, time.Hour)
-	svc.deleteUserHook = func(ctx context.Context, tx *sql.Tx, userID string) error {
+	svc.deleteUserHook = func(ctx context.Context, userID string) error {
 		return simulatedErr
 	}
 	svc.RunOnce(ctx)

--- a/internal/storage/cleanup_runner.go
+++ b/internal/storage/cleanup_runner.go
@@ -17,8 +17,8 @@ func NewCleanupRunner(db *sql.DB) *CleanupRunner {
 	return &CleanupRunner{db: db}
 }
 
-func (r *CleanupRunner) DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff sql.NullTime) (int64, error) {
-	return storeq.New(r.db).DeleteRevokedRefreshTokensBefore(ctx, cutoff)
+func (r *CleanupRunner) DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	return storeq.New(r.db).DeleteRevokedRefreshTokensBefore(ctx, sql.NullTime{Time: cutoff, Valid: true})
 }
 
 func (r *CleanupRunner) DeleteExpiredRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -37,8 +37,8 @@ func (r *CleanupRunner) DeleteExpiredDeviceCodesBefore(ctx context.Context, cuto
 	return storeq.New(r.db).DeleteExpiredDeviceCodesBefore(ctx, cutoff)
 }
 
-func (r *CleanupRunner) ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff sql.NullTime) ([]string, error) {
-	return storeq.New(r.db).ListPendingDeletionUserIDsBefore(ctx, cutoff)
+func (r *CleanupRunner) ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff time.Time) ([]string, error) {
+	return storeq.New(r.db).ListPendingDeletionUserIDsBefore(ctx, sql.NullTime{Time: cutoff, Valid: true})
 }
 
 func (r *CleanupRunner) AnonymizeAuditLogBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -49,7 +49,7 @@ func (r *CleanupRunner) DeleteUser(
 	ctx context.Context,
 	userID string,
 	now time.Time,
-	hook func(ctx context.Context, tx *sql.Tx, userID string) error,
+	hook func(ctx context.Context, userID string) error,
 ) error {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -68,7 +68,7 @@ func (r *CleanupRunner) DeleteUser(
 		return err
 	}
 	if hook != nil {
-		if err := hook(ctx, tx, userID); err != nil {
+		if err := hook(ctx, userID); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- remove `db *sql.DB` field from `CleanupService`
- replace service-side cleanup runner dependency with interface (`cleanupRunner`)
- simplify deletion hook signature from `func(ctx, tx, userID)` to `func(ctx, userID)`
- move `sql.NullTime` adaptation fully inside `storage.CleanupRunner`

## Why
- eliminate DB/transaction type leakage from service layer
- enforce clearer `service -> storage` boundary
- keep behavior unchanged while improving layering quality

## Validation
- go test ./internal/service ./internal/storage ./...
