### PR TITLE
refactor(storage): introduce policy seam for client/resource validation

### DIFF
--- a/internal/storage/clients.go
+++ b/internal/storage/clients.go
@@ -154,6 +154,7 @@ func (s *Storage) SetResourceBindingPolicy(policy ResourceBindingPolicy) {
 }
 
 func (s *Storage) resolveClient(ctx context.Context, clientID string) (*ClientModel, error) {
+	// Safety net for tests constructing Storage without New().
 	if s.clientPolicy == nil {
 		s.clientPolicy = defaultClientResolutionPolicy{s: s}
 	}

--- a/internal/storage/clients.go
+++ b/internal/storage/clients.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -132,4 +133,29 @@ func (s *Storage) LoadClients(clients []ClientConfigEntry) {
 // SetCIMDFetcher sets the CIMD fetcher for URL-based client_id resolution.
 func (s *Storage) SetCIMDFetcher(f CIMDFetcher) {
 	s.cimdFetcher = f
+}
+
+// SetClientResolutionPolicy overrides client resolution behavior for op.Storage lookups.
+func (s *Storage) SetClientResolutionPolicy(policy ClientResolutionPolicy) {
+	if policy == nil {
+		s.clientPolicy = defaultClientResolutionPolicy{s: s}
+		return
+	}
+	s.clientPolicy = policy
+}
+
+// SetResourceBindingPolicy overrides resource binding validation for authorize/token flows.
+func (s *Storage) SetResourceBindingPolicy(policy ResourceBindingPolicy) {
+	if policy == nil {
+		s.resourcePolicy = defaultResourceBindingPolicy{}
+		return
+	}
+	s.resourcePolicy = policy
+}
+
+func (s *Storage) resolveClient(ctx context.Context, clientID string) (*ClientModel, error) {
+	if s.clientPolicy == nil {
+		s.clientPolicy = defaultClientResolutionPolicy{s: s}
+	}
+	return s.clientPolicy.ResolveClient(ctx, clientID)
 }

--- a/internal/storage/policy.go
+++ b/internal/storage/policy.go
@@ -1,0 +1,47 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+)
+
+type defaultClientResolutionPolicy struct {
+	s *Storage
+}
+
+func (p defaultClientResolutionPolicy) ResolveClient(ctx context.Context, clientID string) (*ClientModel, error) {
+	if v, ok := p.s.clients.Load(clientID); ok {
+		return v.(*ClientModel), nil
+	}
+	if p.s.cimdFetcher != nil && isCIMDClientID(clientID) {
+		return p.s.cimdFetcher.FetchClient(ctx, clientID)
+	}
+	return nil, ErrNotFound
+}
+
+type defaultResourceBindingPolicy struct{}
+
+func (defaultResourceBindingPolicy) ValidateAuthorizeRequest(ctx context.Context, client *ClientModel, requestResource string) error {
+	if requestResource == "" && client != nil && client.LoginChannel == "mcp" {
+		return &oidc.Error{ErrorType: "invalid_target", Description: "missing resource"}
+	}
+	return nil
+}
+
+func (defaultResourceBindingPolicy) ValidateTokenRequest(ctx context.Context, clientID, storedResource, requestResource string) error {
+	if storedResource != "" {
+		if requestResource == "" {
+			return &oidc.Error{ErrorType: "invalid_target", Description: "missing resource"}
+		}
+		if requestResource != storedResource {
+			return &oidc.Error{ErrorType: "invalid_target", Description: "resource mismatch"}
+		}
+		return nil
+	}
+	if requestResource != "" {
+		return &oidc.Error{ErrorType: "invalid_target", Description: "unexpected resource"}
+	}
+	return nil
+}
+

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"crypto/rsa"
 	"crypto/sha256"
 	"database/sql"
@@ -23,6 +24,19 @@ var (
 // Injected from main.go — storage never imports service or guard packages.
 type StateChecker func(user *User) error
 
+// ClientResolutionPolicy resolves a client profile for client_id.
+// It is invoked by storage methods that zitadel calls directly.
+type ClientResolutionPolicy interface {
+	ResolveClient(ctx context.Context, clientID string) (*ClientModel, error)
+}
+
+// ResourceBindingPolicy validates resource binding across authorize/token flows.
+// Default policy preserves current behavior for browser/mcp resource checks.
+type ResourceBindingPolicy interface {
+	ValidateAuthorizeRequest(ctx context.Context, client *ClientModel, requestResource string) error
+	ValidateTokenRequest(ctx context.Context, clientID, storedResource, requestResource string) error
+}
+
 type Storage struct {
 	db              *sql.DB
 	clock           clock.Clock
@@ -36,10 +50,12 @@ type Storage struct {
 	refreshTokenTTL time.Duration
 	clients         sync.Map // map[string]*ClientModel (client_id → client)
 	cimdFetcher     CIMDFetcher
+	clientPolicy    ClientResolutionPolicy
+	resourcePolicy  ResourceBindingPolicy
 }
 
 func New(db *sql.DB, clk clock.Clock, gen idgen.IDGenerator, checker StateChecker, accessTTL, refreshTTL time.Duration) *Storage {
-	return &Storage{
+	s := &Storage{
 		db:              db,
 		clock:           clk,
 		idgen:           gen,
@@ -47,6 +63,9 @@ func New(db *sql.DB, clk clock.Clock, gen idgen.IDGenerator, checker StateChecke
 		accessTokenTTL:  accessTTL,
 		refreshTokenTTL: refreshTTL,
 	}
+	s.clientPolicy = defaultClientResolutionPolicy{s: s}
+	s.resourcePolicy = defaultResourceBindingPolicy{}
+	return s
 }
 
 // SetSigningKey sets the current RSA signing key used for JWT issuance.

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -16,10 +16,12 @@ import (
 
 func (s *Storage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest, userID string) (op.AuthRequest, error) {
 	resource := ResourceFromContext(ctx)
-	client, err := s.resolveClient(ctx, req.ClientID)
-	if err == nil && s.resourcePolicy != nil {
-		if err := s.resourcePolicy.ValidateAuthorizeRequest(ctx, client, resource); err != nil {
-			return nil, err
+	if resource == "" {
+		client, err := s.resolveClient(ctx, req.ClientID)
+		if err == nil {
+			if err := s.resourcePolicy.ValidateAuthorizeRequest(ctx, client, resource); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -37,7 +39,7 @@ func (s *Storage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest, 
 		CreatedAt:           s.clock.Now(),
 	}
 
-	err = storeq.New(s.db).InsertAuthRequest(ctx, storeq.InsertAuthRequestParams{
+	err := storeq.New(s.db).InsertAuthRequest(ctx, storeq.InsertAuthRequestParams{
 		ID:                  ar.ID,
 		ClientID:            ar.ClientID,
 		Resource:            sql.NullString{String: ar.Resource, Valid: true},
@@ -81,10 +83,8 @@ func (s *Storage) AuthRequestByCode(ctx context.Context, code string) (op.AuthRe
 		return nil, &oidc.Error{ErrorType: "invalid_grant", Description: "authorization code expired"}
 	}
 	requestResource := ResourceFromContext(ctx)
-	if s.resourcePolicy != nil {
-		if err := s.resourcePolicy.ValidateTokenRequest(ctx, ar.ClientID, ar.Resource, requestResource); err != nil {
-			return nil, err
-		}
+	if err := s.resourcePolicy.ValidateTokenRequest(ctx, ar.ClientID, ar.Resource, requestResource); err != nil {
+		return nil, err
 	}
 	if s.stateChecker != nil && ar.Subject != nil && *ar.Subject != "" {
 		user, err := s.GetUserByID(ctx, *ar.Subject)
@@ -253,11 +253,9 @@ func (s *Storage) TokenRequestByRefreshToken(ctx context.Context, refreshToken s
 		return nil, op.ErrInvalidRefreshToken
 	}
 	requestResource := ResourceFromContext(ctx)
-	if s.resourcePolicy != nil {
-		if err := s.resourcePolicy.ValidateTokenRequest(ctx, rt.ClientID, rt.Resource, requestResource); err != nil {
-			tx.Commit()
-			return nil, err
-		}
+	if err := s.resourcePolicy.ValidateTokenRequest(ctx, rt.ClientID, rt.Resource, requestResource); err != nil {
+		tx.Commit()
+		return nil, err
 	}
 
 	// State check (DeriveLoginState via injected function)

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -16,12 +16,10 @@ import (
 
 func (s *Storage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest, userID string) (op.AuthRequest, error) {
 	resource := ResourceFromContext(ctx)
-	if resource == "" {
-		client, err := s.GetClientByClientID(ctx, req.ClientID)
-		if err == nil {
-			if cm, ok := client.(*ClientModel); ok && cm.LoginChannel == "mcp" {
-				return nil, &oidc.Error{ErrorType: "invalid_target", Description: "missing resource"}
-			}
+	client, err := s.resolveClient(ctx, req.ClientID)
+	if err == nil && s.resourcePolicy != nil {
+		if err := s.resourcePolicy.ValidateAuthorizeRequest(ctx, client, resource); err != nil {
+			return nil, err
 		}
 	}
 
@@ -39,7 +37,7 @@ func (s *Storage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest, 
 		CreatedAt:           s.clock.Now(),
 	}
 
-	err := storeq.New(s.db).InsertAuthRequest(ctx, storeq.InsertAuthRequestParams{
+	err = storeq.New(s.db).InsertAuthRequest(ctx, storeq.InsertAuthRequestParams{
 		ID:                  ar.ID,
 		ClientID:            ar.ClientID,
 		Resource:            sql.NullString{String: ar.Resource, Valid: true},
@@ -83,15 +81,10 @@ func (s *Storage) AuthRequestByCode(ctx context.Context, code string) (op.AuthRe
 		return nil, &oidc.Error{ErrorType: "invalid_grant", Description: "authorization code expired"}
 	}
 	requestResource := ResourceFromContext(ctx)
-	if ar.Resource != "" {
-		if requestResource == "" {
-			return nil, &oidc.Error{ErrorType: "invalid_target", Description: "missing resource"}
+	if s.resourcePolicy != nil {
+		if err := s.resourcePolicy.ValidateTokenRequest(ctx, ar.ClientID, ar.Resource, requestResource); err != nil {
+			return nil, err
 		}
-		if requestResource != ar.Resource {
-			return nil, &oidc.Error{ErrorType: "invalid_target", Description: "resource mismatch"}
-		}
-	} else if requestResource != "" {
-		return nil, &oidc.Error{ErrorType: "invalid_target", Description: "unexpected resource"}
 	}
 	if s.stateChecker != nil && ar.Subject != nil && *ar.Subject != "" {
 		user, err := s.GetUserByID(ctx, *ar.Subject)
@@ -260,18 +253,11 @@ func (s *Storage) TokenRequestByRefreshToken(ctx context.Context, refreshToken s
 		return nil, op.ErrInvalidRefreshToken
 	}
 	requestResource := ResourceFromContext(ctx)
-	if rt.Resource != "" {
-		if requestResource == "" {
+	if s.resourcePolicy != nil {
+		if err := s.resourcePolicy.ValidateTokenRequest(ctx, rt.ClientID, rt.Resource, requestResource); err != nil {
 			tx.Commit()
-			return nil, &oidc.Error{ErrorType: "invalid_target", Description: "missing resource"}
+			return nil, err
 		}
-		if requestResource != rt.Resource {
-			tx.Commit()
-			return nil, &oidc.Error{ErrorType: "invalid_target", Description: "resource mismatch"}
-		}
-	} else if requestResource != "" {
-		tx.Commit()
-		return nil, &oidc.Error{ErrorType: "invalid_target", Description: "unexpected resource"}
 	}
 
 	// State check (DeriveLoginState via injected function)

--- a/internal/storage/storage_oidc_device.go
+++ b/internal/storage/storage_oidc_device.go
@@ -53,38 +53,22 @@ func (s *Storage) KeySet(ctx context.Context) ([]op.Key, error) {
 // --- op.Storage: OPStorage ---
 
 func (s *Storage) GetClientByClientID(ctx context.Context, clientID string) (op.Client, error) {
-	// 1. YAML 클라이언트: 메모리 조회
-	if v, ok := s.clients.Load(clientID); ok {
-		return v.(*ClientModel), nil
+	client, err := s.resolveClient(ctx, clientID)
+	if err != nil {
+		return nil, err
 	}
-	// 2. CIMD 클라이언트: URL 형식이면 fetch
-	if s.cimdFetcher != nil && isCIMDClientID(clientID) {
-		return s.cimdFetcher.FetchClient(ctx, clientID)
-	}
-	return nil, ErrNotFound
+	return client, nil
 }
 
 func (s *Storage) AuthorizeClientIDSecret(ctx context.Context, clientID, clientSecret string) error {
-	v, ok := s.clients.Load(clientID)
-	if !ok {
-		if s.cimdFetcher != nil && isCIMDClientID(clientID) {
-			client, err := s.cimdFetcher.FetchClient(ctx, clientID)
-			if err != nil {
-				return ErrNotFound
-			}
-			cm := client
-			if cm.SecretHash == nil {
-				return errors.New("public client cannot use client_secret")
-			}
-			return verifyBcrypt(*cm.SecretHash, clientSecret)
-		}
+	client, err := s.resolveClient(ctx, clientID)
+	if err != nil {
 		return ErrNotFound
 	}
-	c := v.(*ClientModel)
-	if c.SecretHash == nil {
+	if client.SecretHash == nil {
 		return errors.New("public client cannot use client_secret")
 	}
-	return verifyBcrypt(*c.SecretHash, clientSecret)
+	return verifyBcrypt(*client.SecretHash, clientSecret)
 }
 
 func (s *Storage) SetUserinfoFromScopes(ctx context.Context, userinfo *oidc.UserInfo, userID, clientID string, scopes []string) error {


### PR DESCRIPTION
## Summary
- add `ClientResolutionPolicy` and `ResourceBindingPolicy` interfaces to storage
- route op.Storage critical paths through the new seam:
  - `GetClientByClientID`
  - `AuthorizeClientIDSecret`
  - `CreateAuthRequest`
  - `AuthRequestByCode`
  - `TokenRequestByRefreshToken`
- keep current behavior via default policy implementations (YAML + CIMD fallback, existing resource validation rules)
- add runtime setter methods to override policies later from adapters

## Why
- zitadel calls storage directly on token/code/client paths
- this seam is required before moving MCP-specific policy out of core storage

## Validation
- `go test ./...` passed