### PR TITLE
refactor(cleanup): finalize service boundary with runner injection

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -253,7 +253,8 @@ func main() {
 	}
 
 	// Cleanup service
-	cleanupSvc := service.NewCleanupService(db, clk, 10*time.Minute)
+	cleanupRunner := storage.NewCleanupRunner(db)
+	cleanupSvc := service.NewCleanupService(cleanupRunner, clk, 10*time.Minute)
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
 	defer cleanupCancel()
 	go cleanupSvc.Start(cleanupCtx)

--- a/internal/service/account_test.go
+++ b/internal/service/account_test.go
@@ -161,7 +161,7 @@ func TestE2E_DeleteThenReregister(t *testing.T) {
 	db.ExecContext(ctx, `UPDATE users SET deletion_scheduled_at = $1 WHERE id = $2`,
 		clk.Now().Add(-1*time.Hour), userID)
 
-	cleanupSvc := NewCleanupService(db, clk, time.Hour)
+	cleanupSvc := NewCleanupService(storage.NewCleanupRunner(db), clk, time.Hour)
 	cleanupSvc.RunOnce(ctx)
 
 	var dbStatus, email string

--- a/internal/service/cleanup.go
+++ b/internal/service/cleanup.go
@@ -2,12 +2,10 @@ package service
 
 import (
 	"context"
-	"database/sql"
 	"log/slog"
 	"time"
 
 	"github.com/kangheeyong/authgate/internal/clock"
-	"github.com/kangheeyong/authgate/internal/storage"
 )
 
 type cleanupRunner interface {
@@ -28,9 +26,9 @@ type CleanupService struct {
 	deleteUserHook func(ctx context.Context, userID string) error
 }
 
-func NewCleanupService(db *sql.DB, clk clock.Clock, interval time.Duration) *CleanupService {
+func NewCleanupService(runner cleanupRunner, clk clock.Clock, interval time.Duration) *CleanupService {
 	return &CleanupService{
-		runner:   storage.NewCleanupRunner(db),
+		runner:   runner,
 		clock:    clk,
 		interval: interval,
 	}

--- a/internal/service/cleanup_test.go
+++ b/internal/service/cleanup_test.go
@@ -44,7 +44,7 @@ func TestCleanup_ExpiredSessions(t *testing.T) {
 	}
 
 	// Run cleanup
-	svc := NewCleanupService(db, clk, time.Hour)
+	svc := NewCleanupService(storage.NewCleanupRunner(db), clk, time.Hour)
 	svc.RunOnce(ctx)
 
 	// Session should be deleted
@@ -71,7 +71,7 @@ func TestCleanup_ExpiredAuthRequests(t *testing.T) {
 		t.Fatal("expected at least 1 auth request")
 	}
 
-	svc := NewCleanupService(db, clk, time.Hour)
+	svc := NewCleanupService(storage.NewCleanupRunner(db), clk, time.Hour)
 	svc.RunOnce(ctx)
 
 	db.QueryRowContext(ctx, `SELECT count(*) FROM auth_requests WHERE expires_at < $1`, clk.Now().Add(-1*time.Hour)).Scan(&count)
@@ -94,7 +94,7 @@ func TestCleanup_DeletionPIIScrub(t *testing.T) {
 	// Create session and identity that should be cleaned up
 	store.CreateSession(ctx, user.ID, 24*time.Hour)
 
-	svc := NewCleanupService(db, clk, time.Hour)
+	svc := NewCleanupService(storage.NewCleanupRunner(db), clk, time.Hour)
 	svc.RunOnce(ctx)
 
 	// User should be scrubbed
@@ -155,7 +155,7 @@ func TestE2E8_CleanupRollback(t *testing.T) {
 	}
 
 	simulatedErr := errors.New("simulated cleanup failure")
-	svc := NewCleanupService(db, clk, time.Hour)
+	svc := NewCleanupService(storage.NewCleanupRunner(db), clk, time.Hour)
 	svc.deleteUserHook = func(ctx context.Context, userID string) error {
 		return simulatedErr
 	}
@@ -200,7 +200,7 @@ func TestCleanup_DeletionPIIScrub_Idempotent(t *testing.T) {
 	)
 	store.CreateSession(ctx, user.ID, 24*time.Hour)
 
-	svc := NewCleanupService(db, clk, time.Hour)
+	svc := NewCleanupService(storage.NewCleanupRunner(db), clk, time.Hour)
 	svc.RunOnce(ctx)
 	svc.RunOnce(ctx)
 


### PR DESCRIPTION
## Summary
- remove `database/sql` dependency from `internal/service/cleanup.go`
- change `NewCleanupService` to accept a cleanup runner interface instead of `*sql.DB`
- construct `storage.NewCleanupRunner(db)` in `cmd/authgate/main.go` and inject it
- update cleanup/account tests to use runner injection

## Why
This finalizes the service boundary cleanup so `service` no longer directly depends on SQL DB handles.

## Validation
- `go test ./...`