### PR TITLE
refactor(service): split MCP login service wiring from browser login service

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -151,6 +151,7 @@ func main() {
 
 	// Service layer
 	loginService := service.NewLoginService(store, browserProvider, mcpProvider, cfg.SessionTTL)
+	mcpLoginService := service.NewMCPLoginService(store, mcpProvider, cfg.SessionTTL)
 
 	// Device service
 	deviceService := service.NewDeviceService(store, deviceProvider, cfg.PublicURL, cfg.SessionTTL, clk)
@@ -160,7 +161,7 @@ func main() {
 
 	// Handler layer
 	loginHandler := handler.NewLoginHandler(loginService, cfg.DevMode)
-	mcpLoginHandler := handler.NewMCPLoginHandler(loginService, cfg.DevMode)
+	mcpLoginHandler := handler.NewMCPLoginHandler(mcpLoginService, cfg.DevMode)
 	deviceHandler := handler.NewDeviceHandler(deviceService, cfg.DevMode)
 	accountHandler := handler.NewAccountHandler(accountService, cfg.PublicURL)
 

--- a/internal/handler/mcp_login.go
+++ b/internal/handler/mcp_login.go
@@ -8,11 +8,11 @@ import (
 )
 
 type MCPLoginHandler struct {
-	loginService *service.LoginService
+	loginService *service.MCPLoginService
 	devMode      bool
 }
 
-func NewMCPLoginHandler(loginService *service.LoginService, devMode bool) *MCPLoginHandler {
+func NewMCPLoginHandler(loginService *service.MCPLoginService, devMode bool) *MCPLoginHandler {
 	return &MCPLoginHandler{
 		loginService: loginService,
 		devMode:      devMode,
@@ -24,7 +24,7 @@ func (h *MCPLoginHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	authRequestID := r.URL.Query().Get("authRequestID")
 	sessionID := getSessionCookie(r)
 
-	result := h.loginService.HandleMCPLogin(r.Context(), authRequestID, sessionID, r.RemoteAddr, r.UserAgent())
+	result := h.loginService.HandleLogin(r.Context(), authRequestID, sessionID, r.RemoteAddr, r.UserAgent())
 
 	switch result.Action {
 	case service.ActionRedirectToIdP:
@@ -43,7 +43,7 @@ func (h *MCPLoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request)
 	code := r.URL.Query().Get("code")
 	authRequestID := r.URL.Query().Get("state")
 
-	result := h.loginService.HandleMCPCallback(r.Context(), code, authRequestID, r.RemoteAddr, r.UserAgent())
+	result := h.loginService.HandleCallback(r.Context(), code, authRequestID, r.RemoteAddr, r.UserAgent())
 
 	if result.SessionID != "" {
 		setSessionCookie(w, result.SessionID, h.devMode)
@@ -64,4 +64,3 @@ func (h *MCPLoginHandler) renderError(w http.ResponseWriter, code int, message s
 	w.WriteHeader(code)
 	pages.RenderError(w, pages.ErrorData{Code: code, Message: message})
 }
-

--- a/internal/handler/mcp_login_test.go
+++ b/internal/handler/mcp_login_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func newTestMCPLoginHandler(devMode bool) *MCPLoginHandler {
-	svc := service.NewLoginService(nil, nil, nil, 0)
+	svc := service.NewMCPLoginService(nil, nil, 0)
 	return NewMCPLoginHandler(svc, devMode)
 }
 
@@ -36,4 +36,3 @@ func TestMCPCallback_MissingCodeOrState_ReturnsBadRequest(t *testing.T) {
 		t.Fatalf("status = %d, want 400", w.Code)
 	}
 }
-

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -115,12 +115,13 @@ func SetupTestServer(t *testing.T) *TestServer {
 
 	// Services
 	loginSvc := service.NewLoginService(store, fakeProvider, fakeProvider, 24*time.Hour)
+	mcpLoginSvc := service.NewMCPLoginService(store, fakeProvider, 24*time.Hour)
 	deviceSvc := service.NewDeviceService(store, fakeProvider, srv.URL, 24*time.Hour, clk)
 	accountSvc := service.NewAccountService(store)
 
 	// Handlers
 	loginHandler := handler.NewLoginHandler(loginSvc, true)
-	mcpLoginHandler := handler.NewMCPLoginHandler(loginSvc, true)
+	mcpLoginHandler := handler.NewMCPLoginHandler(mcpLoginSvc, true)
 	deviceHandler := handler.NewDeviceHandler(deviceSvc, true)
 	accountHandler := handler.NewAccountHandler(accountSvc, srv.URL)
 

--- a/internal/service/mcp_login.go
+++ b/internal/service/mcp_login.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/kangheeyong/authgate/internal/upstream"
+)
+
+// MCPLoginService owns MCP channel login/callback orchestration.
+// It reuses existing LoginService flow logic while exposing MCP-only entrypoints.
+type MCPLoginService struct {
+	base *LoginService
+}
+
+func NewMCPLoginService(store LoginStore, mcpProvider upstream.Provider, sessionTTL time.Duration) *MCPLoginService {
+	base := &LoginService{
+		store:           store,
+		browserProvider: mcpProvider,
+		mcpProvider:     mcpProvider,
+		sessionTTL:      sessionTTL,
+	}
+	return &MCPLoginService{base: base}
+}
+
+func (s *MCPLoginService) HandleLogin(ctx context.Context, authRequestID, sessionID, ipAddress, userAgent string) *LoginResult {
+	return s.base.HandleMCPLogin(ctx, authRequestID, sessionID, ipAddress, userAgent)
+}
+
+func (s *MCPLoginService) HandleCallback(ctx context.Context, code, authRequestID, ipAddress, userAgent string) *CallbackResult {
+	return s.base.HandleMCPCallback(ctx, code, authRequestID, ipAddress, userAgent)
+}
+


### PR DESCRIPTION
## Summary
- add `internal/service/mcp_login.go` with dedicated `MCPLoginService`
- wire MCP handler to depend on `MCPLoginService` instead of shared `LoginService`
- keep browser handler on `LoginService`
- update server wiring (`cmd/authgate/main.go`, `internal/integration/server.go`) to construct both services explicitly
- keep behavior unchanged by reusing existing MCP flow logic under the hood

## Why
- continue Phase 3 split: browser and mcp now have separate service ownership at the composition boundary
- reduces cross-channel coupling in handler/service wiring before deeper internal flow extraction

## Validation
- `go test ./...` passed
