### PR TITLE
refactor(service): decouple MCPLoginService from LoginService wrapper

### DIFF
--- a/internal/service/mcp_login.go
+++ b/internal/service/mcp_login.go
@@ -2,32 +2,87 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net/http"
 	"time"
 
+	"github.com/kangheeyong/authgate/internal/storage"
 	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
 // MCPLoginService owns MCP channel login/callback orchestration.
-// It reuses existing LoginService flow logic while exposing MCP-only entrypoints.
 type MCPLoginService struct {
-	base *LoginService
+	store       LoginStore
+	mcpProvider upstream.Provider
+	sessionTTL  time.Duration
 }
 
 func NewMCPLoginService(store LoginStore, mcpProvider upstream.Provider, sessionTTL time.Duration) *MCPLoginService {
-	base := &LoginService{
-		store:           store,
-		browserProvider: mcpProvider,
-		mcpProvider:     mcpProvider,
-		sessionTTL:      sessionTTL,
+	return &MCPLoginService{
+		store:       store,
+		mcpProvider: mcpProvider,
+		sessionTTL:  sessionTTL,
 	}
-	return &MCPLoginService{base: base}
 }
 
 func (s *MCPLoginService) HandleLogin(ctx context.Context, authRequestID, sessionID, ipAddress, userAgent string) *LoginResult {
-	return s.base.HandleMCPLogin(ctx, authRequestID, sessionID, ipAddress, userAgent)
+	if authRequestID == "" {
+		return &LoginResult{Action: ActionError, Error: "missing authRequestID", ErrorCode: http.StatusBadRequest}
+	}
+
+	if sessionID != "" {
+		user, err := s.store.GetValidSession(ctx, sessionID)
+		if err == nil {
+			switch CheckAccess(user.Status, "mcp") {
+			case AccessDeny:
+				s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status})
+				return &LoginResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
+			case AccessRecover:
+				return &LoginResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
+			}
+			if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
+				return &LoginResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
+			}
+			return &LoginResult{Action: ActionAutoApprove, AuthRequestID: authRequestID}
+		}
+	}
+
+	return &LoginResult{Action: ActionRedirectToIdP, RedirectURL: s.mcpProvider.AuthURL(authRequestID)}
 }
 
 func (s *MCPLoginService) HandleCallback(ctx context.Context, code, authRequestID, ipAddress, userAgent string) *CallbackResult {
-	return s.base.HandleMCPCallback(ctx, code, authRequestID, ipAddress, userAgent)
-}
+	if code == "" || authRequestID == "" {
+		return &CallbackResult{Action: ActionError, Error: "missing code or state", ErrorCode: http.StatusBadRequest}
+	}
 
+	userInfo, err := s.mcpProvider.Exchange(ctx, code)
+	if err != nil {
+		return &CallbackResult{Action: ActionError, Error: fmt.Sprintf("upstream_error: %v", err), ErrorCode: http.StatusInternalServerError}
+	}
+
+	providerName := s.mcpProvider.Name()
+	user, err := s.store.GetUserByProviderIdentity(ctx, providerName, userInfo.Sub)
+	if errors.Is(err, storage.ErrNotFound) {
+		return &CallbackResult{Action: ActionError, Error: "account_not_found", ErrorCode: http.StatusForbidden}
+	}
+	if err != nil {
+		return &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+	}
+	s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{"channel": "mcp"})
+
+	switch CheckAccess(user.Status, "mcp") {
+	case AccessDeny, AccessRecover:
+		s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "mcp"})
+		return &CallbackResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
+	}
+
+	sessionID, err := s.store.CreateSession(ctx, user.ID, s.sessionTTL)
+	if err != nil {
+		return &CallbackResult{Action: ActionError, Error: "session creation failed", ErrorCode: http.StatusInternalServerError}
+	}
+	if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
+		return &CallbackResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
+	}
+	return &CallbackResult{Action: ActionAutoApprove, AuthRequestID: authRequestID, SessionID: sessionID}
+}


### PR DESCRIPTION
## Summary
- refactor `MCPLoginService` to own MCP login/callback orchestration directly
- remove internal `LoginService` base-wrapper dependency from `MCPLoginService`
- keep external behavior unchanged (same audit, access checks, session creation, auth request completion rules)

## Why
- eliminate the ambiguous wiring where MCP service previously instantiated a `LoginService` and populated both browser/mcp provider fields
- make channel ownership explicit: MCP service now contains only MCP concerns

## Validation
- `go test ./...` passed
