### PR TITLE
docs: clarify core/adapter boundaries and MCP separation plan

### DIFF
--- a/docs/architecture/001-component-boundaries.md
+++ b/docs/architecture/001-component-boundaries.md
@@ -1,341 +1,437 @@
 # Architecture 001: 컴포넌트 경계
 
-## 개요
+## 목적
 
-authgate의 내부 컴포넌트를 정의하고, 각 컴포넌트의 책임 범위와 의존 방향을 고정한다.
-이 문서는 Go 패키지 구조의 근거가 된다.
+authgate의 내부 구조, 책임 경계, 의존 방향을 정의한다.
+이 문서는 "무엇이 공통 코어이고, 무엇이 채널 어댑터인지"를 명확히 하기 위한 기준 문서다.
 
-## 최상위 경계: zitadel/oidc vs authgate
+핵심 목표는 두 가지다.
 
-[ADR-001](../adr/001-adopt-zitadel-oidc.md)에서 확정된 책임 분리:
+```text
+1. authgate를 재사용 가능한 인증 서비스로 유지한다.
+2. Browser / Device / MCP가 같은 인증 코어를 공유하는 어댑터 계층으로 정리한다.
+```
+
+설계 원칙은 [ADR-000](../adr/000-authgate-identity.md), 기술 선택은 [ADR-001](../adr/001-adopt-zitadel-oidc.md)을 따른다.
+
+## 최상위 경계
+
+### 1. zitadel/oidc vs authgate
 
 ```text
 zitadel/oidc (프로토콜 계층)         authgate (비즈니스 계층)
 ──────────────────────              ──────────────────────
-/authorize 검증                     op.Storage 구현 (필수 22 + Device 2)
+/authorize 검증                     op.Storage 구현
 /oauth/token grant 처리             upstream IdP 연동
-JWT 서명/발급 (RS256)               로그인 UI + 세션 관리
+JWT 서명/발급 (RS256)               로그인/세션 orchestration
 JWKS, Discovery 자동 생성           유저/계정 lifecycle
-Device polling 상태머신             user.Status 기반 상태 검사
-Refresh grant orchestration
+Device polling 상태머신             user.Status 정책
+Refresh grant orchestration         pages / audit / cleanup
 ```
 
-zitadel이 대부분의 프로토콜 라우팅을 소유하고 (`/.well-known/*`, `/authorize`, `/oauth/*`),
-authgate가 `op.Storage` 인터페이스로 데이터를 제공한다.
-다만 authgate는 일부 메타데이터/보조 엔드포인트를 직접 제공할 수 있다
-(`/.well-known/oauth-authorization-server`, `/login`, `/device`, `/account` 등).
+zitadel이 대부분의 표준 OAuth/OIDC 라우팅을 소유하고,
+authgate는 `op.Storage`와 채널별 인증 UX를 제공한다.
 
-## authgate 내부 컴포넌트
+### 2. Authentication vs Authorization
 
 ```text
-┌──────────────────────────────────────────────────────┐
-│                      main                             │
-│  config 로드, DB 연결, zitadel OP 생성, 서버 시작       │
-└───────────────────────┬──────────────────────────────┘
-                        │
-        ┌───────────────┼───────────────┐
-        │               │               │
-        v               v               v
- ┌──────────┐    ┌────────────┐   ┌──────────────┐
- │ handler  │    │  service   │   │   upstream   │
- │          │───>│            │   │              │
- │ /login   │    │ login      │   │ OIDC         │
- │ /login/* │    │ device     │   │ Discovery    │
- │ /device  │    │ account    │   │              │
- │ /device/*│    │ cleanup    │   │ code exchange│
- │ /account │    │            │   │ userinfo     │
- │ /health  │    └──┬──┬──┬───┘   └──────────────┘
- └──────────┘       │  │  │
-                    │  │  │
-        ┌───────────┘  │  └───────────┐
-        v              v              v
- ┌────────────┐  ┌──────────┐  ┌──────────┐
- │  storage   │  │  pages   │  │  clock   │
- │            │  │          │  │          │
- │ op.Storage │  │ device   │  │ Now()    │
- │ 22 + Dev 2 │  │ result   │  └──────────┘
- │            │  └──────────┘
- │ users      │
- │ sessions   │
- │ tokens     │
- │ clients    │
- │ auth_reqs  │
- │ device     │
- │ audit      │
- └──────┬─────┘
-        │
- ┌──────────┐   ┌──────────┐
- │  idgen   │   │ sqlc db  │
- │          │   │          │
- │ NewUUID  │   │ queries/ │
- │ NewToken │   │ storeq/  │
- └──────────┘   └────┬─────┘
-                     │
-                 PostgreSQL
+Authentication
+  - 사용자가 누구인지 확인
+  - 세션 생성
+  - 토큰 발급/갱신/폐기
+  - 계정 상태에 따른 로그인 허용 여부 판단
+
+Authorization
+  - 이 토큰으로 무엇을 할 수 있는지 판단
+  - role/permission/org/workspace/tool 권한
+  - resource 내부 접근 통제
 ```
 
-**핵심 구조**: `handler -> service -> storage -> sqlc(storeq)` 조합과 `handler -> pages` 렌더링 분리.
-service가 `user.Status`를 직접 switch하여 상태를 판정한다.
-`clock`과 `idgen`은 service/storage가 사용하는 deterministic test seam이다.
+authgate는 Authentication만 책임진다.
+Authorization은 consuming app, API, MCP server 책임이다.
 
-## 컴포넌트별 책임
+`user.Status`는 authorization이 아니라 **인증 게이트 정책**이다.
 
-### 1. config
+### 3. OAuth 2.0 / OAuth 2.1 / 범위 밖 구분
 
-환경변수를 로드하고 유효성을 검증한다.
-
-| 항목 | 설명 |
-|------|------|
-| **책임** | 환경변수 파싱, 기본값, DEV_MODE 강제, 타입 변환 |
-| **스펙 근거** | [Spec 009](../spec/009-operations.md) 환경변수 표 |
-| **의존** | 없음 (외부 의존 0) |
-| **비고** | 구조체 1개로 전체 설정을 표현. 생성 시 검증 완료. |
-
-### 2. storage
-
-zitadel/oidc의 `op.Storage` + `op.DeviceAuthorizationStorage` 인터페이스를 PostgreSQL로 구현한다.
-
-| 항목 | 설명 |
-|------|------|
-| **책임** | auth_requests, device_codes, tokens, clients, keys CRUD. users/sessions/audit CRUD. |
-| **스펙 근거** | [ADR-001](../adr/001-adopt-zitadel-oidc.md) Storage 인터페이스, [Spec 007](../spec/007-data-model.md) 테이블 구조 |
-| **의존** | `*sql.DB`, `internal/db/storeq` (sqlc 생성 코드) |
-| **인터페이스** | `op.Storage` (필수 22메서드) + `op.DeviceAuthorizationStorage` (2메서드) |
-| **원자성** | 가입(users+identities), 삭제(status+revoke), refresh rotation은 단일 TX |
-
-storage는 비즈니스 상태 판정을 하지 않는다. 다만 예외적으로 refresh grant는 zitadel이 `TokenRequestByRefreshToken`만 호출하므로, storage 내부에서 user 조회 후 `user.Status` 기반 상태 검증을 수행해야 한다.
-
-### 3. handler
-
-zitadel이 소유하지 않는 HTTP 엔드포인트를 처리한다. **얇은 HTTP 바인딩 계층**이다.
-
-| 항목 | 설명 |
-|------|------|
-| **책임** | HTTP 요청/응답 바인딩, 쿠키/세션 처리, service 호출 |
-| **스펙 근거** | [Spec 002](../spec/002-browser-login.md), [003](../spec/003-device-login.md), [004](../spec/004-mcp-login.md), [006](../spec/006-account-lifecycle.md) |
-| **의존** | service |
-| **엔드포인트** | `/login`, `/login/callback`, `/device`, `/device/approve`, `/device/auth/callback`, `/mcp/login`, `/mcp/callback`, `/account`, `/health`, `/ready` |
-
-handler는 **HTTP를 파싱하고 service에 위임**한다. 비즈니스 로직을 직접 수행하지 않는다.
-
-### 4. service
-
-비즈니스 orchestration 계층. handler에서 분리된 핵심 로직을 담당한다.
-
-| 항목 | 설명 |
-|------|------|
-| **책임** | 로그인 조율 (upstream 호출 → user 조회/생성 → user.Status 직접 판정 → 세션/로그인 완료 상태), Device 승인, 계정 삭제, cleanup |
-| **스펙 근거** | Spec 001~006 전체 플로우 |
-| **의존** | storage, upstream, clock |
-| **파일** | `login.go`, `device.go`, `account.go`, `cleanup.go` |
-
-service가 존재하는 이유:
-- handler는 HTTP 바인딩만 담당 → handler 테스트 = HTTP 경로/응답 검증
-- service는 비즈니스 전이 담당 → service 테스트 = 실DB + fixed clock으로 상태 전이 검증
-- handler에 로직이 몰리면 HTTP 테스트가 너무 무거워진다
-
-service는 **HTML을 직접 렌더링하지 않는다.**
-service는 `ActionAutoApprove`, `DeviceShowApprove` 같은 결과를 반환하고,
-handler가 이를 해석해 pages 템플릿을 렌더링하거나 redirect를 수행한다.
-
-### 5. upstream
-
-외부 IdP에 대한 프록시를 구현한다. OIDC Discovery를 통해 엔드포인트를 자동으로 탐지한다.
-
-| 항목 | 설명 |
-|------|------|
-| **책임** | authorization URL 생성, authorization code → token 교환, userinfo 조회 |
-| **스펙 근거** | [ADR-000](../adr/000-authgate-identity.md) IdP 정책, [Spec 002](../spec/002-browser-login.md) 4~5단계 |
-| **의존** | config (OIDC credentials), HTTP client |
-| **인터페이스** | `Provider` (3메서드: `Name`, `AuthURL`, `Exchange`) |
-| **구현체** | `OIDCProvider` (OIDC Discovery 기반, zitadel/oidc v3 사용) |
-
-upstream은 **authgate의 유저/세션을 모른다.** code를 교환하고 userinfo를 반환할 뿐이다.
-service가 userinfo를 받아 storage에서 유저를 조회/생성한다.
-
-### 6. pages
-
-HTML 템플릿을 렌더링한다.
-
-| 항목 | 설명 |
-|------|------|
-| **책임** | 디바이스 코드 입력, 디바이스 승인, 결과 페이지 렌더링 |
-| **스펙 근거** | [Spec 008](../spec/008-pages.md) 페이지 목록 |
-| **의존** | 없음 (Go html/template) |
-| **원칙** | CSS 인라인, 외부 의존성 없음, 반응형, 시맨틱 HTML |
-
-### 7. clock
-
-시간 소스를 추상화한다. **mock이 아니라 deterministic test seam**이다.
-
-| 항목 | 설명 |
-|------|------|
-| **책임** | 현재 시각 제공 |
-| **인터페이스** | `Clock` (1메서드: `Now() time.Time`) |
-| **구현체** | `RealClock` (프로덕션: `time.Now()`), `FixedClock` (테스트: 고정/진행 가능 시각) |
-| **의존** | 없음 |
-| **사용처** | service (cleanup 판정), storage (expires_at 비교, TTL 계산) |
-
-시간 의존이 많은 로직: auth_request/device_code 만료, refresh_token TTL, deletion_scheduled_at. `time.Now()` 직접 호출 대신 `clock.Now()`를 사용하면 테스트에서 시간을 제어할 수 있다.
-
-### 8. idgen
-
-ID와 토큰을 생성한다. 테스트에서 **예측 가능한 값**을 만들기 위한 seam이다.
-
-| 항목 | 설명 |
-|------|------|
-| **책임** | UUID, opaque token 생성. device_code/user_code는 zitadel이 자체 생성하므로 idgen 범위 밖. |
-| **인터페이스** | `IDGenerator` (메서드: `NewUUID`, `NewOpaqueToken`) |
-| **구현체** | `CryptoGenerator` (프로덕션: crypto/rand), `SequentialGenerator` (테스트: 예측 가능한 순차 값) |
-| **의존** | 없음 |
-| **사용처** | storage (token_id, refresh_token 생성) |
-
-프로덕션에서는 128bit+ 엔트로피를 보장하고, 테스트에서는 `token-1`, `token-2` 같은 순차 값으로 assertion을 쉽게 한다.
-
-## 의존 방향
+이 문서에서는 표준 프로파일을 다음처럼 구분한다.
 
 ```text
-main → handler → service     (비즈니스 위임)
-main → handler → pages       (HTTP 응답 렌더링)
+OAuth 2.0
+  - 전체 기반 프로토콜 계층
+  - token, revocation, refresh, device grant의 기반
 
-service → storage            (DB 읽기/쓰기)
-       → upstream            (IdP 교환)
-       → clock               (현재 시각)
+OAuth 2.1 스타일
+  - Authorization Code + PKCE 중심
+  - 브라우저와 MCP 채널에 적용되는 권장 프로파일
 
-storage → clock             (TTL/만료 계산)
-       → idgen              (ID/토큰 생성)
-       → internal/db/storeq (sqlc query layer)
-
-zitadel OP → storage        (op.Storage 인터페이스 호출)
-
-config ← main               (시작 시 1회 로드)
-       ← storage            (DB URL)
-       ← upstream           (OIDC credentials)
-       ← handler            (TTL 등)
+범위 밖
+  - 현재 authgate의 코어 계약에 포함하지 않는 grant/endpoint/확장
 ```
 
-**순환 의존 없음.** 모든 의존이 단방향이다.
+#### 현재 authgate에 포함되는 것
 
-핵심 규칙:
-- `clock`, `idgen`은 외부 의존 없다 (인터페이스만 정의)
-- `upstream`은 `storage`를 모른다
-- `handler`는 HTTP 바인딩만 — 비즈니스 로직은 `service`
-- `handler`가 HTML 렌더링을 담당하고 `pages`를 직접 호출한다
-- `service`만 여러 컴포넌트를 조합하며, `user.Status`를 직접 switch하여 채널 접근을 판정한다
+| 분류 | 포함 항목 |
+|------|-----------|
+| OAuth 2.0 기반 | authorization endpoint, token endpoint, refresh token rotation, revocation, device authorization grant |
+| OAuth 2.1 스타일 | Authorization Code + PKCE(S256) 중심 브라우저/MCP 로그인 프로파일, implicit/password 미사용 |
+| OIDC | discovery, JWKS, id_token, userinfo |
 
-## Go 패키지 매핑
+#### 현재 authgate에서 별도 구분해야 하는 것
+
+| 항목 | 설명 |
+|------|------|
+| Device Flow | RFC 8628 기반이며 OAuth 2.1의 브라우저 code flow와는 별도 채널 |
+| MCP | OAuth 2.1 스타일 code + PKCE를 사용하지만, CIMD/resource 정책이 추가된 확장 채널 |
+
+#### 현재 코어 계약에 포함하지 않는 것
+
+아래 항목은 현재 authgate의 코어 구조에서 지원 대상으로 보지 않는다.
 
 ```text
-authgate/
-├── cmd/
-│   └── authgate/
-│       └── main.go              # 진입점, 조립, 서버 시작
-├── internal/
-│   ├── config/
-│   │   └── config.go            # 환경변수 → Config 구조체
-│   ├── db/
-│   │   ├── queries/             # handwritten SQL source (*.sql)
-│   │   └── storeq/              # sqlc generated Go code
-│   ├── storage/
-│   │   ├── storage.go           # op.Storage 조립/상태검증 진입점
-│   │   ├── storage_auth_tokens.go
-│   │   ├── storage_oidc_device.go
-│   │   ├── users.go             # user/session/account lifecycle
-│   │   ├── cleanup_runner.go    # cleanup sqlc runner
-│   │   ├── audit.go             # audit_log 기록
-│   │   ├── dberr.go             # DB error mapping
-│   │   ├── mappers.go           # nullable/type mapper
-│   │   └── clients.go / keys.go / cimd.go / bcrypt.go / models.go / pgarray.go
-│   ├── service/
-│   │   ├── login.go             # 로그인 orchestration (가입 포함)
-│   │   ├── device.go            # Device 승인 orchestration
-│   │   ├── account.go           # 계정 삭제/복구
-│   │   └── cleanup.go           # 2종 cleanup (deletion/token)
-│   ├── handler/
-│   │   ├── login.go             # /login, /login/callback
-│   │   ├── device.go            # /device, /device/approve, /device/auth/callback
-│   │   └── account.go           # DELETE /account
-│   │   # /health, /ready → cmd/authgate/main.go에 인라인
-│   ├── upstream/
-│   │   ├── provider.go          # Provider 인터페이스
-│   │   └── oidc.go              # OIDC Discovery 기반 범용 Provider
-│   ├── pages/
-│   │   ├── renderer.go          # 템플릿 로드 + 렌더 함수
-│   │   └── templates/           # HTML 파일
-│   │       ├── device_entry.html
-│   │       ├── device_approve.html
-│   │       └── result.html
-│   ├── clock/
-│   │   └── clock.go             # Clock 인터페이스 + RealClock
-│   └── idgen/
-│       └── idgen.go             # IDGenerator 인터페이스 + CryptoGenerator
-└── migrations/
-    └── 001_init.sql             # Spec 007 스키마
+grant type
+  - implicit
+  - resource owner password credentials
+  - client credentials
+
+dynamic client model
+  - DCR (dynamic client registration)
+  - PAR (pushed authorization requests)
+
+introspection / resource-server authz
+  - token introspection endpoint 기반 권한 판정
+  - resource-level authorization policy
 ```
 
-## 데이터 흐름 예시: 브라우저 로그인
+즉 authgate의 현재 표준 프로파일은 다음처럼 요약된다.
 
 ```text
-1. [zitadel] /authorize → storage.CreateAuthRequest(userID="")
-2. [zitadel] → redirect /login?authRequestID=xxx
-3. [handler] /login → service.HandleLogin()
-4. [service] → storage.GetSession() → user.Status 확인
-5. [service] 세션 없음 → upstream.AuthURL() → redirect IdP
-6. [handler] /login/callback → service.HandleCallback()
-7. [service] → upstream.Exchange() → userinfo
-8. [service] → storage.GetUserByProviderIdentity()
-9. [service] → user.Status switch (상태 검사)
-10. [service] → 상태 결과에 따라:
-      active → storage.CreateSession() → auth_request에 subject 연결 + 완료 상태 반영
-      pending_deletion(browser) → storage.RecoverUser() (TX) → CreateSession
-      disabled/deleted → 403
-11. [zitadel] /oauth/token → storage.AuthRequestByCode() → subject 기준 최종 상태 재검사 → JWT 발급
+core standard profile
+  = OAuth 2.0 + OIDC 기반
+  = browser/mcp에는 OAuth 2.1 스타일 code + PKCE 적용
+  = device는 RFC 8628 extension
+  = 권한 시스템/추가 grant 확장은 범위 밖
 ```
 
-## 실제 라이브러리 경계 주의
+## 공통 코어
+
+### 코어가 공유하는 것
+
+아래 요소는 Browser / Device / MCP가 공통으로 공유하는 인증 코어다.
 
 ```text
-/oauth/token (code)
-  -> zitadel이 AuthRequestByCode(code)에서 subject를 읽어 토큰을 만든다.
-  -> service는 auth code를 직접 발급하지 않는다.
-  -> authgate는 storage.AuthRequestByCode 안에서 subject -> user를 재조회해
-     `user.Status = active`인지 마지막으로 확인한다.
-  -> 따라서 code 발급 후 pending_deletion / disabled / deleted로 바뀌면
-     최종 응답은 invalid_grant다.
-
-/oauth/token (refresh)
-  -> zitadel은 TokenRequestByRefreshToken(refreshToken)만 호출한다.
-  -> 따라서 refresh 차단 정책은 storage 내부에서 user 상태를 직접 검증해야 한다.
-
-Device approve
-  -> authgate가 user_code에 대응하는 DeviceAuthorizationState.Subject를 채우고 Done=true로 만든다.
-  -> 이후 polling/token issuance는 zitadel이 처리한다.
+Identity / Token Core
+  - users / user_identities
+  - sessions
+  - refresh_tokens
+  - auth_requests
+  - device_codes
+  - signing keys / JWKS
+  - zitadel provider wiring
+  - upstream OIDC exchange
+  - account status policy
+  - token issue / refresh / revoke
+  - audit log
 ```
+
+즉, authgate의 코어는 다음과 같이 정의한다.
+
+```text
+코어 = op.Storage 구현(토큰/인증 데이터) + 채널중립 인프라
+```
+
+코어 storage는 특정 채널의 URL/화면 흐름을 모른다.
+채널별 로그인 흐름(browser/device/mcp)은 어댑터가 소유한다.
+built-in adapter의 서비스 로직은 물리적으로 `internal/service` 패키지에 둘 수 있다.
+
+### 코어/어댑터 책임 분할
+
+| 영역 | 코어(storage/infra) | 채널 어댑터(service/handler) |
+|------|----------------------|-------------------------------|
+| 토큰 | 발급/갱신/폐기, refresh rotation | 채널별 토큰 진입 경로 연결 |
+| 데이터 | users/sessions/refresh/auth_requests/device/audit 저장/조회 | 채널 입력 파싱, UX 흐름 |
+| 서명/메타 | JWKS, discovery, 기본 AS metadata | 채널별 metadata 확장(MCP 등) |
+| 로그인 | 채널중립 검증 훅/정책 seam | upstream IdP redirect/callback 오케스트레이션 |
+| 세션 | session 저장/검증 primitive | 쿠키 발급/사용, 세션 경로 제어 |
+| 가입/복구 | 데이터 업데이트 primitive | browser 채널에서 가입/복구 정책 적용 |
+| 상태 정책 | 공통 정책 함수/검증 훅 | 채널별 allow/recover/deny 적용 |
+| 운영 | cleanup, key loading, audit storage | 채널 액션에 대한 audit 이벤트 트리거 |
+
+### 코어가 책임지지 않는 것
+
+| 영역 | 항목 |
+|------|------|
+| 인가 | role, admin 여부, 조직/워크스페이스 권한 |
+| 리소스 정책 | 특정 API/tool/resource 접근 허용 여부 |
+| 앱 정책 | 약관, 결제 상태, 기능 플래그, 조직 정책 |
+
+## 채널 어댑터
+
+채널 어댑터는 코어를 사용해 특정 채널의 진입점과 UX를 제공한다.
+
+```text
+코어
+  = 로그인 성공 후 무엇을 저장하고 어떤 토큰을 발급하는가
+
+어댑터
+  = 사용자가 어떤 채널로 들어와서 코어를 호출하는가
+```
+
+채널 어댑터는 두 종류로 나눈다.
+
+```text
+built-in adapter
+  - 제품의 기본 채널
+  - 항상 함께 배포되는 채널
+
+optional adapter
+  - 선택적으로 붙는 확장 채널
+```
+
+### Browser built-in adapter
+
+```text
+책임
+  - /login
+  - /login/callback
+  - signup 허용
+  - pending_deletion recover 허용
+```
+
+### Device built-in adapter
+
+```text
+책임
+  - /device
+  - /device/approve
+  - /device/auth/callback
+  - 디바이스 승인 UI
+  - approve / deny orchestration
+```
+
+### MCP optional adapter
+
+```text
+책임
+  - /mcp/login
+  - /mcp/callback
+  - CIMD
+  - resource binding
+  - MCP 전용 metadata 확장
+```
+
+즉 Browser도 Device도 코어 그 자체가 아니라 채널 어댑터다.
+다만 Browser와 Device는 기본 제공 채널이므로 built-in adapter로 본다.
+MCP는 코어 위에 붙는 선택적 확장 채널이므로 optional adapter로 본다.
+
+## 엔드포인트 소유 규칙
+
+엔드포인트는 다음 원칙으로 나눈다.
+
+```text
+표준 프로토콜 path = core
+채널 진입/복귀 path = 각 adapter
+```
+
+### Core 엔드포인트
+
+```text
+/.well-known/openid-configuration
+/.well-known/oauth-authorization-server
+/authorize
+/oauth/token
+/oauth/revoke
+/oauth/device/authorize
+/keys
+/userinfo
+/end_session
+```
+
+### Adapter 엔드포인트
+
+```text
+Browser built-in adapter
+  /login
+  /login/callback
+
+Device built-in adapter
+  /device
+  /device/approve
+  /device/auth/callback
+
+MCP optional adapter
+  /mcp/login
+  /mcp/callback
+```
+
+즉 경로가 다르더라도, 각 어댑터는 결국 같은 코어를 호출한다.
+
+## 목표 구조
+
+```text
+                           +----------------------+
+                           |   zitadel/oidc OP    |
+                           | protocol engine      |
+                           +----------+-----------+
+                                      |
+                                      v
+┌──────────────────────────────────────────────────────────────┐
+│                      authgate core                          │
+│--------------------------------------------------------------│
+│ users / sessions / tokens / auth_requests / device_codes     │
+│ upstream OIDC / JWKS / refresh / revoke / account policy     │
+└───────────────┬──────────────────────┬───────────────────────┘
+                │                      │
+                v                      v
+       ┌────────────────┐     ┌────────────────┐
+       │ Browser        │     │ Device         │
+       │ built-in       │     │ built-in       │
+       │ adapter        │     │ adapter        │
+       └────────┬───────┘     └────────┬───────┘
+                │                      │
+                └──────────┬───────────┘
+                           v
+                  ┌────────────────────┐
+                  │ MCP optional       │
+                  │ adapter            │
+                  └────────────────────┘
+```
+
+## 패키지 구조 목표
+
+```text
+cmd/authgate/
+  main.go
+
+internal/
+  config/                   # 환경변수/설정 로딩
+
+  service/                  # 채널별 비즈니스 로직 (built-in adapter 포함)
+    access.go
+    login.go
+    device.go
+    account.go
+    cleanup.go
+
+  handler/                  # HTTP 변환 (built-in adapter 포함)
+    browser_login.go
+    device.go
+    account.go
+
+  storage/                  # op.Storage 구현 (코어)
+    storage.go
+    auth_requests.go
+    refresh_tokens.go
+    device_codes.go
+    users.go
+    clients.go
+    keys.go
+    cleanup_runner.go
+
+  db/                       # DB 접근 계층
+    storeq/                 # sqlc 생성 코드
+    queries/                # SQL 원본
+
+  adapter/                  # optional adapter
+    mcp/
+      module.go
+      handler.go
+      service.go
+      cimd.go
+      policy.go
+      metadata.go
+
+  upstream/                 # 외부 IdP 연동
+  pages/                    # HTML 템플릿 렌더링
+    templates/
+  clock/                    # 시간 추상화
+  idgen/                    # ID/토큰 생성
+
+  integration/              # 통합 테스트 (test only)
+  testutil/                 # 테스트 헬퍼 (test only)
+
+migrations/                 # DB 마이그레이션 SQL
+```
+
+구조 의도:
+
+```text
+storage
+  - 공통 persistence
+  - MCP 정책/검증을 몰라야 한다
+  - 범용 필드(resource 등) 저장은 허용된다
+
+service
+  - flat 패키지 유지
+  - 공통 인증 유스케이스 유지
+  - browser/device는 built-in adapter가 호출
+  - mcp는 optional adapter가 호출
+
+adapter/mcp
+  - MCP에서만 의미가 있는 흐름과 정책
+```
+
+## 데이터 흐름 예시
+
+### Browser built-in adapter
+
+```text
+App -> /authorize
+    -> /login
+    -> /login/callback
+    -> /authorize/callback
+    -> /oauth/token
+```
+
+### Device built-in adapter
+
+```text
+CLI  -> /oauth/device/authorize
+User -> /device
+     -> /device/auth/callback
+     -> /device/approve
+CLI  -> /oauth/token
+```
+
+### MCP optional adapter
+
+```text
+Tool -> /authorize
+     -> /mcp/login
+     -> /mcp/callback
+     -> /authorize/callback
+     -> /oauth/token
+```
+
+세 채널 모두 결국 같은 코어의 저장소, 상태 정책, 토큰 발급 엔진을 공유한다.
+
 ## 테스트 전략
 
 | 레벨 | 대상 | 의존성 | mock |
 |------|------|--------|------|
 | **unit** | clock, idgen | 없음 | 없음 |
-| **unit** | service(login/device/account) | fake store + fake provider | DB 없음 |
-| **integration** | storage | 실 PostgreSQL (ephemeral) | 없음 |
-| **integration** | service | 실 PostgreSQL + FixedClock + fake OIDCProvider | upstream만 fake |
-| **e2e** | handler + zitadel OP | 실 PostgreSQL + fake IdP server | 외부 IdP만 fake |
+| **unit** | service(access/login/device/account) | fake store + fake provider | DB 없음 |
+| **integration** | storage | 실 PostgreSQL | 없음 |
+| **integration** | service + OP | 실 PostgreSQL + fake IdP | upstream만 fake |
 
 mock 최소화 원칙:
-- repository mock 없음 — storage는 항상 실 DB
-- HTTP client mock 없음 — upstream은 fake IdP 서버로 대체
-- 시간/랜덤만 deterministic seam으로 제어
 
-## 스펙 ↔ 컴포넌트 매핑
+```text
+repository mock 없음
+storage는 가능하면 실 DB
+시간/랜덤만 deterministic seam으로 제어
+```
+
+## 스펙 매핑
 
 | 스펙 | 주요 컴포넌트 |
 |------|-------------|
-| Spec 001 (가입) | handler/login + service/login + storage/users + upstream |
-| Spec 002 (브라우저 로그인) | handler/login + service/login + upstream |
-| Spec 003 (Device 로그인) | handler/device + service/device + storage/device + pages |
-| Spec 004 (MCP Authorization) | handler/login + service/login |
-| Spec 005 (토큰 Lifecycle) | storage/tokens + clock |
-| Spec 006 (계정 Lifecycle) | handler/account + service/account + service/cleanup + storage/users |
+| Spec 001 (가입) | browser built-in adapter + storage/users + upstream |
+| Spec 002 (브라우저 로그인) | browser built-in adapter + storage + upstream |
+| Spec 003 (Device 로그인) | device built-in adapter + storage/device + pages |
+| Spec 004 (MCP Authorization) | mcp optional adapter + storage/op.Storage seam |
+| Spec 005 (토큰 Lifecycle) | storage(op.Storage) + clock |
+| Spec 006 (계정 Lifecycle) | account built-in adapter + cleanup + storage/users |
 | Spec 007 (데이터 모델) | storage/* + migrations/ |
 | Spec 008 (페이지) | pages/* |
-| Spec 009 (운영) | config + storage/keys + service/cleanup |
+| Spec 009 (운영) | config + storage/keys + cleanup |

--- a/docs/architecture/002-mcp-separation-plan.md
+++ b/docs/architecture/002-mcp-separation-plan.md
@@ -1,0 +1,145 @@
+# Architecture 002: MCP 분리 리팩터링 계획
+
+> 이 문서는 [001-component-boundaries.md](001-component-boundaries.md)의 목표 구조를 달성하기 위한 실행 계획이다.
+> 리팩터링 완료 후 archive 또는 삭제한다.
+
+## 현재 구현과의 차이
+
+현재 코드는 기능적으로 동작하지만, 코어와 MCP 확장이 몇 군데에서 섞여 있다.
+
+```text
+cmd/authgate/main.go
+  - core 조립
+  - mcp 조립
+  - metadata 응답
+  - resource context 주입
+
+internal/service/login.go
+  - browser / mcp 공용 서비스 + channel 분기
+
+internal/handler/login.go
+  - /login, /mcp/login, /login/callback, /mcp/callback 혼합
+
+internal/storage/storage_auth_tokens.go
+  - 공통 auth/token 로직 + MCP resource 정책 결합
+
+internal/storage/cimd.go
+  - storage 패키지 안에 MCP 전용 client discovery 포함
+```
+
+이 결합 때문에 "코어"와 "채널 어댑터"의 경계가 문서와 코드 모두에서 흐려진다.
+
+## 공통부를 기준으로 본 이동 계획
+
+### 코어에 남길 것
+
+```text
+internal/service/access.go
+internal/service/device.go
+internal/service/account.go
+internal/storage/storage.go
+internal/storage/users.go
+internal/storage/storage_oidc_device.go
+internal/storage/clients.go
+internal/storage/cleanup_runner.go
+internal/upstream/*
+```
+
+### built-in / optional adapter 경계로 분리해야 하는 것
+
+```text
+internal/service/login.go
+  -> browser built-in adapter용 흐름
+  -> mcp optional adapter용 흐름 분리
+
+internal/handler/login.go
+  -> browser built-in adapter handler
+  -> mcp optional adapter handler
+
+internal/storage/cimd.go
+  -> mcp optional adapter
+
+internal/storage/storage_auth_tokens.go
+  -> 공통 token/storage
+  -> resource/client 정책 seam 도입 (Phase 1에서 실행, 아래 "op.Storage 분리 전략" 참조)
+
+cmd/authgate/main.go
+  -> core wiring
+  -> built-in adapter wiring
+  -> optional mcp wiring
+```
+
+## op.Storage 분리 전략 (필수 선행조건)
+
+zitadel OP는 authgate의 service/handler가 아니라 `op.Storage`를 직접 호출한다.
+따라서 MCP 정책 분리는 storage 경계에서 먼저 seam을 만들어야 한다.
+
+```text
+zitadel OP engine
+  -> Storage.GetClientByClientID()
+  -> Storage.AuthRequestByCode()
+  -> Storage.TokenRequestByRefreshToken()
+```
+
+현재 MCP 결합이 들어 있는 핵심 지점:
+
+```text
+- CIMD fallback (GetClientByClientID)
+- resource 일치/필수 검증 (AuthRequestByCode, TokenRequestByRefreshToken)
+```
+
+### 선택지
+
+```text
+방법 A: storage decorator/wrapper
+  mcpStorage wraps coreStorage
+  zitadel에는 wrapper를 주입
+
+방법 B: policy 주입 (권장 기본안)
+  coreStorage는 policy 인터페이스를 호출만 함
+  MCP adapter가 policy 구현을 주입
+```
+
+권장안은 B를 기본으로 하고, 필요 시 A를 보완적으로 사용한다.
+
+```text
+권장 기본안
+  - core storage는 MCP를 직접 모른다
+  - client/resource 정책은 interface로 호출
+  - MCP adapter가 구현을 제공
+```
+
+예시 seam:
+
+```text
+type ClientResolutionPolicy interface {
+  ResolveClient(ctx, clientID) (ClientProfile, error)
+}
+
+type ResourceBindingPolicy interface {
+  ValidateAuthorizeRequest(ctx, clientID, resource string) error
+  ValidateTokenRequest(ctx, clientID, storedResource, requestResource string) error
+}
+```
+
+이 seam이 생겨야 `CIMD/resource를 adapter/mcp로 이동`하는 Phase가 실행 가능해진다.
+
+## 단계별 리팩터링 순서
+
+```text
+Phase 1
+  - op.Storage seam 도입 (client/resource policy 추상화)
+  - storage에서 MCP 로직을 분리할 수 있는 경계 확보
+
+Phase 2
+  - CIMD와 resource 정책을 MCP 어댑터 패키지로 이동
+  - core storage에서 MCP 전용 책임 제거/축소
+
+Phase 3
+  - browser built-in adapter 와 mcp optional adapter 흐름 분리
+  - /login 과 /mcp route/handler 분리
+
+Phase 4
+  - main 조립을 core + built-in adapters + optional mcp 형태로 변경
+  - 문서와 코드의 패키지 매핑을 목표 구조 기준으로 갱신
+```

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,3 +10,4 @@ authgate의 내부 구조, 컴포넌트 경계, 의존 관계를 정의한다.
 | # | 문서 | 목적 |
 |---|------|------|
 | 001 | [컴포넌트 경계](001-component-boundaries.md) | authgate 내부 컴포넌트의 책임, 의존 방향, Go 패키지 매핑 |
+| 002 | [MCP 분리 계획](002-mcp-separation-plan.md) | MCP를 optional adapter로 분리하는 리팩터링 실행 계획 (완료 후 삭제) |

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -4,6 +4,7 @@
 
 authgate가 제공하는 전체 서비스 경험을 정의한다.
 설계 원칙은 [ADR-000](../adr/000-authgate-identity.md), 기술 선택은 [ADR-001](../adr/001-adopt-zitadel-oidc.md)을 따른다.
+구조와 경계 원칙은 [Architecture 001](../architecture/001-component-boundaries.md)을 참조한다.
 
 ## 목차
 


### PR DESCRIPTION
## Summary
- rewrite Architecture 001 to clarify core vs adapter boundaries (Browser/Device built-in, MCP optional)
- explicitly separate Authentication vs Authorization responsibilities
- document OAuth 2.0 baseline, OAuth 2.1-style profile usage, and out-of-scope areas
- add Architecture 002 as a temporary MCP separation execution plan with storage seam strategy and phase ordering
- update docs indexes to link architecture references

## Why
- avoid MCP concerns leaking into browser/device baseline flows
- make refactoring sequence executable (storage seam first)
- reduce ambiguity about endpoint ownership and channel responsibilities

## Notes
- document-only changes (no runtime behavior change)
