### PR TITLE
refactor(service): remove MCP paths from LoginService

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -150,7 +150,7 @@ func main() {
 	}
 
 	// Service layer
-	loginService := service.NewLoginService(store, browserProvider, mcpProvider, cfg.SessionTTL)
+	loginService := service.NewLoginService(store, browserProvider, cfg.SessionTTL)
 	mcpLoginService := service.NewMCPLoginService(store, mcpProvider, cfg.SessionTTL)
 
 	// Device service

--- a/internal/handler/login_test.go
+++ b/internal/handler/login_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func newTestLoginHandler(devMode bool) *LoginHandler {
-	svc := service.NewLoginService(nil, nil, nil, 0)
+	svc := service.NewLoginService(nil, nil, 0)
 	return NewLoginHandler(svc, devMode)
 }
 

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -114,7 +114,7 @@ func SetupTestServer(t *testing.T) *TestServer {
 	}
 
 	// Services
-	loginSvc := service.NewLoginService(store, fakeProvider, fakeProvider, 24*time.Hour)
+	loginSvc := service.NewLoginService(store, fakeProvider, 24*time.Hour)
 	mcpLoginSvc := service.NewMCPLoginService(store, fakeProvider, 24*time.Hour)
 	deviceSvc := service.NewDeviceService(store, fakeProvider, srv.URL, 24*time.Hour, clk)
 	accountSvc := service.NewAccountService(store)

--- a/internal/service/account_test.go
+++ b/internal/service/account_test.go
@@ -28,7 +28,7 @@ func setupAccountTest(t *testing.T) (*AccountService, *LoginService, *storage.St
 	}
 
 	accountSvc := NewAccountService(store)
-	loginSvc := NewLoginService(store, fakeProvider, fakeProvider, 24*time.Hour)
+	loginSvc := NewLoginService(store, fakeProvider, 24*time.Hour)
 	return accountSvc, loginSvc, store, db, clk
 }
 
@@ -186,7 +186,7 @@ func TestE2E_DeleteThenReregister(t *testing.T) {
 
 // account-004: pending_deletion + Device/MCP → account_inactive
 func TestAccount004_PendingDeletion_DeviceRejected(t *testing.T) {
-	_, deviceSvc, _, store, _, _ := setupGapTest(t)
+	_, _, deviceSvc, _, store, _, _ := setupGapTest(t)
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, "pd-device@test.com", true, "Test", "", "google", "gap-sub", "pd@test.com")
@@ -203,14 +203,14 @@ func TestAccount004_PendingDeletion_DeviceRejected(t *testing.T) {
 
 // account-004b: pending_deletion + MCP login → account_inactive
 func TestAccount004b_PendingDeletion_MCPRejected(t *testing.T) {
-	loginSvc, _, _, store, _, _ := setupGapTest(t)
+	_, mcpLoginSvc, _, _, store, _, _ := setupGapTest(t)
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, "pd-mcp@test.com", true, "Test", "", "google", "gap-sub", "pdm@test.com")
 	store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	arID, _ := store.CreateTestAuthRequest(ctx, "pd-mcp")
-	result := loginSvc.HandleMCPCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
+	result := mcpLoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error (pending_deletion via MCP)", result.Action)

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -130,7 +130,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		}
 		arID, _ := store.CreateTestAuthRequest(ctx, "audit-mcp")
 
-		result := svc.HandleMCPCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-agent")
+		result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-agent")
 		if result.Action != ActionAutoApprove {
 			t.Fatalf("action = %v, want AutoApprove", result.Action)
 		}
@@ -330,7 +330,7 @@ func TestAuditSecurity_MCPInactiveUser_Metadata(t *testing.T) {
 			}
 			arID, _ := store.CreateTestAuthRequest(ctx, "audit-mcp-"+tt.name)
 
-			result := svc.HandleMCPCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-agent")
+			result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-agent")
 			if result.Action != ActionError {
 				t.Fatalf("action = %v, want ActionError", result.Action)
 			}

--- a/internal/service/cleanup_test.go
+++ b/internal/service/cleanup_test.go
@@ -132,7 +132,7 @@ func TestCleanup_DeletionPIIScrub(t *testing.T) {
 
 // E2E 8: cleanup 롤백 — 중간 실패 시 데이터 일관성
 func TestE2E8_CleanupRollback(t *testing.T) {
-	_, _, _, store, db, clk := setupGapTest(t)
+	_, _, _, _, store, db, clk := setupGapTest(t)
 	ctx := context.Background()
 
 	// Create user set for deletion

--- a/internal/service/e2e_test.go
+++ b/internal/service/e2e_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
-func setupE2ETest(t *testing.T) (*LoginService, *DeviceService, *AccountService, *storage.Storage, *sql.DB, *clock.FixedClock) {
+func setupE2ETest(t *testing.T) (*LoginService, *MCPLoginService, *DeviceService, *AccountService, *storage.Storage, *sql.DB, *clock.FixedClock) {
 	t.Helper()
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
@@ -34,10 +34,11 @@ func setupE2ETest(t *testing.T) (*LoginService, *DeviceService, *AccountService,
 		User: &upstream.UserInfo{Sub: "e2e-sub", Email: "e2e@test.com", EmailVerified: true, Name: "E2E User"},
 	}
 
-	loginSvc := NewLoginService(store, fakeProvider, fakeProvider, 24*time.Hour)
+	loginSvc := NewLoginService(store, fakeProvider, 24*time.Hour)
+	mcpLoginSvc := NewMCPLoginService(store, fakeProvider, 24*time.Hour)
 	deviceSvc := NewDeviceService(store, fakeProvider, "http://localhost:8080", 24*time.Hour, clk)
 	accountSvc := NewAccountService(store)
-	return loginSvc, deviceSvc, accountSvc, store, db, clk
+	return loginSvc, mcpLoginSvc, deviceSvc, accountSvc, store, db, clk
 }
 
 func createRefreshTokenForUser(t *testing.T, ctx context.Context, store *storage.Storage, userID string) string {
@@ -56,7 +57,7 @@ func createRefreshTokenForUser(t *testing.T, ctx context.Context, store *storage
 
 // E2E 1: 최초 가입 → 정상 사용 → Device/MCP 후속 채널
 func TestE2E1_SignupToAllChannels(t *testing.T) {
-	loginSvc, deviceSvc, _, store, _, clk := setupE2ETest(t)
+	loginSvc, mcpLoginSvc, deviceSvc, _, store, _, clk := setupE2ETest(t)
 	ctx := context.Background()
 
 	// 1. Browser signup → auto-approve (no terms step)
@@ -82,7 +83,7 @@ func TestE2E1_SignupToAllChannels(t *testing.T) {
 
 	// 4. MCP → auto-approve
 	arID3, _ := store.CreateTestAuthRequest(ctx, "e2e1-mcp")
-	mcpResult := loginSvc.HandleMCPCallback(ctx, "fake-code", arID3, "127.0.0.1", "mcp-client")
+	mcpResult := mcpLoginSvc.HandleCallback(ctx, "fake-code", arID3, "127.0.0.1", "mcp-client")
 	if mcpResult.Action != ActionAutoApprove {
 		t.Fatalf("step 4: mcp action = %v, want AutoApprove", mcpResult.Action)
 	}
@@ -93,7 +94,7 @@ func TestE2E1_SignupToAllChannels(t *testing.T) {
 // Device/MCP 로그인을 시도하면 account_not_found로 차단된다.
 // Browser로 가입 완료 후에는 모든 채널이 정상 동작해야 한다.
 func TestE2E2_SignupAbandonAndReturn(t *testing.T) {
-	loginSvc, deviceSvc, _, store, _, clk := setupE2ETest(t)
+	loginSvc, mcpLoginSvc, deviceSvc, _, store, _, clk := setupE2ETest(t)
 	ctx := context.Background()
 
 	// Step 2/3: 유저 DB 없음 → Device/MCP 차단 (account_not_found)
@@ -104,7 +105,7 @@ func TestE2E2_SignupAbandonAndReturn(t *testing.T) {
 	}
 
 	arIDMCP, _ := store.CreateTestAuthRequest(ctx, "e2e2-mcp-pre")
-	mcpResult := loginSvc.HandleMCPCallback(ctx, "fake-code", arIDMCP, "127.0.0.1", "mcp")
+	mcpResult := mcpLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP, "127.0.0.1", "mcp")
 	if mcpResult.Action != ActionError {
 		t.Fatalf("mcp before signup: action=%v, want ActionError", mcpResult.Action)
 	}
@@ -125,7 +126,7 @@ func TestE2E2_SignupAbandonAndReturn(t *testing.T) {
 
 	// 가입 후 MCP 정상 동작
 	arIDMCP2, _ := store.CreateTestAuthRequest(ctx, "e2e2-mcp-post")
-	mcpResult2 := loginSvc.HandleMCPCallback(ctx, "fake-code", arIDMCP2, "127.0.0.1", "mcp")
+	mcpResult2 := mcpLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP2, "127.0.0.1", "mcp")
 	if mcpResult2.Action != ActionAutoApprove {
 		t.Fatalf("mcp after signup: action=%v, want ActionAutoApprove", mcpResult2.Action)
 	}
@@ -133,7 +134,7 @@ func TestE2E2_SignupAbandonAndReturn(t *testing.T) {
 
 // E2E 4: 탈퇴 후 복구
 func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
-	loginSvc, deviceSvc, accountSvc, store, db, clk := setupE2ETest(t)
+	loginSvc, mcpLoginSvc, deviceSvc, accountSvc, store, db, clk := setupE2ETest(t)
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, "e2e4-full@test.com", true, "Test", "", "google", "e2e-sub", "e2e4-full@test.com")
@@ -164,7 +165,7 @@ func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
 		t.Fatalf("step 3: device should reject pending_deletion user, got action=%v code=%d", devResult.Action, devResult.ErrorCode)
 	}
 	arIDMCP, _ := store.CreateTestAuthRequest(ctx, "e2e4-mcp")
-	mcpResult := loginSvc.HandleMCPCallback(ctx, "fake-code", arIDMCP, "127.0.0.1", "mcp-client")
+	mcpResult := mcpLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP, "127.0.0.1", "mcp-client")
 	if mcpResult.Action != ActionError || mcpResult.ErrorCode != 403 {
 		t.Fatalf("step 3: mcp should reject pending_deletion user, got action=%v code=%d", mcpResult.Action, mcpResult.ErrorCode)
 	}
@@ -187,7 +188,7 @@ func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
 		t.Fatalf("step 5: device should succeed after recovery, got action=%v", devResult2.Action)
 	}
 	arIDMCP2, _ := store.CreateTestAuthRequest(ctx, "e2e4-mcp-ok")
-	mcpResult2 := loginSvc.HandleMCPCallback(ctx, "fake-code", arIDMCP2, "127.0.0.1", "mcp-client")
+	mcpResult2 := mcpLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP2, "127.0.0.1", "mcp-client")
 	if mcpResult2.Action != ActionAutoApprove {
 		t.Fatalf("step 5: mcp should succeed after recovery, got action=%v", mcpResult2.Action)
 	}
@@ -195,7 +196,7 @@ func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
 
 // E2E 5: 복구 후 로그인 완료 실패가 발생해도 다음 재시도에서 정상 완료되어야 한다.
 func TestE2E5_RecoveryThenAuthRequestRetry(t *testing.T) {
-	loginSvc, _, accountSvc, store, db, _ := setupE2ETest(t)
+	loginSvc, _, _, accountSvc, store, db, _ := setupE2ETest(t)
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, "e2e5-retry@test.com", true, "Retry User", "", "google", "e2e-sub", "e2e5-retry@test.com")

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -14,7 +14,6 @@ import (
 type LoginService struct {
 	store           LoginStore
 	browserProvider upstream.Provider
-	mcpProvider     upstream.Provider
 	sessionTTL      time.Duration
 }
 
@@ -29,14 +28,10 @@ type LoginStore interface {
 	CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error)
 }
 
-func NewLoginService(store LoginStore, browserProvider, mcpProvider upstream.Provider, sessionTTL time.Duration) *LoginService {
-	if mcpProvider == nil {
-		mcpProvider = browserProvider
-	}
+func NewLoginService(store LoginStore, browserProvider upstream.Provider, sessionTTL time.Duration) *LoginService {
 	return &LoginService{
 		store:           store,
 		browserProvider: browserProvider,
-		mcpProvider:     mcpProvider,
 		sessionTTL:      sessionTTL,
 	}
 }
@@ -60,15 +55,10 @@ const (
 
 // HandleLogin processes GET /login?authRequestID=xxx
 func (s *LoginService) HandleLogin(ctx context.Context, authRequestID, sessionID, ipAddress, userAgent string) *LoginResult {
-	return s.handleLogin(ctx, authRequestID, sessionID, ipAddress, userAgent, "browser")
+	return s.handleLogin(ctx, authRequestID, sessionID, ipAddress, userAgent)
 }
 
-// HandleMCPLogin processes GET /mcp/login?authRequestID=xxx
-func (s *LoginService) HandleMCPLogin(ctx context.Context, authRequestID, sessionID, ipAddress, userAgent string) *LoginResult {
-	return s.handleLogin(ctx, authRequestID, sessionID, ipAddress, userAgent, "mcp")
-}
-
-func (s *LoginService) handleLogin(ctx context.Context, authRequestID, sessionID, ipAddress, userAgent string, channel string) *LoginResult {
+func (s *LoginService) handleLogin(ctx context.Context, authRequestID, sessionID, ipAddress, userAgent string) *LoginResult {
 	if authRequestID == "" {
 		return &LoginResult{Action: ActionError, Error: "missing authRequestID", ErrorCode: http.StatusBadRequest}
 	}
@@ -78,18 +68,18 @@ func (s *LoginService) handleLogin(ctx context.Context, authRequestID, sessionID
 		user, err := s.store.GetValidSession(ctx, sessionID)
 		if err == nil {
 			// Session exists — check login state
-			return s.handleExistingSession(ctx, user, authRequestID, ipAddress, userAgent, channel)
+			return s.handleExistingSession(ctx, user, authRequestID, ipAddress, userAgent)
 		}
 		// Session invalid/expired — fall through to IdP redirect
 	}
 
 	// No valid session — redirect to upstream IdP
-	authURL := s.providerForChannel(channel).AuthURL(authRequestID)
+	authURL := s.browserProvider.AuthURL(authRequestID)
 	return &LoginResult{Action: ActionRedirectToIdP, RedirectURL: authURL}
 }
 
-func (s *LoginService) handleExistingSession(ctx context.Context, user *storage.User, authRequestID, ipAddress, userAgent string, channel string) *LoginResult {
-	switch CheckAccess(user.Status, channel) {
+func (s *LoginService) handleExistingSession(ctx context.Context, user *storage.User, authRequestID, ipAddress, userAgent string) *LoginResult {
+	switch CheckAccess(user.Status, "browser") {
 	case AccessDeny:
 		s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status})
 		return &LoginResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
@@ -120,33 +110,24 @@ type CallbackResult struct {
 
 // HandleCallback processes GET /login/callback?code=xxx&state=authRequestID
 func (s *LoginService) HandleCallback(ctx context.Context, code, authRequestID, ipAddress, userAgent string) *CallbackResult {
-	return s.handleCallback(ctx, code, authRequestID, ipAddress, userAgent, "browser")
+	return s.handleCallback(ctx, code, authRequestID, ipAddress, userAgent)
 }
 
-// HandleMCPCallback processes GET /mcp/callback?code=xxx&state=authRequestID
-func (s *LoginService) HandleMCPCallback(ctx context.Context, code, authRequestID, ipAddress, userAgent string) *CallbackResult {
-	return s.handleCallback(ctx, code, authRequestID, ipAddress, userAgent, "mcp")
-}
-
-func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, ipAddress, userAgent string, channel string) *CallbackResult {
+func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, ipAddress, userAgent string) *CallbackResult {
 	if code == "" || authRequestID == "" {
 		return &CallbackResult{Action: ActionError, Error: "missing code or state", ErrorCode: http.StatusBadRequest}
 	}
 
 	// Exchange code for user info
-	userInfo, err := s.providerForChannel(channel).Exchange(ctx, code)
+	userInfo, err := s.browserProvider.Exchange(ctx, code)
 	if err != nil {
 		return &CallbackResult{Action: ActionError, Error: fmt.Sprintf("upstream_error: %v", err), ErrorCode: http.StatusInternalServerError}
 	}
 
 	// Look up user by provider identity
-	provider := s.providerForChannel(channel)
-	providerName := provider.Name()
+	providerName := s.browserProvider.Name()
 	user, err := s.store.GetUserByProviderIdentity(ctx, providerName, userInfo.Sub)
 	if errors.Is(err, storage.ErrNotFound) {
-		if channel != "browser" {
-			return &CallbackResult{Action: ActionError, Error: "account_not_found", ErrorCode: http.StatusForbidden}
-		}
 		// New user — signup
 		user, err = s.store.CreateUserWithIdentity(ctx,
 			userInfo.Email, userInfo.EmailVerified, userInfo.Name, userInfo.Picture,
@@ -162,13 +143,13 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 	} else if err != nil {
 		return &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
 	} else {
-		s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{"channel": channel})
+		s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{"channel": "browser"})
 	}
 
 	// Access check
-	switch CheckAccess(user.Status, channel) {
+	switch CheckAccess(user.Status, "browser") {
 	case AccessDeny:
-		s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": channel})
+		s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "browser"})
 		return &CallbackResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
 
 	case AccessRecover:
@@ -194,11 +175,4 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 	}
 
 	return &CallbackResult{Action: ActionAutoApprove, AuthRequestID: authRequestID, SessionID: sessionID}
-}
-
-func (s *LoginService) providerForChannel(channel string) upstream.Provider {
-	if channel == "mcp" {
-		return s.mcpProvider
-	}
-	return s.browserProvider
 }

--- a/internal/service/login_test.go
+++ b/internal/service/login_test.go
@@ -32,7 +32,7 @@ func setupLoginService(t *testing.T) (*LoginService, *storage.Storage) {
 		},
 	}
 
-	svc := NewLoginService(store, fakeProvider, fakeProvider, 24*time.Hour)
+	svc := NewLoginService(store, fakeProvider, 24*time.Hour)
 	return svc, store
 }
 
@@ -154,7 +154,7 @@ func TestHandleCallback_InactiveUser_Error(t *testing.T) {
 
 // browser-007 / E2E 6: 복구 후 auth_request 완료 실패 → 재시도 멱등성
 func TestBrowser007_RecoveryRetryIdempotent(t *testing.T) {
-	loginSvc, _, _, store, _, _ := setupGapTest(t)
+	loginSvc, _, _, _, store, _, _ := setupGapTest(t)
 	ctx := context.Background()
 
 	// Create user, then set to pending_deletion

--- a/internal/service/login_unit_test.go
+++ b/internal/service/login_unit_test.go
@@ -74,7 +74,7 @@ func TestLogin_HandleLogin_RecoversPendingDeletionSession(t *testing.T) {
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "s1"}}
-	svc := NewLoginService(store, provider, provider, 24*time.Hour)
+	svc := NewLoginService(store, provider, 24*time.Hour)
 
 	result := svc.HandleLogin(context.Background(), "ar-1", "sess-1", "127.0.0.1", "ua")
 
@@ -107,7 +107,7 @@ func TestLogin_HandleCallback_EmailConflict(t *testing.T) {
 			Name:          "Dup",
 		},
 	}
-	svc := NewLoginService(store, provider, provider, 24*time.Hour)
+	svc := NewLoginService(store, provider, 24*time.Hour)
 
 	result := svc.HandleCallback(context.Background(), "code", "ar-1", "127.0.0.1", "ua")
 
@@ -126,7 +126,7 @@ func TestLogin_HandleLogin_NoSession_Redirect(t *testing.T) {
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "s1"}}
-	svc := NewLoginService(store, provider, provider, 24*time.Hour)
+	svc := NewLoginService(store, provider, 24*time.Hour)
 
 	result := svc.HandleLogin(context.Background(), "ar-1", "sess-1", "127.0.0.1", "ua")
 

--- a/internal/service/mcp_test.go
+++ b/internal/service/mcp_test.go
@@ -17,7 +17,7 @@ import (
 // MCP uses dedicated login/callback paths and applies MCP channel policy.
 // These tests verify the MCP channel guard works correctly.
 
-func setupMCPTest(t *testing.T) (*LoginService, *storage.Storage) {
+func setupMCPTest(t *testing.T) (*MCPLoginService, *storage.Storage) {
 	t.Helper()
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
@@ -29,7 +29,7 @@ func setupMCPTest(t *testing.T) (*LoginService, *storage.Storage) {
 		User: &upstream.UserInfo{Sub: "mcp-sub-123", Email: "mcp@test.com", EmailVerified: true, Name: "MCP User"},
 	}
 
-	svc := NewLoginService(store, fakeProvider, fakeProvider, 24*time.Hour)
+	svc := NewMCPLoginService(store, fakeProvider, 24*time.Hour)
 	return svc, store
 }
 
@@ -40,7 +40,7 @@ func TestMCP_CompleteUser_AutoApprove(t *testing.T) {
 	store.CreateUserWithIdentity(ctx, "mcp-ok@test.com", true, "MCP", "", "google", "mcp-sub-123", "mcp@test.com")
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-ok")
 
-	result := svc.HandleMCPCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
+	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionAutoApprove {
 		t.Errorf("action = %v, want AutoApprove (MCP active user)", result.Action)
@@ -51,7 +51,7 @@ func TestMCP_NewUser_SignupRequired(t *testing.T) {
 	svc, _ := setupMCPTest(t)
 	ctx := context.Background()
 
-	result := svc.HandleMCPCallback(ctx, "fake-code", "req-mcp-new", "127.0.0.1", "mcp-client")
+	result := svc.HandleCallback(ctx, "fake-code", "req-mcp-new", "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error (MCP new user)", result.Action)
@@ -68,7 +68,7 @@ func TestMCP_DisabledUser_Rejected(t *testing.T) {
 	user, _ := store.CreateUserWithIdentity(ctx, "mcp-dis@test.com", true, "MCP", "", "google", "mcp-sub-123", "mcp@test.com")
 	store.DisableUser(ctx, user.ID)
 
-	result := svc.HandleMCPCallback(ctx, "fake-code", "req-mcp-dis", "127.0.0.1", "mcp-client")
+	result := svc.HandleCallback(ctx, "fake-code", "req-mcp-dis", "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error (disabled user)", result.Action)
@@ -87,7 +87,7 @@ func TestMCP005_Recoverable_Rejected(t *testing.T) {
 	store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-005")
-	result := svc.HandleMCPCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
+	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error (recoverable via MCP)", result.Action)
@@ -107,7 +107,7 @@ func TestMCPLogin_PendingDeletionSession_Rejected(t *testing.T) {
 	_ = store.SetUserStatus(ctx, user.ID, "pending_deletion")
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-login-pending")
 
-	result := svc.HandleMCPLogin(ctx, arID, sessionID, "127.0.0.1", "mcp-client")
+	result := svc.HandleLogin(ctx, arID, sessionID, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error", result.Action)
@@ -127,7 +127,7 @@ func TestMCPLogin_DeletedSession_Rejected(t *testing.T) {
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-login-deleted")
 
-	result := svc.HandleMCPLogin(ctx, arID, sessionID, "127.0.0.1", "mcp-client")
+	result := svc.HandleLogin(ctx, arID, sessionID, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error", result.Action)
@@ -146,7 +146,7 @@ func TestMCP_DeletedUser_Rejected(t *testing.T) {
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-deleted")
 
-	result := svc.HandleMCPCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
+	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error (deleted user)", result.Action)

--- a/internal/service/testhelpers_test.go
+++ b/internal/service/testhelpers_test.go
@@ -20,10 +20,10 @@ func setupBrowserExtTest(t *testing.T) (*LoginService, *storage.Storage) {
 	return setupLoginServiceWithSub(t, "browser-ext-sub", "browser-ext@test.com")
 }
 
-// setupMCPExtTest creates a LoginService with a configurable sub for MCP tests.
-func setupMCPExtTest(t *testing.T, sub string) (*LoginService, *storage.Storage) {
+// setupMCPExtTest creates an MCPLoginService with a configurable sub for MCP tests.
+func setupMCPExtTest(t *testing.T, sub string) (*MCPLoginService, *storage.Storage) {
 	t.Helper()
-	return setupLoginServiceWithSub(t, sub, sub+"@test.com")
+	return setupMCPLoginServiceWithSub(t, sub, sub+"@test.com")
 }
 
 // setupDeviceExtTest creates a DeviceService with a configurable sub.
@@ -54,7 +54,7 @@ func setupAccountExtTest(t *testing.T) (*AccountService, *storage.Storage) {
 }
 
 // setupGapTest creates all services for cross-service gap tests.
-func setupGapTest(t *testing.T) (*LoginService, *DeviceService, *AccountService, *storage.Storage, *sql.DB, *clock.FixedClock) {
+func setupGapTest(t *testing.T) (*LoginService, *MCPLoginService, *DeviceService, *AccountService, *storage.Storage, *sql.DB, *clock.FixedClock) {
 	t.Helper()
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
@@ -64,10 +64,11 @@ func setupGapTest(t *testing.T) (*LoginService, *DeviceService, *AccountService,
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: "gap-sub", Email: "gap@test.com", EmailVerified: true, Name: "Gap User"},
 	}
-	loginSvc := NewLoginService(store, fakeProvider, fakeProvider, 24*time.Hour)
+	loginSvc := NewLoginService(store, fakeProvider, 24*time.Hour)
+	mcpLoginSvc := NewMCPLoginService(store, fakeProvider, 24*time.Hour)
 	deviceSvc := NewDeviceService(store, fakeProvider, "http://localhost:8080", 24*time.Hour, clk)
 	accountSvc := NewAccountService(store)
-	return loginSvc, deviceSvc, accountSvc, store, db, clk
+	return loginSvc, mcpLoginSvc, deviceSvc, accountSvc, store, db, clk
 }
 
 // setupLoginServiceWithSub creates a LoginService with a specific upstream sub/email.
@@ -81,6 +82,21 @@ func setupLoginServiceWithSub(t *testing.T, sub, email string) (*LoginService, *
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: sub, Email: email, EmailVerified: true, Name: "Test User"},
 	}
-	svc := NewLoginService(store, fakeProvider, fakeProvider, 24*time.Hour)
+	svc := NewLoginService(store, fakeProvider, 24*time.Hour)
+	return svc, store
+}
+
+// setupMCPLoginServiceWithSub creates an MCPLoginService with a specific upstream sub/email.
+func setupMCPLoginServiceWithSub(t *testing.T, sub, email string) (*MCPLoginService, *storage.Storage) {
+	t.Helper()
+	db := testutil.SetupPostgres(t)
+	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
+	gen := idgen.CryptoGenerator{}
+	noopChecker := func(user *storage.User) error { return nil }
+	store := storage.New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
+		User: &upstream.UserInfo{Sub: sub, Email: email, EmailVerified: true, Name: "Test User"},
+	}
+	svc := NewMCPLoginService(store, fakeProvider, 24*time.Hour)
 	return svc, store
 }


### PR DESCRIPTION
## Summary
- make `LoginService` browser-only
  - remove MCP-specific fields/methods from `LoginService`
  - remove channel-switching helper (`providerForChannel`)
  - keep browser login/callback behavior unchanged
- update composition/wiring to pass only browser provider to `NewLoginService`
- migrate MCP-oriented tests/callers to use `MCPLoginService` directly
  - update `setupMCPExtTest` and add MCP helper wiring in shared test helpers
  - update E2E/gap/account/audit/mcp tests accordingly

## Why
- complete browser vs MCP service ownership split after #51/#52/#53
- remove remaining mixed-channel API surface from `LoginService`

## Validation
- `go test ./...` passed
