### PR TITLE
refactor(mcp): move MCP policy behavior to adapter wiring

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/zitadel/oidc/v3/pkg/op"
 
+	mcpadapter "github.com/kangheeyong/authgate/internal/adapter/mcp"
 	"github.com/kangheeyong/authgate/internal/clock"
 	"github.com/kangheeyong/authgate/internal/config"
 	"github.com/kangheeyong/authgate/internal/handler"
@@ -80,8 +81,10 @@ func main() {
 		}
 	}
 
-	// CIMD fetcher for MCP clients (URL-based client_id)
-	store.SetCIMDFetcher(storage.NewHTTPCIMDFetcher())
+	// MCP adapter policies: enable CIMD-based client resolution and MCP-specific resource checks.
+	cimdFetcher := storage.NewHTTPCIMDFetcher()
+	store.SetClientResolutionPolicy(mcpadapter.NewClientResolutionPolicy(storage.NewCoreClientResolutionPolicy(store), cimdFetcher))
+	store.SetResourceBindingPolicy(mcpadapter.NewResourceBindingPolicy(storage.NewCoreResourceBindingPolicy()))
 
 	// zitadel OP config
 	cryptoKey := sha256.Sum256([]byte(cfg.SessionSecret))

--- a/internal/adapter/mcp/policy.go
+++ b/internal/adapter/mcp/policy.go
@@ -1,0 +1,50 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+
+	"github.com/kangheeyong/authgate/internal/storage"
+)
+
+type clientResolutionPolicy struct {
+	base    storage.ClientResolutionPolicy
+	fetcher storage.CIMDFetcher
+}
+
+func (p *clientResolutionPolicy) ResolveClient(ctx context.Context, clientID string) (*storage.ClientModel, error) {
+	client, err := p.base.ResolveClient(ctx, clientID)
+	if err == nil {
+		return client, nil
+	}
+	if p.fetcher != nil && storage.IsCIMDClientID(clientID) && errors.Is(err, storage.ErrNotFound) {
+		return p.fetcher.FetchClient(ctx, clientID)
+	}
+	return nil, err
+}
+
+type resourceBindingPolicy struct {
+	base storage.ResourceBindingPolicy
+}
+
+func (p *resourceBindingPolicy) ValidateAuthorizeRequest(ctx context.Context, client *storage.ClientModel, requestResource string) error {
+	if requestResource == "" && client != nil && client.LoginChannel == "mcp" {
+		return &oidc.Error{ErrorType: "invalid_target", Description: "missing resource"}
+	}
+	return p.base.ValidateAuthorizeRequest(ctx, client, requestResource)
+}
+
+func (p *resourceBindingPolicy) ValidateTokenRequest(ctx context.Context, clientID, storedResource, requestResource string) error {
+	return p.base.ValidateTokenRequest(ctx, clientID, storedResource, requestResource)
+}
+
+func NewClientResolutionPolicy(base storage.ClientResolutionPolicy, fetcher storage.CIMDFetcher) storage.ClientResolutionPolicy {
+	return &clientResolutionPolicy{base: base, fetcher: fetcher}
+}
+
+func NewResourceBindingPolicy(base storage.ResourceBindingPolicy) storage.ResourceBindingPolicy {
+	return &resourceBindingPolicy{base: base}
+}
+

--- a/internal/storage/cimd_client_lookup_test.go
+++ b/internal/storage/cimd_client_lookup_test.go
@@ -11,6 +11,20 @@ import (
 	"github.com/kangheeyong/authgate/internal/clock"
 )
 
+type testCIMDClientResolutionPolicy struct {
+	s *Storage
+}
+
+func (p testCIMDClientResolutionPolicy) ResolveClient(ctx context.Context, clientID string) (*ClientModel, error) {
+	if v, ok := p.s.clients.Load(clientID); ok {
+		return v.(*ClientModel), nil
+	}
+	if p.s.cimdFetcher != nil && IsCIMDClientID(clientID) {
+		return p.s.cimdFetcher.FetchClient(ctx, clientID)
+	}
+	return nil, ErrNotFound
+}
+
 func TestGetClientByClientID_YAML(t *testing.T) {
 	store := &Storage{}
 	store.clients.Store("my-app", &ClientModel{
@@ -54,6 +68,7 @@ func TestGetClientByClientID_CIMD(t *testing.T) {
 
 	store := &Storage{}
 	store.SetCIMDFetcher(&HTTPCIMDFetcher{client: srv.Client(), clock: clock.RealClock{}, cacheTTL: 5 * time.Minute})
+	store.SetClientResolutionPolicy(testCIMDClientResolutionPolicy{s: store})
 
 	clientID := serverURL + "/oauth/client.json"
 	client, err := store.GetClientByClientID(context.Background(), clientID)

--- a/internal/storage/clients.go
+++ b/internal/storage/clients.go
@@ -138,7 +138,7 @@ func (s *Storage) SetCIMDFetcher(f CIMDFetcher) {
 // SetClientResolutionPolicy overrides client resolution behavior for op.Storage lookups.
 func (s *Storage) SetClientResolutionPolicy(policy ClientResolutionPolicy) {
 	if policy == nil {
-		s.clientPolicy = defaultClientResolutionPolicy{s: s}
+		s.clientPolicy = NewCoreClientResolutionPolicy(s)
 		return
 	}
 	s.clientPolicy = policy
@@ -147,7 +147,7 @@ func (s *Storage) SetClientResolutionPolicy(policy ClientResolutionPolicy) {
 // SetResourceBindingPolicy overrides resource binding validation for authorize/token flows.
 func (s *Storage) SetResourceBindingPolicy(policy ResourceBindingPolicy) {
 	if policy == nil {
-		s.resourcePolicy = defaultResourceBindingPolicy{}
+		s.resourcePolicy = NewCoreResourceBindingPolicy()
 		return
 	}
 	s.resourcePolicy = policy
@@ -156,7 +156,7 @@ func (s *Storage) SetResourceBindingPolicy(policy ResourceBindingPolicy) {
 func (s *Storage) resolveClient(ctx context.Context, clientID string) (*ClientModel, error) {
 	// Safety net for tests constructing Storage without New().
 	if s.clientPolicy == nil {
-		s.clientPolicy = defaultClientResolutionPolicy{s: s}
+		s.clientPolicy = NewCoreClientResolutionPolicy(s)
 	}
 	return s.clientPolicy.ResolveClient(ctx, clientID)
 }

--- a/internal/storage/policy.go
+++ b/internal/storage/policy.go
@@ -6,30 +6,24 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
 
-type defaultClientResolutionPolicy struct {
+type coreClientResolutionPolicy struct {
 	s *Storage
 }
 
-func (p defaultClientResolutionPolicy) ResolveClient(ctx context.Context, clientID string) (*ClientModel, error) {
+func (p coreClientResolutionPolicy) ResolveClient(ctx context.Context, clientID string) (*ClientModel, error) {
 	if v, ok := p.s.clients.Load(clientID); ok {
 		return v.(*ClientModel), nil
-	}
-	if p.s.cimdFetcher != nil && isCIMDClientID(clientID) {
-		return p.s.cimdFetcher.FetchClient(ctx, clientID)
 	}
 	return nil, ErrNotFound
 }
 
-type defaultResourceBindingPolicy struct{}
+type coreResourceBindingPolicy struct{}
 
-func (defaultResourceBindingPolicy) ValidateAuthorizeRequest(ctx context.Context, client *ClientModel, requestResource string) error {
-	if requestResource == "" && client != nil && client.LoginChannel == "mcp" {
-		return &oidc.Error{ErrorType: "invalid_target", Description: "missing resource"}
-	}
+func (coreResourceBindingPolicy) ValidateAuthorizeRequest(ctx context.Context, client *ClientModel, requestResource string) error {
 	return nil
 }
 
-func (defaultResourceBindingPolicy) ValidateTokenRequest(ctx context.Context, clientID, storedResource, requestResource string) error {
+func (coreResourceBindingPolicy) ValidateTokenRequest(ctx context.Context, clientID, storedResource, requestResource string) error {
 	if storedResource != "" {
 		if requestResource == "" {
 			return &oidc.Error{ErrorType: "invalid_target", Description: "missing resource"}
@@ -45,3 +39,10 @@ func (defaultResourceBindingPolicy) ValidateTokenRequest(ctx context.Context, cl
 	return nil
 }
 
+func NewCoreClientResolutionPolicy(s *Storage) ClientResolutionPolicy {
+	return coreClientResolutionPolicy{s: s}
+}
+
+func NewCoreResourceBindingPolicy() ResourceBindingPolicy {
+	return coreResourceBindingPolicy{}
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -63,8 +63,8 @@ func New(db *sql.DB, clk clock.Clock, gen idgen.IDGenerator, checker StateChecke
 		accessTokenTTL:  accessTTL,
 		refreshTokenTTL: refreshTTL,
 	}
-	s.clientPolicy = defaultClientResolutionPolicy{s: s}
-	s.resourcePolicy = defaultResourceBindingPolicy{}
+	s.clientPolicy = NewCoreClientResolutionPolicy(s)
+	s.resourcePolicy = NewCoreResourceBindingPolicy()
 	return s
 }
 


### PR DESCRIPTION
## Summary
- add `internal/adapter/mcp/policy.go` with MCP-specific policy implementations
  - client resolution: static clients + CIMD fallback
  - authorize resource guard: MCP channel requires resource
- narrow storage core defaults to core behavior
  - core client policy resolves only configured static clients
  - core resource policy keeps token-side resource consistency checks
- wire MCP policies from `main.go` via storage seam
- keep storage seam API introduced in #47 and reuse it for composition
- update CIMD lookup test to use explicit policy injection

## Why
- continue Phase 2 direction: MCP-specific behavior should be adapter-owned, not core default
- keep browser/device baseline isolated from MCP extensions while preserving runtime behavior through adapter wiring

## Validation
- `go test ./...` passed