### PR TITLE
refactor(tests): use fixture structs instead of tuple setup returns

### DIFF
--- a/internal/service/account_test.go
+++ b/internal/service/account_test.go
@@ -15,7 +15,15 @@ import (
 	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
-func setupAccountTest(t *testing.T) (*AccountService, *LoginService, *storage.Storage, *sql.DB, *clock.FixedClock) {
+type accountFixture struct {
+	AccountSvc *AccountService
+	LoginSvc   *LoginService
+	Store      *storage.Storage
+	DB         *sql.DB
+	Clock      *clock.FixedClock
+}
+
+func setupAccountTest(t *testing.T) *accountFixture {
 	t.Helper()
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
@@ -29,7 +37,13 @@ func setupAccountTest(t *testing.T) (*AccountService, *LoginService, *storage.St
 
 	accountSvc := NewAccountService(store)
 	loginSvc := NewLoginService(store, fakeProvider, 24*time.Hour)
-	return accountSvc, loginSvc, store, db, clk
+	return &accountFixture{
+		AccountSvc: accountSvc,
+		LoginSvc:   loginSvc,
+		Store:      store,
+		DB:         db,
+		Clock:      clk,
+	}
 }
 
 // Helper: create user + session, return sessionID for deletion tests
@@ -48,31 +62,31 @@ func createUserWithSession(t *testing.T, store *storage.Storage, email, sub stri
 }
 
 func TestDeleteAccount_Success(t *testing.T) {
-	accountSvc, _, store, db, _ := setupAccountTest(t)
+	fx := setupAccountTest(t)
 	ctx := context.Background()
 
-	userID, sessionID := createUserWithSession(t, store, "delete@test.com", "del-sub")
+	userID, sessionID := createUserWithSession(t, fx.Store, "delete@test.com", "del-sub")
 
-	result := accountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
+	result := fx.AccountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
 	if !result.Success {
 		t.Fatalf("expected success, got: %s", result.Message)
 	}
 
 	var status string
-	db.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, userID).Scan(&status)
+	fx.DB.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, userID).Scan(&status)
 	if status != "pending_deletion" {
 		t.Errorf("status = %q, want pending_deletion", status)
 	}
 }
 
 func TestDeleteAccount_Idempotent(t *testing.T) {
-	accountSvc, _, store, _, _ := setupAccountTest(t)
+	fx := setupAccountTest(t)
 	ctx := context.Background()
 
-	_, sessionID := createUserWithSession(t, store, "idempotent@test.com", "idem-sub")
+	_, sessionID := createUserWithSession(t, fx.Store, "idempotent@test.com", "idem-sub")
 
-	accountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
-	result := accountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
+	fx.AccountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
+	result := fx.AccountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
 	if !result.Success {
 		t.Errorf("expected idempotent success, got: %s", result.Message)
 	}
@@ -89,14 +103,14 @@ func TestDeleteAccount_InactiveUser_Rejected(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accountSvc, _, store, _, _ := setupAccountTest(t)
+			fx := setupAccountTest(t)
 			ctx := context.Background()
 
-			_, sessionID := createUserWithSession(t, store, tt.name+"-del@test.com", tt.name+"-del-sub")
-			user, _ := store.GetValidSession(ctx, sessionID)
-			_ = store.SetUserStatus(ctx, user.ID, tt.status)
+			_, sessionID := createUserWithSession(t, fx.Store, tt.name+"-del@test.com", tt.name+"-del-sub")
+			user, _ := fx.Store.GetValidSession(ctx, sessionID)
+			_ = fx.Store.SetUserStatus(ctx, user.ID, tt.status)
 
-			result := accountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
+			result := fx.AccountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
 			if result.Success {
 				t.Fatalf("expected failure for %s user", tt.status)
 			}
@@ -108,10 +122,10 @@ func TestDeleteAccount_InactiveUser_Rejected(t *testing.T) {
 }
 
 func TestDeleteAccount_NoSession(t *testing.T) {
-	accountSvc, _, _, _, _ := setupAccountTest(t)
+	fx := setupAccountTest(t)
 	ctx := context.Background()
 
-	result := accountSvc.RequestDeletion(ctx, "", "127.0.0.1", "test")
+	result := fx.AccountSvc.RequestDeletion(ctx, "", "127.0.0.1", "test")
 	if result.Success {
 		t.Error("expected failure without session")
 	}
@@ -122,28 +136,28 @@ func TestDeleteAccount_NoSession(t *testing.T) {
 
 // E2E 4: 탈퇴 후 복구
 func TestE2E_DeleteThenRecover(t *testing.T) {
-	accountSvc, loginSvc, store, db, _ := setupAccountTest(t)
+	fx := setupAccountTest(t)
 	ctx := context.Background()
 
-	_, sessionID := createUserWithSession(t, store, "e2e4@test.com", "acct-sub-123")
-	user, _ := store.GetValidSession(ctx, sessionID)
+	_, sessionID := createUserWithSession(t, fx.Store, "e2e4@test.com", "acct-sub-123")
+	user, _ := fx.Store.GetValidSession(ctx, sessionID)
 
-	accountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
+	fx.AccountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
 
 	var status string
-	db.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
+	fx.DB.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
 	if status != "pending_deletion" {
 		t.Fatalf("status = %q, want pending_deletion", status)
 	}
 
-	arID, _ := store.CreateTestAuthRequest(ctx, "e2e4-recovery")
-	result := loginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test")
+	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e4-recovery")
+	result := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test")
 
 	if result.Action != ActionAutoApprove {
 		t.Errorf("action = %v, want AutoApprove (recovered)", result.Action)
 	}
 
-	db.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
+	fx.DB.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
 	if status != "active" {
 		t.Errorf("status after recovery = %q, want active", status)
 	}
@@ -151,21 +165,21 @@ func TestE2E_DeleteThenRecover(t *testing.T) {
 
 // E2E 5: 탈퇴 후 삭제 → 재가입
 func TestE2E_DeleteThenReregister(t *testing.T) {
-	accountSvc, loginSvc, store, db, clk := setupAccountTest(t)
+	fx := setupAccountTest(t)
 	ctx := context.Background()
 
-	userID, sessionID := createUserWithSession(t, store, "e2e5@test.com", "acct-sub-123")
+	userID, sessionID := createUserWithSession(t, fx.Store, "e2e5@test.com", "acct-sub-123")
 
-	accountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
+	fx.AccountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
 
-	db.ExecContext(ctx, `UPDATE users SET deletion_scheduled_at = $1 WHERE id = $2`,
-		clk.Now().Add(-1*time.Hour), userID)
+	fx.DB.ExecContext(ctx, `UPDATE users SET deletion_scheduled_at = $1 WHERE id = $2`,
+		fx.Clock.Now().Add(-1*time.Hour), userID)
 
-	cleanupSvc := NewCleanupService(storage.NewCleanupRunner(db), clk, time.Hour)
+	cleanupSvc := NewCleanupService(storage.NewCleanupRunner(fx.DB), fx.Clock, time.Hour)
 	cleanupSvc.RunOnce(ctx)
 
 	var dbStatus, email string
-	db.QueryRowContext(ctx, `SELECT status, email FROM users WHERE id = $1`, userID).Scan(&dbStatus, &email)
+	fx.DB.QueryRowContext(ctx, `SELECT status, email FROM users WHERE id = $1`, userID).Scan(&dbStatus, &email)
 	if dbStatus != "deleted" {
 		t.Fatalf("status = %q, want deleted", dbStatus)
 	}
@@ -173,8 +187,8 @@ func TestE2E_DeleteThenReregister(t *testing.T) {
 		t.Error("email should be scrubbed")
 	}
 
-	arID, _ := store.CreateTestAuthRequest(ctx, "e2e5-reregister")
-	result := loginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test")
+	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e5-reregister")
+	result := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test")
 
 	if result.Action != ActionAutoApprove {
 		t.Errorf("action = %v, want AutoApprove (new signup after deletion)", result.Action)
@@ -186,13 +200,13 @@ func TestE2E_DeleteThenReregister(t *testing.T) {
 
 // account-004: pending_deletion + Device/MCP → account_inactive
 func TestAccount004_PendingDeletion_DeviceRejected(t *testing.T) {
-	_, _, deviceSvc, _, store, _, _ := setupGapTest(t)
+	fx := setupGapTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "pd-device@test.com", true, "Test", "", "google", "gap-sub", "pd@test.com")
-	store.SetUserStatus(ctx, user.ID, "pending_deletion")
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, "pd-device@test.com", true, "Test", "", "google", "gap-sub", "pd@test.com")
+	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
-	result := deviceSvc.HandleDeviceCallback(ctx, "fake-code", "PD-CODE", "127.0.0.1", "test")
+	result := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "PD-CODE", "127.0.0.1", "test")
 	if result.Action != DeviceError {
 		t.Errorf("action = %v, want DeviceError (pending_deletion on device)", result.Action)
 	}
@@ -203,14 +217,14 @@ func TestAccount004_PendingDeletion_DeviceRejected(t *testing.T) {
 
 // account-004b: pending_deletion + MCP login → account_inactive
 func TestAccount004b_PendingDeletion_MCPRejected(t *testing.T) {
-	_, mcpLoginSvc, _, _, store, _, _ := setupGapTest(t)
+	fx := setupGapTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "pd-mcp@test.com", true, "Test", "", "google", "gap-sub", "pdm@test.com")
-	store.SetUserStatus(ctx, user.ID, "pending_deletion")
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, "pd-mcp@test.com", true, "Test", "", "google", "gap-sub", "pdm@test.com")
+	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
-	arID, _ := store.CreateTestAuthRequest(ctx, "pd-mcp")
-	result := mcpLoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
+	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "pd-mcp")
+	result := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error (pending_deletion via MCP)", result.Action)

--- a/internal/service/cleanup_test.go
+++ b/internal/service/cleanup_test.go
@@ -132,30 +132,30 @@ func TestCleanup_DeletionPIIScrub(t *testing.T) {
 
 // E2E 8: cleanup 롤백 — 중간 실패 시 데이터 일관성
 func TestE2E8_CleanupRollback(t *testing.T) {
-	_, _, _, _, store, db, clk := setupGapTest(t)
+	fx := setupGapTest(t)
 	ctx := context.Background()
 
 	// Create user set for deletion
-	user, _ := store.CreateUserWithIdentity(ctx, "rollback@test.com", true, "Test", "", "google", "rollback-sub", "rb@test.com")
-	db.ExecContext(ctx, `UPDATE users SET status='pending_deletion', deletion_scheduled_at=$1 WHERE id=$2`,
-		clk.Now().Add(-1*time.Hour), user.ID)
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, "rollback@test.com", true, "Test", "", "google", "rollback-sub", "rb@test.com")
+	fx.DB.ExecContext(ctx, `UPDATE users SET status='pending_deletion', deletion_scheduled_at=$1 WHERE id=$2`,
+		fx.Clock.Now().Add(-1*time.Hour), user.ID)
 
 	// Create child records that would be removed during cleanup.
-	sessionID, err := store.CreateSession(ctx, user.ID, 24*time.Hour)
+	sessionID, err := fx.Store.CreateSession(ctx, user.ID, 24*time.Hour)
 	if err != nil {
 		t.Fatalf("create session: %v", err)
 	}
-	_, err = db.ExecContext(ctx,
+	_, err = fx.DB.ExecContext(ctx,
 		`INSERT INTO refresh_tokens (id, token_hash, family_id, user_id, client_id, scopes, expires_at, created_at)
 		 VALUES (uuid_generate_v4(), $1, uuid_generate_v4(), $2, 'test-client', '{openid}', $3, $4)`,
-		"rollback-token-hash", user.ID, clk.Now().Add(30*24*time.Hour), clk.Now(),
+		"rollback-token-hash", user.ID, fx.Clock.Now().Add(30*24*time.Hour), fx.Clock.Now(),
 	)
 	if err != nil {
 		t.Fatalf("insert refresh token: %v", err)
 	}
 
 	simulatedErr := errors.New("simulated cleanup failure")
-	svc := NewCleanupService(storage.NewCleanupRunner(db), clk, time.Hour)
+	svc := NewCleanupService(storage.NewCleanupRunner(fx.DB), fx.Clock, time.Hour)
 	svc.deleteUserHook = func(ctx context.Context, userID string) error {
 		return simulatedErr
 	}
@@ -163,16 +163,16 @@ func TestE2E8_CleanupRollback(t *testing.T) {
 
 	// Verify everything rolled back: user is still pending_deletion, child records still exist.
 	var status string
-	db.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
+	fx.DB.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
 	if status != "pending_deletion" {
 		t.Fatalf("status = %q, want pending_deletion after rollback", status)
 	}
 
 	var identityCount, sessionCount, refreshCount, auditCount int
-	db.QueryRowContext(ctx, `SELECT count(*) FROM user_identities WHERE user_id = $1`, user.ID).Scan(&identityCount)
-	db.QueryRowContext(ctx, `SELECT count(*) FROM sessions WHERE id = $1 AND user_id = $2`, sessionID, user.ID).Scan(&sessionCount)
-	db.QueryRowContext(ctx, `SELECT count(*) FROM refresh_tokens WHERE user_id = $1`, user.ID).Scan(&refreshCount)
-	db.QueryRowContext(ctx, `SELECT count(*) FROM audit_log WHERE user_id = $1 AND event_type = 'auth.deletion_completed'`, user.ID).Scan(&auditCount)
+	fx.DB.QueryRowContext(ctx, `SELECT count(*) FROM user_identities WHERE user_id = $1`, user.ID).Scan(&identityCount)
+	fx.DB.QueryRowContext(ctx, `SELECT count(*) FROM sessions WHERE id = $1 AND user_id = $2`, sessionID, user.ID).Scan(&sessionCount)
+	fx.DB.QueryRowContext(ctx, `SELECT count(*) FROM refresh_tokens WHERE user_id = $1`, user.ID).Scan(&refreshCount)
+	fx.DB.QueryRowContext(ctx, `SELECT count(*) FROM audit_log WHERE user_id = $1 AND event_type = 'auth.deletion_completed'`, user.ID).Scan(&auditCount)
 
 	if identityCount != 1 {
 		t.Errorf("identity count = %d, want 1 after rollback", identityCount)

--- a/internal/service/e2e_test.go
+++ b/internal/service/e2e_test.go
@@ -17,7 +17,17 @@ import (
 	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
-func setupE2ETest(t *testing.T) (*LoginService, *MCPLoginService, *DeviceService, *AccountService, *storage.Storage, *sql.DB, *clock.FixedClock) {
+type e2eFixture struct {
+	LoginSvc    *LoginService
+	MCPLoginSvc *MCPLoginService
+	DeviceSvc   *DeviceService
+	AccountSvc  *AccountService
+	Store       *storage.Storage
+	DB          *sql.DB
+	Clock       *clock.FixedClock
+}
+
+func setupE2ETest(t *testing.T) *e2eFixture {
 	t.Helper()
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
@@ -38,7 +48,15 @@ func setupE2ETest(t *testing.T) (*LoginService, *MCPLoginService, *DeviceService
 	mcpLoginSvc := NewMCPLoginService(store, fakeProvider, 24*time.Hour)
 	deviceSvc := NewDeviceService(store, fakeProvider, "http://localhost:8080", 24*time.Hour, clk)
 	accountSvc := NewAccountService(store)
-	return loginSvc, mcpLoginSvc, deviceSvc, accountSvc, store, db, clk
+	return &e2eFixture{
+		LoginSvc:    loginSvc,
+		MCPLoginSvc: mcpLoginSvc,
+		DeviceSvc:   deviceSvc,
+		AccountSvc:  accountSvc,
+		Store:       store,
+		DB:          db,
+		Clock:       clk,
+	}
 }
 
 func createRefreshTokenForUser(t *testing.T, ctx context.Context, store *storage.Storage, userID string) string {
@@ -57,33 +75,33 @@ func createRefreshTokenForUser(t *testing.T, ctx context.Context, store *storage
 
 // E2E 1: 최초 가입 → 정상 사용 → Device/MCP 후속 채널
 func TestE2E1_SignupToAllChannels(t *testing.T) {
-	loginSvc, mcpLoginSvc, deviceSvc, _, store, _, clk := setupE2ETest(t)
+	fx := setupE2ETest(t)
 	ctx := context.Background()
 
 	// 1. Browser signup → auto-approve (no terms step)
-	arID1, _ := store.CreateTestAuthRequest(ctx, "e2e1-signup")
-	result := loginSvc.HandleCallback(ctx, "fake-code", arID1, "127.0.0.1", "browser")
+	arID1, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e1-signup")
+	result := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID1, "127.0.0.1", "browser")
 	if result.Action != ActionAutoApprove {
 		t.Fatalf("step 1: action = %v, want AutoApprove", result.Action)
 	}
 
 	// 2. Browser re-login → auto-approve
-	arID2, _ := store.CreateTestAuthRequest(ctx, "e2e1-relogin")
-	relogin := loginSvc.HandleCallback(ctx, "fake-code", arID2, "127.0.0.1", "browser")
+	arID2, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e1-relogin")
+	relogin := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID2, "127.0.0.1", "browser")
 	if relogin.Action != ActionAutoApprove {
 		t.Fatalf("step 2: action = %v, want AutoApprove", relogin.Action)
 	}
 
 	// 3. Device callback → should succeed (redirect back)
-	store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e1", "E2E1-CODE", clk.Now().Add(5*time.Minute), []string{"openid"})
-	devResult := deviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E1-CODE", "127.0.0.1", "cli")
+	fx.Store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e1", "E2E1-CODE", fx.Clock.Now().Add(5*time.Minute), []string{"openid"})
+	devResult := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E1-CODE", "127.0.0.1", "cli")
 	if devResult.Action != DeviceRedirectBack {
 		t.Fatalf("step 3: device action = %v, want RedirectBack", devResult.Action)
 	}
 
 	// 4. MCP → auto-approve
-	arID3, _ := store.CreateTestAuthRequest(ctx, "e2e1-mcp")
-	mcpResult := mcpLoginSvc.HandleCallback(ctx, "fake-code", arID3, "127.0.0.1", "mcp-client")
+	arID3, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e1-mcp")
+	mcpResult := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arID3, "127.0.0.1", "mcp-client")
 	if mcpResult.Action != ActionAutoApprove {
 		t.Fatalf("step 4: mcp action = %v, want AutoApprove", mcpResult.Action)
 	}
@@ -94,39 +112,39 @@ func TestE2E1_SignupToAllChannels(t *testing.T) {
 // Device/MCP 로그인을 시도하면 account_not_found로 차단된다.
 // Browser로 가입 완료 후에는 모든 채널이 정상 동작해야 한다.
 func TestE2E2_SignupAbandonAndReturn(t *testing.T) {
-	loginSvc, mcpLoginSvc, deviceSvc, _, store, _, clk := setupE2ETest(t)
+	fx := setupE2ETest(t)
 	ctx := context.Background()
 
 	// Step 2/3: 유저 DB 없음 → Device/MCP 차단 (account_not_found)
-	store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e2", "E2E2-DCODE", clk.Now().Add(5*time.Minute), []string{"openid"})
-	devResult := deviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E2-DCODE", "127.0.0.1", "cli")
+	fx.Store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e2", "E2E2-DCODE", fx.Clock.Now().Add(5*time.Minute), []string{"openid"})
+	devResult := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E2-DCODE", "127.0.0.1", "cli")
 	if devResult.Action != DeviceError {
 		t.Fatalf("device before signup: action=%v, want DeviceError", devResult.Action)
 	}
 
-	arIDMCP, _ := store.CreateTestAuthRequest(ctx, "e2e2-mcp-pre")
-	mcpResult := mcpLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP, "127.0.0.1", "mcp")
+	arIDMCP, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e2-mcp-pre")
+	mcpResult := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP, "127.0.0.1", "mcp")
 	if mcpResult.Action != ActionError {
 		t.Fatalf("mcp before signup: action=%v, want ActionError", mcpResult.Action)
 	}
 
 	// Step 3: Browser 완료 → 가입 (새 유저 생성)
-	arIDBrowser, _ := store.CreateTestAuthRequest(ctx, "e2e2-browser")
-	browserResult := loginSvc.HandleCallback(ctx, "fake-code", arIDBrowser, "127.0.0.1", "browser")
+	arIDBrowser, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e2-browser")
+	browserResult := fx.LoginSvc.HandleCallback(ctx, "fake-code", arIDBrowser, "127.0.0.1", "browser")
 	if browserResult.Action != ActionAutoApprove {
 		t.Fatalf("browser signup: action=%v, want ActionAutoApprove", browserResult.Action)
 	}
 
 	// 가입 후 Device 정상 동작
-	store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e2-ok", "E2E2-DCODE2", clk.Now().Add(5*time.Minute), []string{"openid"})
-	devResult2 := deviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E2-DCODE2", "127.0.0.1", "cli")
+	fx.Store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e2-ok", "E2E2-DCODE2", fx.Clock.Now().Add(5*time.Minute), []string{"openid"})
+	devResult2 := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E2-DCODE2", "127.0.0.1", "cli")
 	if devResult2.Action != DeviceRedirectBack {
 		t.Fatalf("device after signup: action=%v, want DeviceRedirectBack", devResult2.Action)
 	}
 
 	// 가입 후 MCP 정상 동작
-	arIDMCP2, _ := store.CreateTestAuthRequest(ctx, "e2e2-mcp-post")
-	mcpResult2 := mcpLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP2, "127.0.0.1", "mcp")
+	arIDMCP2, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e2-mcp-post")
+	mcpResult2 := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP2, "127.0.0.1", "mcp")
 	if mcpResult2.Action != ActionAutoApprove {
 		t.Fatalf("mcp after signup: action=%v, want ActionAutoApprove", mcpResult2.Action)
 	}
@@ -134,61 +152,61 @@ func TestE2E2_SignupAbandonAndReturn(t *testing.T) {
 
 // E2E 4: 탈퇴 후 복구
 func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
-	loginSvc, mcpLoginSvc, deviceSvc, accountSvc, store, db, clk := setupE2ETest(t)
+	fx := setupE2ETest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "e2e4-full@test.com", true, "Test", "", "google", "e2e-sub", "e2e4-full@test.com")
-	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
-	refreshToken := createRefreshTokenForUser(t, ctx, store, user.ID)
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, "e2e4-full@test.com", true, "Test", "", "google", "e2e-sub", "e2e4-full@test.com")
+	sessionID, _ := fx.Store.CreateSession(ctx, user.ID, 24*time.Hour)
+	refreshToken := createRefreshTokenForUser(t, ctx, fx.Store, user.ID)
 
 	// 1. DELETE /account -> pending_deletion
-	result := accountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
+	result := fx.AccountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
 	if !result.Success {
 		t.Fatalf("step 1: deletion request failed: %s", result.Message)
 	}
 	var status string
-	db.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
+	fx.DB.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
 	if status != "pending_deletion" {
 		t.Fatalf("step 1: status = %q, want pending_deletion", status)
 	}
 
 	// 2. Refresh should fail immediately
-	_, err := store.TokenRequestByRefreshToken(ctx, refreshToken)
+	_, err := fx.Store.TokenRequestByRefreshToken(ctx, refreshToken)
 	if err == nil || !strings.Contains(err.Error(), "invalid_refresh_token") {
 		t.Fatalf("step 2: refresh should fail with invalid_refresh_token, got err=%v", err)
 	}
 
 	// 3. Device/MCP should be rejected
-	store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e4", "E2E4-CODE", clk.Now().Add(5*time.Minute), []string{"openid"})
-	devResult := deviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E4-CODE", "127.0.0.1", "cli")
+	fx.Store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e4", "E2E4-CODE", fx.Clock.Now().Add(5*time.Minute), []string{"openid"})
+	devResult := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E4-CODE", "127.0.0.1", "cli")
 	if devResult.Action != DeviceError || devResult.ErrorCode != 403 {
 		t.Fatalf("step 3: device should reject pending_deletion user, got action=%v code=%d", devResult.Action, devResult.ErrorCode)
 	}
-	arIDMCP, _ := store.CreateTestAuthRequest(ctx, "e2e4-mcp")
-	mcpResult := mcpLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP, "127.0.0.1", "mcp-client")
+	arIDMCP, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e4-mcp")
+	mcpResult := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP, "127.0.0.1", "mcp-client")
 	if mcpResult.Action != ActionError || mcpResult.ErrorCode != 403 {
 		t.Fatalf("step 3: mcp should reject pending_deletion user, got action=%v code=%d", mcpResult.Action, mcpResult.ErrorCode)
 	}
 
 	// 4. Browser login recovers
-	arIDBrowser, _ := store.CreateTestAuthRequest(ctx, "e2e4-browser")
-	recoverResult := loginSvc.HandleCallback(ctx, "fake-code", arIDBrowser, "127.0.0.1", "browser")
+	arIDBrowser, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e4-browser")
+	recoverResult := fx.LoginSvc.HandleCallback(ctx, "fake-code", arIDBrowser, "127.0.0.1", "browser")
 	if recoverResult.Action != ActionAutoApprove {
 		t.Fatalf("step 4: browser recovery action = %v, want AutoApprove", recoverResult.Action)
 	}
 
 	// 5. After recovery, refresh/device/mcp work again
-	newRefreshToken := createRefreshTokenForUser(t, ctx, store, user.ID)
-	if _, err := store.TokenRequestByRefreshToken(ctx, newRefreshToken); err != nil {
+	newRefreshToken := createRefreshTokenForUser(t, ctx, fx.Store, user.ID)
+	if _, err := fx.Store.TokenRequestByRefreshToken(ctx, newRefreshToken); err != nil {
 		t.Fatalf("step 5: refresh should succeed after recovery, got err=%v", err)
 	}
-	store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e4-ok", "E2E4-OK", clk.Now().Add(5*time.Minute), []string{"openid"})
-	devResult2 := deviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E4-OK", "127.0.0.1", "cli")
+	fx.Store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e4-ok", "E2E4-OK", fx.Clock.Now().Add(5*time.Minute), []string{"openid"})
+	devResult2 := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E4-OK", "127.0.0.1", "cli")
 	if devResult2.Action != DeviceRedirectBack {
 		t.Fatalf("step 5: device should succeed after recovery, got action=%v", devResult2.Action)
 	}
-	arIDMCP2, _ := store.CreateTestAuthRequest(ctx, "e2e4-mcp-ok")
-	mcpResult2 := mcpLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP2, "127.0.0.1", "mcp-client")
+	arIDMCP2, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e4-mcp-ok")
+	mcpResult2 := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP2, "127.0.0.1", "mcp-client")
 	if mcpResult2.Action != ActionAutoApprove {
 		t.Fatalf("step 5: mcp should succeed after recovery, got action=%v", mcpResult2.Action)
 	}
@@ -196,34 +214,34 @@ func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
 
 // E2E 5: 복구 후 로그인 완료 실패가 발생해도 다음 재시도에서 정상 완료되어야 한다.
 func TestE2E5_RecoveryThenAuthRequestRetry(t *testing.T) {
-	loginSvc, _, _, accountSvc, store, db, _ := setupE2ETest(t)
+	fx := setupE2ETest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "e2e5-retry@test.com", true, "Retry User", "", "google", "e2e-sub", "e2e5-retry@test.com")
-	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, "e2e5-retry@test.com", true, "Retry User", "", "google", "e2e-sub", "e2e5-retry@test.com")
+	sessionID, _ := fx.Store.CreateSession(ctx, user.ID, 24*time.Hour)
 
 	// 1) pending_deletion 전환
-	del := accountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
+	del := fx.AccountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
 	if !del.Success {
 		t.Fatalf("deletion request failed: %s", del.Message)
 	}
 
 	// 2) Browser callback 시도하되 존재하지 않는 authRequestID로 완료 단계 실패 유도
-	first := loginSvc.HandleCallback(ctx, "fake-code", "missing-auth-request", "127.0.0.1", "browser")
+	first := fx.LoginSvc.HandleCallback(ctx, "fake-code", "missing-auth-request", "127.0.0.1", "browser")
 	if first.Action != ActionError {
 		t.Fatalf("first action = %v, want ActionError", first.Action)
 	}
 
 	// 복구는 선행되므로 status는 active여야 한다.
 	var status string
-	db.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
+	fx.DB.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
 	if status != "active" {
 		t.Fatalf("status after failed completion = %q, want active", status)
 	}
 
 	// 3) 정상 authRequest로 재시도 시 성공해야 한다.
-	arID, _ := store.CreateTestAuthRequest(ctx, "e2e5-retry")
-	second := loginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "browser")
+	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e5-retry")
+	second := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "browser")
 	if second.Action != ActionAutoApprove {
 		t.Fatalf("second action = %v, want ActionAutoApprove", second.Action)
 	}

--- a/internal/service/login_test.go
+++ b/internal/service/login_test.go
@@ -154,28 +154,28 @@ func TestHandleCallback_InactiveUser_Error(t *testing.T) {
 
 // browser-007 / E2E 6: 복구 후 auth_request 완료 실패 → 재시도 멱등성
 func TestBrowser007_RecoveryRetryIdempotent(t *testing.T) {
-	loginSvc, _, _, _, store, _, _ := setupGapTest(t)
+	fx := setupGapTest(t)
 	ctx := context.Background()
 
 	// Create user, then set to pending_deletion
-	user, _ := store.CreateUserWithIdentity(ctx, "retry@test.com", true, "Test", "", "google", "gap-sub", "r@test.com")
-	store.SetUserStatus(ctx, user.ID, "pending_deletion")
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, "retry@test.com", true, "Test", "", "google", "gap-sub", "r@test.com")
+	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	// First attempt: recovery succeeds, but use an invalid authRequestID so CompleteAuthRequest fails
-	result1 := loginSvc.HandleCallback(ctx, "fake-code", "invalid-ar-id", "127.0.0.1", "browser")
+	result1 := fx.LoginSvc.HandleCallback(ctx, "fake-code", "invalid-ar-id", "127.0.0.1", "browser")
 	// Recovery happened (user is now active), but auth_request completion may fail
 	// The important thing: user is recovered
 
 	// Verify user is active (recovery persisted even if auth_request failed)
 	var status string
-	store.DB().QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
+	fx.Store.DB().QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
 	if status != "active" {
 		t.Fatalf("user should be active after recovery, got %q", status)
 	}
 
 	// Second attempt: retry login → should succeed normally (idempotent)
-	arID, _ := store.CreateTestAuthRequest(ctx, "retry")
-	result2 := loginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "browser")
+	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "retry")
+	result2 := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "browser")
 	if result2.Action != ActionAutoApprove {
 		t.Errorf("retry action = %v, want AutoApprove (recovery already done)", result2.Action)
 	}

--- a/internal/service/testhelpers_test.go
+++ b/internal/service/testhelpers_test.go
@@ -14,6 +14,16 @@ import (
 	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
+type gapFixture struct {
+	LoginSvc    *LoginService
+	MCPLoginSvc *MCPLoginService
+	DeviceSvc   *DeviceService
+	AccountSvc  *AccountService
+	Store       *storage.Storage
+	DB          *sql.DB
+	Clock       *clock.FixedClock
+}
+
 // setupBrowserExtTest creates a LoginService with a fixed sub for browser extended tests.
 func setupBrowserExtTest(t *testing.T) (*LoginService, *storage.Storage) {
 	t.Helper()
@@ -54,7 +64,7 @@ func setupAccountExtTest(t *testing.T) (*AccountService, *storage.Storage) {
 }
 
 // setupGapTest creates all services for cross-service gap tests.
-func setupGapTest(t *testing.T) (*LoginService, *MCPLoginService, *DeviceService, *AccountService, *storage.Storage, *sql.DB, *clock.FixedClock) {
+func setupGapTest(t *testing.T) *gapFixture {
 	t.Helper()
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
@@ -68,7 +78,15 @@ func setupGapTest(t *testing.T) (*LoginService, *MCPLoginService, *DeviceService
 	mcpLoginSvc := NewMCPLoginService(store, fakeProvider, 24*time.Hour)
 	deviceSvc := NewDeviceService(store, fakeProvider, "http://localhost:8080", 24*time.Hour, clk)
 	accountSvc := NewAccountService(store)
-	return loginSvc, mcpLoginSvc, deviceSvc, accountSvc, store, db, clk
+	return &gapFixture{
+		LoginSvc:    loginSvc,
+		MCPLoginSvc: mcpLoginSvc,
+		DeviceSvc:   deviceSvc,
+		AccountSvc:  accountSvc,
+		Store:       store,
+		DB:          db,
+		Clock:       clk,
+	}
 }
 
 // setupLoginServiceWithSub creates a LoginService with a specific upstream sub/email.


### PR DESCRIPTION
## Summary
- replace high-arity tuple setup returns with fixture structs in service integration tests
  - `setupGapTest` -> `*gapFixture`
  - `setupE2ETest` -> `*e2eFixture`
  - `setupAccountTest` -> `*accountFixture`
- migrate call sites from positional unpacking (`_, _, _, ...`) to named fixture fields
- keep existing test behavior unchanged while improving readability and change-safety

## Why
- eliminate brittle positional return unpacking patterns that are hard to maintain
- reduce accidental coupling to return order as fixtures evolve

## Validation
- `go test ./...` passed
