### PR TITLE
refactor(handler): split MCP login handler from browser login handler

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -160,6 +160,7 @@ func main() {
 
 	// Handler layer
 	loginHandler := handler.NewLoginHandler(loginService, cfg.DevMode)
+	mcpLoginHandler := handler.NewMCPLoginHandler(loginService, cfg.DevMode)
 	deviceHandler := handler.NewDeviceHandler(deviceService, cfg.DevMode)
 	accountHandler := handler.NewAccountHandler(accountService, cfg.PublicURL)
 
@@ -220,8 +221,8 @@ func main() {
 	// authgate login routes
 	mux.HandleFunc("/login", loginHandler.HandleLogin)
 	mux.HandleFunc("/login/callback", loginHandler.HandleCallback)
-	mux.HandleFunc("/mcp/login", loginHandler.HandleMCPLogin)
-	mux.HandleFunc("/mcp/callback", loginHandler.HandleMCPCallback)
+	mux.HandleFunc("/mcp/login", mcpLoginHandler.HandleLogin)
+	mux.HandleFunc("/mcp/callback", mcpLoginHandler.HandleCallback)
 
 	// authgate account routes
 	mux.HandleFunc("/account", accountHandler.HandleDeleteAccount)

--- a/internal/handler/login_test.go
+++ b/internal/handler/login_test.go
@@ -29,36 +29,12 @@ func TestLogin_MissingAuthRequestID_ReturnsBadRequest(t *testing.T) {
 	}
 }
 
-func TestMCPLogin_MissingAuthRequestID_ReturnsBadRequest(t *testing.T) {
-	h := newTestLoginHandler(true)
-	req := httptest.NewRequest(http.MethodGet, "/mcp/login", nil)
-	w := httptest.NewRecorder()
-
-	h.HandleMCPLogin(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", w.Code)
-	}
-}
-
 func TestLoginCallback_MissingCodeOrState_ReturnsBadRequest(t *testing.T) {
 	h := newTestLoginHandler(true)
 	req := httptest.NewRequest(http.MethodGet, "/login/callback", nil)
 	w := httptest.NewRecorder()
 
 	h.HandleCallback(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", w.Code)
-	}
-}
-
-func TestMCPCallback_MissingCodeOrState_ReturnsBadRequest(t *testing.T) {
-	h := newTestLoginHandler(true)
-	req := httptest.NewRequest(http.MethodGet, "/mcp/callback", nil)
-	w := httptest.NewRecorder()
-
-	h.HandleMCPCallback(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", w.Code)

--- a/internal/handler/mcp_login.go
+++ b/internal/handler/mcp_login.go
@@ -7,46 +7,43 @@ import (
 	"github.com/kangheeyong/authgate/internal/service"
 )
 
-type LoginHandler struct {
+type MCPLoginHandler struct {
 	loginService *service.LoginService
 	devMode      bool
 }
 
-func NewLoginHandler(loginService *service.LoginService, devMode bool) *LoginHandler {
-	return &LoginHandler{
+func NewMCPLoginHandler(loginService *service.LoginService, devMode bool) *MCPLoginHandler {
+	return &MCPLoginHandler{
 		loginService: loginService,
 		devMode:      devMode,
 	}
 }
 
-// HandleLogin handles GET /login?authRequestID=xxx
-func (h *LoginHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
+// HandleLogin handles GET /mcp/login?authRequestID=xxx
+func (h *MCPLoginHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	authRequestID := r.URL.Query().Get("authRequestID")
 	sessionID := getSessionCookie(r)
 
-	result := h.loginService.HandleLogin(r.Context(), authRequestID, sessionID, r.RemoteAddr, r.UserAgent())
+	result := h.loginService.HandleMCPLogin(r.Context(), authRequestID, sessionID, r.RemoteAddr, r.UserAgent())
 
 	switch result.Action {
 	case service.ActionRedirectToIdP:
 		http.Redirect(w, r, result.RedirectURL, http.StatusFound)
-
 	case service.ActionAutoApprove:
-		// Redirect back to zitadel's authorize callback
 		http.Redirect(w, r, "/authorize/callback?id="+result.AuthRequestID, http.StatusFound)
-
 	case service.ActionError:
 		h.renderError(w, result.ErrorCode, result.Error)
+	default:
+		h.renderError(w, http.StatusInternalServerError, "invalid mcp login action")
 	}
 }
 
-// HandleCallback handles GET /login/callback?code=xxx&state=authRequestID
-func (h *LoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
+// HandleCallback handles GET /mcp/callback?code=xxx&state=authRequestID
+func (h *MCPLoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 	authRequestID := r.URL.Query().Get("state")
-	ipAddress := r.RemoteAddr
-	userAgent := r.UserAgent()
 
-	result := h.loginService.HandleCallback(r.Context(), code, authRequestID, ipAddress, userAgent)
+	result := h.loginService.HandleMCPCallback(r.Context(), code, authRequestID, r.RemoteAddr, r.UserAgent())
 
 	if result.SessionID != "" {
 		setSessionCookie(w, result.SessionID, h.devMode)
@@ -55,14 +52,16 @@ func (h *LoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	switch result.Action {
 	case service.ActionAutoApprove:
 		http.Redirect(w, r, "/authorize/callback?id="+result.AuthRequestID, http.StatusFound)
-
 	case service.ActionError:
 		h.renderError(w, result.ErrorCode, result.Error)
+	default:
+		h.renderError(w, http.StatusInternalServerError, "invalid mcp callback action")
 	}
 }
 
-func (h *LoginHandler) renderError(w http.ResponseWriter, code int, message string) {
+func (h *MCPLoginHandler) renderError(w http.ResponseWriter, code int, message string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(code)
 	pages.RenderError(w, pages.ErrorData{Code: code, Message: message})
 }
+

--- a/internal/handler/mcp_login_test.go
+++ b/internal/handler/mcp_login_test.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kangheeyong/authgate/internal/service"
+)
+
+func newTestMCPLoginHandler(devMode bool) *MCPLoginHandler {
+	svc := service.NewLoginService(nil, nil, nil, 0)
+	return NewMCPLoginHandler(svc, devMode)
+}
+
+func TestMCPLogin_MissingAuthRequestID_ReturnsBadRequest(t *testing.T) {
+	h := newTestMCPLoginHandler(true)
+	req := httptest.NewRequest(http.MethodGet, "/mcp/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestMCPCallback_MissingCodeOrState_ReturnsBadRequest(t *testing.T) {
+	h := newTestMCPLoginHandler(true)
+	req := httptest.NewRequest(http.MethodGet, "/mcp/callback", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleCallback(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -120,6 +120,7 @@ func SetupTestServer(t *testing.T) *TestServer {
 
 	// Handlers
 	loginHandler := handler.NewLoginHandler(loginSvc, true)
+	mcpLoginHandler := handler.NewMCPLoginHandler(loginSvc, true)
 	deviceHandler := handler.NewDeviceHandler(deviceSvc, true)
 	accountHandler := handler.NewAccountHandler(accountSvc, srv.URL)
 
@@ -167,8 +168,8 @@ func SetupTestServer(t *testing.T) *TestServer {
 	mux.Handle("/", provider)
 	mux.HandleFunc("/login", loginHandler.HandleLogin)
 	mux.HandleFunc("/login/callback", loginHandler.HandleCallback)
-	mux.HandleFunc("/mcp/login", loginHandler.HandleMCPLogin)
-	mux.HandleFunc("/mcp/callback", loginHandler.HandleMCPCallback)
+	mux.HandleFunc("/mcp/login", mcpLoginHandler.HandleLogin)
+	mux.HandleFunc("/mcp/callback", mcpLoginHandler.HandleCallback)
 	mux.HandleFunc("/device", deviceHandler.HandleDevicePage)
 	mux.HandleFunc("/device/approve", deviceHandler.HandleDeviceApprove)
 	mux.HandleFunc("/device/auth/callback", deviceHandler.HandleDeviceCallback)


### PR DESCRIPTION
## Summary
- split MCP login/callback handling into dedicated `MCPLoginHandler`
  - new file: `internal/handler/mcp_login.go`
  - moved `/mcp/login` and `/mcp/callback` logic out of browser `LoginHandler`
- keep browser login handler focused on `/login` and `/login/callback`
- update server wiring to use separate handlers
  - `cmd/authgate/main.go`
  - `internal/integration/server.go`
- split handler tests accordingly
  - browser tests stay in `login_test.go`
  - MCP endpoint tests moved to `mcp_login_test.go`

## Why
- continue Phase 3 direction: separate channel entry handlers so MCP and browser flows are independently owned
- reduce mixed responsibilities in one handler type before deeper service/module split

## Validation
- `go test ./...` passed
