### PR TITLE
refactor: use CreateUserWithIdentityInput across storage and services

### DIFF
--- a/internal/integration/integration_account_test.go
+++ b/internal/integration/integration_account_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/kangheeyong/authgate/internal/storage"
 )
 
 func TestIntegration_DeleteAccount_WrongOrigin_Rejected(t *testing.T) {

--- a/internal/integration/integration_account_test.go
+++ b/internal/integration/integration_account_test.go
@@ -16,7 +16,7 @@ func TestIntegration_DeleteAccount_WrongOrigin_Rejected(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user + get session
-	user, _ := ts.Store.CreateUserWithIdentity(ctx, "origin-test@test.com", true, "Test", "", "google", "test-google-sub", "o@test.com")
+	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "origin-test@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "o@test.com"})
 	sessionID, _ := ts.Store.CreateSession(ctx, user.ID, 24*3600*1e9)
 
 	req, _ := http.NewRequest("DELETE", ts.BaseURL+"/account", nil)
@@ -49,7 +49,7 @@ func TestIntegration_DeleteAccount_InactiveUser_Rejected(t *testing.T) {
 			ts := SetupTestServer(t)
 			ctx := context.Background()
 
-			user, err := ts.Store.CreateUserWithIdentity(ctx, "inactive-delete-"+tt.name+"@test.com", true, "Inactive Delete", "", "google", "inactive-delete-sub-"+tt.name, "inactive-delete-"+tt.name+"@test.com")
+			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "inactive-delete-"+tt.name+"@test.com", EmailVerified: true, Name: "Inactive Delete", AvatarURL: "", Provider: "google", ProviderUserID: "inactive-delete-sub-"+tt.name, ProviderEmail: "inactive-delete-"+tt.name+"@test.com"})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}
@@ -93,7 +93,7 @@ func TestIntegration_DeleteAccount_ResponseShape(t *testing.T) {
 	ts := SetupTestServer(t)
 	ctx := context.Background()
 
-	user, _ := ts.Store.CreateUserWithIdentity(ctx, "shape@test.com", true, "Shape", "", "google", "shape-sub", "shape@test.com")
+	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "shape@test.com", EmailVerified: true, Name: "Shape", AvatarURL: "", Provider: "google", ProviderUserID: "shape-sub", ProviderEmail: "shape@test.com"})
 	sessionID, _ := ts.Store.CreateSession(ctx, user.ID, 24*3600*1e9)
 
 	req, _ := http.NewRequest(http.MethodDelete, ts.BaseURL+"/account", nil)

--- a/internal/integration/integration_device_test.go
+++ b/internal/integration/integration_device_test.go
@@ -34,7 +34,7 @@ func TestIntegration_DeviceCallback_PendingDeletion_Rejected(t *testing.T) {
 	ts := SetupTestServer(t)
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, "device-pending@test.com", true, "Device Pending", "", "google", "test-google-sub", "device-pending@test.com")
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-pending@test.com", EmailVerified: true, Name: "Device Pending", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-pending@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestIntegration_DeviceConsumed_RePolling(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user and approve device code
-	user, _ := ts.Store.CreateUserWithIdentity(ctx, "device-consumed@test.com", true, "Test", "", "google", "device-consumed-sub", "dc@test.com")
+	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-consumed@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-consumed-sub", ProviderEmail: "dc@test.com"})
 	_ = user
 
 	// Store a device code and approve it
@@ -95,7 +95,7 @@ func TestIntegration_DeviceFullFlow_TokenIssued(t *testing.T) {
 	ts := SetupTestServer(t)
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, "device-ok@test.com", true, "Device OK", "", "google", "test-google-sub", "device-ok@test.com")
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-ok@test.com", EmailVerified: true, Name: "Device OK", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-ok@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestIntegration_DeviceConcurrentPolling_ExactlyOneSuccess(t *testing.T) {
 	ts := SetupTestServer(t)
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, "device-race@test.com", true, "Device Race", "", "google", "test-google-sub", "device-race@test.com")
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-race@test.com", EmailVerified: true, Name: "Device Race", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-race@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}

--- a/internal/integration/integration_device_test.go
+++ b/internal/integration/integration_device_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/kangheeyong/authgate/internal/storage"
 )
 
 func TestIntegration_DeviceCallback_NewUser_Rejected(t *testing.T) {

--- a/internal/integration/integration_mcp_test.go
+++ b/internal/integration/integration_mcp_test.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/kangheeyong/authgate/internal/storage"
 )
 
 func TestIntegration_MCPTokenExchange_NoPKCE_Rejected(t *testing.T) {

--- a/internal/integration/integration_mcp_test.go
+++ b/internal/integration/integration_mcp_test.go
@@ -16,7 +16,7 @@ func TestIntegration_MCPTokenExchange_NoPKCE_Rejected(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, "mcp-pkce@test.com", true, "MCP PKCE", "", "google", "test-google-sub", "mcp-pkce@test.com")
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-pkce@test.com", EmailVerified: true, Name: "MCP PKCE", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-pkce@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestIntegration_MCPTokenExchange_MissingResource_Rejected(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	if _, err := ts.Store.CreateUserWithIdentity(ctx, "mcp-missing-resource@test.com", true, "MCP Missing Resource", "", "google", "test-google-sub", "mcp-missing-resource@test.com"); err != nil {
+	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-missing-resource@test.com", EmailVerified: true, Name: "MCP Missing Resource", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-missing-resource@test.com"}); err != nil {
 		t.Fatalf("create user: %v", err)
 	}
 
@@ -71,7 +71,7 @@ func TestIntegration_MCPRefresh_MismatchedResource_Rejected(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	if _, err := ts.Store.CreateUserWithIdentity(ctx, "mcp-refresh-resource@test.com", true, "MCP Refresh Resource", "", "google", "test-google-sub", "mcp-refresh-resource@test.com"); err != nil {
+	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-refresh-resource@test.com", EmailVerified: true, Name: "MCP Refresh Resource", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-refresh-resource@test.com"}); err != nil {
 		t.Fatalf("create user: %v", err)
 	}
 
@@ -96,7 +96,7 @@ func TestIntegration_MCPAccessToken_AudienceBoundToResource(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	if _, err := ts.Store.CreateUserWithIdentity(ctx, "mcp-audience@test.com", true, "MCP Audience", "", "google", "test-google-sub", "mcp-audience@test.com"); err != nil {
+	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-audience@test.com", EmailVerified: true, Name: "MCP Audience", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-audience@test.com"}); err != nil {
 		t.Fatalf("create user: %v", err)
 	}
 
@@ -136,7 +136,7 @@ func TestIntegration_MCPCodeExchange_StateChange_InvalidGrant(t *testing.T) {
 			client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 
 			ctx := context.Background()
-			user, err := ts.Store.CreateUserWithIdentity(ctx, "mcp-token-state@test.com", true, "MCP Token", "", "google", "test-google-sub", "mcp-token-state@test.com")
+			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-token-state@test.com", EmailVerified: true, Name: "MCP Token", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-token-state@test.com"})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}
@@ -182,7 +182,7 @@ func TestIntegration_MCPCallback_PendingDeletion_Rejected(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, "mcp-callback-pending@test.com", true, "MCP Callback Pending", "", "google", "test-google-sub", "mcp-callback-pending@test.com")
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-callback-pending@test.com", EmailVerified: true, Name: "MCP Callback Pending", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-callback-pending@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}

--- a/internal/service/account_test.go
+++ b/internal/service/account_test.go
@@ -50,7 +50,7 @@ func setupAccountTest(t *testing.T) *accountFixture {
 func createUserWithSession(t *testing.T, store *storage.Storage, email, sub string) (string, string) {
 	t.Helper()
 	ctx := context.Background()
-	user, err := store.CreateUserWithIdentity(ctx, email, true, "Test", "", "google", sub, email)
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: sub, ProviderEmail: email})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestAccount004_PendingDeletion_DeviceRejected(t *testing.T) {
 	fx := setupGapTest(t)
 	ctx := context.Background()
 
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, "pd-device@test.com", true, "Test", "", "google", "gap-sub", "pd@test.com")
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pd-device@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "pd@test.com"})
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	result := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "PD-CODE", "127.0.0.1", "test")
@@ -220,7 +220,7 @@ func TestAccount004b_PendingDeletion_MCPRejected(t *testing.T) {
 	fx := setupGapTest(t)
 	ctx := context.Background()
 
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, "pd-mcp@test.com", true, "Test", "", "google", "gap-sub", "pdm@test.com")
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pd-mcp@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "pdm@test.com"})
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "pd-mcp")

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -83,7 +83,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		svc, store := setupBrowserExtTest(t)
 		ctx := context.Background()
 
-		user, err := store.CreateUserWithIdentity(ctx, "audit-browser@test.com", true, "Browser", "", "google", "browser-ext-sub", "audit-browser@test.com")
+		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-browser@test.com", EmailVerified: true, Name: "Browser", AvatarURL: "", Provider: "google", ProviderUserID: "browser-ext-sub", ProviderEmail: "audit-browser@test.com"})
 		if err != nil {
 			t.Fatalf("create user: %v", err)
 		}
@@ -104,7 +104,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		svc, store, _ := setupDeviceExtTest(t, "audit-device-sub")
 		ctx := context.Background()
 
-		user, err := store.CreateUserWithIdentity(ctx, "audit-device@test.com", true, "Device", "", "google", "audit-device-sub", "audit-device@test.com")
+		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device@test.com", EmailVerified: true, Name: "Device", AvatarURL: "", Provider: "google", ProviderUserID: "audit-device-sub", ProviderEmail: "audit-device@test.com"})
 		if err != nil {
 			t.Fatalf("create user: %v", err)
 		}
@@ -124,7 +124,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		svc, store := setupMCPExtTest(t, "audit-mcp-sub")
 		ctx := context.Background()
 
-		user, err := store.CreateUserWithIdentity(ctx, "audit-mcp@test.com", true, "MCP", "", "google", "audit-mcp-sub", "audit-mcp@test.com")
+		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp@test.com", EmailVerified: true, Name: "MCP", AvatarURL: "", Provider: "google", ProviderUserID: "audit-mcp-sub", ProviderEmail: "audit-mcp@test.com"})
 		if err != nil {
 			t.Fatalf("create user: %v", err)
 		}
@@ -146,7 +146,7 @@ func TestAudit004_DeviceApproved(t *testing.T) {
 	svc, store, clk := setupDeviceService(t)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, "audit-approve@test.com", true, "Approve", "", "google", "device-sub-123", "audit-approve@test.com")
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-approve@test.com", EmailVerified: true, Name: "Approve", AvatarURL: "", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "audit-approve@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestAudit005_DeviceDenied(t *testing.T) {
 	svc, store, clk := setupDeviceService(t)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, "audit-deny@test.com", true, "Deny", "", "google", "device-sub-123", "audit-deny@test.com")
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-deny@test.com", EmailVerified: true, Name: "Deny", AvatarURL: "", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "audit-deny@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestAudit006_DeletionRequested(t *testing.T) {
 	svc, store := setupAccountExtTest(t)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, "audit-delete@test.com", true, "Delete", "", "google", "audit-delete-sub", "audit-delete@test.com")
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-delete@test.com", EmailVerified: true, Name: "Delete", AvatarURL: "", Provider: "google", ProviderUserID: "audit-delete-sub", ProviderEmail: "audit-delete@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -205,7 +205,7 @@ func TestAudit007_DeletionCancelled(t *testing.T) {
 	svc, store := setupLoginService(t)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, "audit-recover@test.com", true, "Recover", "", "google", "google-sub-123", "audit-recover@test.com")
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-recover@test.com", EmailVerified: true, Name: "Recover", AvatarURL: "", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "audit-recover@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestAudit009_InactiveUser(t *testing.T) {
 			svc, store := setupLoginService(t)
 			ctx := context.Background()
 
-			user, err := store.CreateUserWithIdentity(ctx, "audit-inactive-"+tt.name+"@test.com", true, "Inactive", "", "google", "google-sub-123", "audit-inactive@test.com")
+			user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-inactive-"+tt.name+"@test.com", EmailVerified: true, Name: "Inactive", AvatarURL: "", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "audit-inactive@test.com"})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}
@@ -261,7 +261,7 @@ func TestAuditSecurity003_DeviceInactiveUser(t *testing.T) {
 	svc, store, _ := setupDeviceExtTest(t, "audit-device-inactive-sub")
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, "audit-device-inactive@test.com", true, "Inactive Device", "", "google", "audit-device-inactive-sub", "audit-device-inactive@test.com")
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-inactive@test.com", EmailVerified: true, Name: "Inactive Device", AvatarURL: "", Provider: "google", ProviderUserID: "audit-device-inactive-sub", ProviderEmail: "audit-device-inactive@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -284,7 +284,7 @@ func TestAuditSecurity_DevicePendingDeletionInactiveUser(t *testing.T) {
 	svc, store, _ := setupDeviceExtTest(t, "audit-device-pending-sub")
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, "audit-device-pending@test.com", true, "Pending Device", "", "google", "audit-device-pending-sub", "audit-device-pending@test.com")
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-pending@test.com", EmailVerified: true, Name: "Pending Device", AvatarURL: "", Provider: "google", ProviderUserID: "audit-device-pending-sub", ProviderEmail: "audit-device-pending@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -321,7 +321,7 @@ func TestAuditSecurity_MCPInactiveUser_Metadata(t *testing.T) {
 			svc, store := setupMCPExtTest(t, "audit-mcp-"+tt.name+"-sub")
 			ctx := context.Background()
 
-			user, err := store.CreateUserWithIdentity(ctx, "audit-mcp-"+tt.name+"@test.com", true, "MCP Inactive", "", "google", "audit-mcp-"+tt.name+"-sub", "audit-mcp-"+tt.name+"@test.com")
+			user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp-"+tt.name+"@test.com", EmailVerified: true, Name: "MCP Inactive", AvatarURL: "", Provider: "google", ProviderUserID: "audit-mcp-"+tt.name+"-sub", ProviderEmail: "audit-mcp-"+tt.name+"@test.com"})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}

--- a/internal/service/cleanup_test.go
+++ b/internal/service/cleanup_test.go
@@ -30,7 +30,7 @@ func TestCleanup_ExpiredSessions(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user + expired session
-	user, _ := store.CreateUserWithIdentity(ctx, "cleanup-session@test.com", true, "Test", "", "google", "cleanup-session-sub", "c@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "cleanup-session@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "cleanup-session-sub", ProviderEmail: "c@test.com"})
 	db.ExecContext(ctx,
 		`INSERT INTO sessions (id, user_id, expires_at, created_at) VALUES (uuid_generate_v4(), $1, $2, $3)`,
 		user.ID, clk.Now().Add(-1*time.Hour), clk.Now().Add(-25*time.Hour), // expired 1 hour ago
@@ -85,7 +85,7 @@ func TestCleanup_DeletionPIIScrub(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user, then set to pending_deletion with past scheduled date
-	user, _ := store.CreateUserWithIdentity(ctx, "delete-me@test.com", true, "Delete Me", "", "google", "delete-sub", "d@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "delete-me@test.com", EmailVerified: true, Name: "Delete Me", AvatarURL: "", Provider: "google", ProviderUserID: "delete-sub", ProviderEmail: "d@test.com"})
 	db.ExecContext(ctx,
 		`UPDATE users SET status = 'pending_deletion', deletion_scheduled_at = $1 WHERE id = $2`,
 		clk.Now().Add(-1*time.Hour), user.ID, // scheduled in the past
@@ -136,7 +136,7 @@ func TestE2E8_CleanupRollback(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user set for deletion
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, "rollback@test.com", true, "Test", "", "google", "rollback-sub", "rb@test.com")
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "rollback@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "rollback-sub", ProviderEmail: "rb@test.com"})
 	fx.DB.ExecContext(ctx, `UPDATE users SET status='pending_deletion', deletion_scheduled_at=$1 WHERE id=$2`,
 		fx.Clock.Now().Add(-1*time.Hour), user.ID)
 
@@ -193,7 +193,7 @@ func TestCleanup_DeletionPIIScrub_Idempotent(t *testing.T) {
 	db, store, clk := setupCleanupTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "cleanup-idem@test.com", true, "Idem", "", "google", "cleanup-idem-sub", "cleanup-idem@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "cleanup-idem@test.com", EmailVerified: true, Name: "Idem", AvatarURL: "", Provider: "google", ProviderUserID: "cleanup-idem-sub", ProviderEmail: "cleanup-idem@test.com"})
 	db.ExecContext(ctx,
 		`UPDATE users SET status = 'pending_deletion', deletion_scheduled_at = $1 WHERE id = $2`,
 		clk.Now().Add(-1*time.Hour), user.ID,

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -79,7 +79,7 @@ func TestDevicePage_ValidCode_WithSession_ShowApprove(t *testing.T) {
 	ctx := context.Background()
 
 	// Create active user and session
-	user, _ := store.CreateUserWithIdentity(ctx, "device-approve@test.com", true, "Test", "", "google", "device-approve-sub", "d@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-approve@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-approve-sub", ProviderEmail: "d@test.com"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 
 	insertDeviceCode(t, store, "APPR-CODE", clk)
@@ -95,7 +95,7 @@ func TestDevicePage_InactiveUser_Rejected(t *testing.T) {
 	ctx := context.Background()
 
 	// Create disabled user
-	user, _ := store.CreateUserWithIdentity(ctx, "device-inactive@test.com", true, "Test", "", "google", "device-inactive-sub", "di@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-inactive@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-inactive-sub", ProviderEmail: "di@test.com"})
 	store.DisableUser(ctx, user.ID)
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 
@@ -114,7 +114,7 @@ func TestDeviceApprove_Allow(t *testing.T) {
 	svc, store, clk := setupDeviceService(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "device-allow@test.com", true, "Test", "", "google", "device-allow-sub", "da@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-allow@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-allow-sub", ProviderEmail: "da@test.com"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 
 	insertDeviceCode(t, store, "ALLW-CODE", clk)
@@ -129,7 +129,7 @@ func TestDeviceApprove_Deny(t *testing.T) {
 	svc, store, clk := setupDeviceService(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "device-deny@test.com", true, "Test", "", "google", "device-deny-sub", "dd@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-deny@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-deny-sub", ProviderEmail: "dd@test.com"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 
 	insertDeviceCode(t, store, "DENY-CODE", clk)
@@ -169,7 +169,7 @@ func TestDeviceCallback_ExistingUser_RedirectBack(t *testing.T) {
 	svc, store, _ := setupDeviceService(t)
 	ctx := context.Background()
 
-	store.CreateUserWithIdentity(ctx, "device-cb@test.com", true, "Test", "", "google", "device-sub-123", "dc@test.com")
+	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-cb@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "dc@test.com"})
 
 	result := svc.HandleDeviceCallback(ctx, "fake-code", "RDIR-CODE", "127.0.0.1", "test")
 	if result.Action != DeviceRedirectBack {
@@ -188,7 +188,7 @@ func TestDevice005_RecoverableCallback_Rejected(t *testing.T) {
 	svc, store, _ := setupDeviceExtTest(t, "dev-recover-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "dev-recover@test.com", true, "Test", "", "google", "dev-recover-sub", "drc@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-recover@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-recover-sub", ProviderEmail: "drc@test.com"})
 	store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	result := svc.HandleDeviceCallback(ctx, "fake-code", "RECV-CODE", "127.0.0.1", "test")
@@ -205,7 +205,7 @@ func TestDevice006_InactiveCallback_Rejected(t *testing.T) {
 	svc, store, _ := setupDeviceExtTest(t, "dev-inactive-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "dev-inactive@test.com", true, "Test", "", "google", "dev-inactive-sub", "di@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-inactive@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-inactive-sub", ProviderEmail: "di@test.com"})
 	store.DisableUser(ctx, user.ID)
 
 	result := svc.HandleDeviceCallback(ctx, "fake-code", "INAC-CODE", "127.0.0.1", "test")
@@ -222,7 +222,7 @@ func TestDeviceCallback_DeletedUser_Rejected(t *testing.T) {
 	svc, store, _ := setupDeviceExtTest(t, "dev-deleted-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "dev-deleted@test.com", true, "Deleted", "", "google", "dev-deleted-sub", "dev-deleted@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-deleted@test.com", EmailVerified: true, Name: "Deleted", AvatarURL: "", Provider: "google", ProviderUserID: "dev-deleted-sub", ProviderEmail: "dev-deleted@test.com"})
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
 
 	result := svc.HandleDeviceCallback(ctx, "fake-code", "DELD-CODE", "127.0.0.1", "test")
@@ -239,7 +239,7 @@ func TestDevice011_ApproveAfterDisable(t *testing.T) {
 	svc, store, clk := setupDeviceExtTest(t, "dev-approve-dis-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "dev-approve-dis@test.com", true, "Test", "", "google", "dev-approve-dis-sub", "dad@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-dis@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-approve-dis-sub", ProviderEmail: "dad@test.com"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 	insertDeviceCode(t, store, "ADIS-CODE", clk)
 
@@ -270,7 +270,7 @@ func TestDeviceApprove_AfterStatusTransition_Rejected(t *testing.T) {
 			svc, store, clk := setupDeviceExtTest(t, "dev-approve-"+tt.status)
 			ctx := context.Background()
 
-			user, _ := store.CreateUserWithIdentity(ctx, "dev-approve-"+tt.status+"@test.com", true, "Test", "", "google", "dev-approve-"+tt.status, "dev-approve-"+tt.status+"@test.com")
+			user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-"+tt.status+"@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-approve-"+tt.status, ProviderEmail: "dev-approve-"+tt.status+"@test.com"})
 			sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 			insertDeviceCode(t, store, "ASTA-"+tt.status, clk)
 

--- a/internal/service/e2e_test.go
+++ b/internal/service/e2e_test.go
@@ -155,7 +155,7 @@ func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
 	fx := setupE2ETest(t)
 	ctx := context.Background()
 
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, "e2e4-full@test.com", true, "Test", "", "google", "e2e-sub", "e2e4-full@test.com")
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "e2e4-full@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "e2e-sub", ProviderEmail: "e2e4-full@test.com"})
 	sessionID, _ := fx.Store.CreateSession(ctx, user.ID, 24*time.Hour)
 	refreshToken := createRefreshTokenForUser(t, ctx, fx.Store, user.ID)
 
@@ -217,7 +217,7 @@ func TestE2E5_RecoveryThenAuthRequestRetry(t *testing.T) {
 	fx := setupE2ETest(t)
 	ctx := context.Background()
 
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, "e2e5-retry@test.com", true, "Retry User", "", "google", "e2e-sub", "e2e5-retry@test.com")
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "e2e5-retry@test.com", EmailVerified: true, Name: "Retry User", AvatarURL: "", Provider: "google", ProviderUserID: "e2e-sub", ProviderEmail: "e2e5-retry@test.com"})
 	sessionID, _ := fx.Store.CreateSession(ctx, user.ID, 24*time.Hour)
 
 	// 1) pending_deletion 전환

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -23,7 +23,7 @@ type LoginStore interface {
 	RecoverUser(ctx context.Context, userID string) error
 	CompleteAuthRequest(ctx context.Context, authRequestID, userID string) error
 	GetUserByProviderIdentity(ctx context.Context, provider, providerUserID string) (*storage.User, error)
-	CreateUserWithIdentity(ctx context.Context, email string, emailVerified bool, name, avatarURL, provider, providerUserID, providerEmail string) (*storage.User, error)
+	CreateUserWithIdentity(ctx context.Context, input storage.CreateUserWithIdentityInput) (*storage.User, error)
 	GetUserByID(ctx context.Context, userID string) (*storage.User, error)
 	CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error)
 }
@@ -129,10 +129,15 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 	user, err := s.store.GetUserByProviderIdentity(ctx, providerName, userInfo.Sub)
 	if errors.Is(err, storage.ErrNotFound) {
 		// New user — signup
-		user, err = s.store.CreateUserWithIdentity(ctx,
-			userInfo.Email, userInfo.EmailVerified, userInfo.Name, userInfo.Picture,
-			providerName, userInfo.Sub, userInfo.Email,
-		)
+		user, err = s.store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
+			Email:          userInfo.Email,
+			EmailVerified:  userInfo.EmailVerified,
+			Name:           userInfo.Name,
+			AvatarURL:      userInfo.Picture,
+			Provider:       providerName,
+			ProviderUserID: userInfo.Sub,
+			ProviderEmail:  userInfo.Email,
+		})
 		if errors.Is(err, storage.ErrEmailConflict) {
 			return &CallbackResult{Action: ActionError, Error: "email_conflict", ErrorCode: http.StatusConflict}
 		}

--- a/internal/service/login_test.go
+++ b/internal/service/login_test.go
@@ -86,7 +86,7 @@ func TestHandleCallback_ExistingUser_AutoApprove(t *testing.T) {
 	ctx := context.Background()
 
 	// Pre-create user
-	_, err := store.CreateUserWithIdentity(ctx, "existing@example.com", true, "Existing", "", "google", "google-sub-123", "existing@example.com")
+	_, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "existing@example.com", EmailVerified: true, Name: "Existing", AvatarURL: "", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "existing@example.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestHandleCallback_PendingDeletion_RecoveryAutoApprove(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user, then set to pending_deletion
-	user, err := store.CreateUserWithIdentity(ctx, "pending@example.com", true, "Pending", "", "google", "google-sub-123", "pending@example.com")
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pending@example.com", EmailVerified: true, Name: "Pending", AvatarURL: "", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "pending@example.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestHandleCallback_InactiveUser_Error(t *testing.T) {
 	ctx := context.Background()
 
 	// Create disabled user
-	user, _ := store.CreateUserWithIdentity(ctx, "disabled@example.com", true, "Disabled", "", "google", "google-sub-123", "disabled@example.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "disabled@example.com", EmailVerified: true, Name: "Disabled", AvatarURL: "", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "disabled@example.com"})
 	store.DisableUser(ctx, user.ID)
 
 	result := svc.HandleCallback(ctx, "fake-code", "req-disabled", "127.0.0.1", "test-agent")
@@ -158,7 +158,7 @@ func TestBrowser007_RecoveryRetryIdempotent(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user, then set to pending_deletion
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, "retry@test.com", true, "Test", "", "google", "gap-sub", "r@test.com")
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "retry@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "r@test.com"})
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	// First attempt: recovery succeeds, but use an invalid authRequestID so CompleteAuthRequest fails

--- a/internal/service/login_unit_test.go
+++ b/internal/service/login_unit_test.go
@@ -16,7 +16,7 @@ type fakeLoginStore struct {
 	recoverUserFn             func(ctx context.Context, userID string) error
 	completeAuthRequestFn     func(ctx context.Context, authRequestID, userID string) error
 	getUserByProviderIdentity func(ctx context.Context, provider, providerUserID string) (*storage.User, error)
-	createUserWithIdentityFn  func(ctx context.Context, email string, emailVerified bool, name, avatarURL, provider, providerUserID, providerEmail string) (*storage.User, error)
+	createUserWithIdentityFn  func(ctx context.Context, input storage.CreateUserWithIdentityInput) (*storage.User, error)
 	getUserByIDFn             func(ctx context.Context, userID string) (*storage.User, error)
 	createSessionFn           func(ctx context.Context, userID string, ttl time.Duration) (string, error)
 }
@@ -44,8 +44,8 @@ func (f *fakeLoginStore) GetUserByProviderIdentity(ctx context.Context, provider
 	return f.getUserByProviderIdentity(ctx, provider, providerUserID)
 }
 
-func (f *fakeLoginStore) CreateUserWithIdentity(ctx context.Context, email string, emailVerified bool, name, avatarURL, provider, providerUserID, providerEmail string) (*storage.User, error) {
-	return f.createUserWithIdentityFn(ctx, email, emailVerified, name, avatarURL, provider, providerUserID, providerEmail)
+func (f *fakeLoginStore) CreateUserWithIdentity(ctx context.Context, input storage.CreateUserWithIdentityInput) (*storage.User, error) {
+	return f.createUserWithIdentityFn(ctx, input)
 }
 
 func (f *fakeLoginStore) GetUserByID(ctx context.Context, userID string) (*storage.User, error) {
@@ -94,7 +94,7 @@ func TestLogin_HandleCallback_EmailConflict(t *testing.T) {
 		getUserByProviderIdentity: func(context.Context, string, string) (*storage.User, error) {
 			return nil, storage.ErrNotFound
 		},
-		createUserWithIdentityFn: func(context.Context, string, bool, string, string, string, string, string) (*storage.User, error) {
+		createUserWithIdentityFn: func(context.Context, storage.CreateUserWithIdentityInput) (*storage.User, error) {
 			return nil, storage.ErrEmailConflict
 		},
 	}
@@ -134,4 +134,3 @@ func TestLogin_HandleLogin_NoSession_Redirect(t *testing.T) {
 		t.Fatalf("action = %v, want %v", result.Action, ActionRedirectToIdP)
 	}
 }
-

--- a/internal/service/mcp_test.go
+++ b/internal/service/mcp_test.go
@@ -37,7 +37,7 @@ func TestMCP_CompleteUser_AutoApprove(t *testing.T) {
 	svc, store := setupMCPTest(t)
 	ctx := context.Background()
 
-	store.CreateUserWithIdentity(ctx, "mcp-ok@test.com", true, "MCP", "", "google", "mcp-sub-123", "mcp@test.com")
+	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-ok@test.com", EmailVerified: true, Name: "MCP", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-sub-123", ProviderEmail: "mcp@test.com"})
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-ok")
 
 	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
@@ -65,7 +65,7 @@ func TestMCP_DisabledUser_Rejected(t *testing.T) {
 	svc, store := setupMCPTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "mcp-dis@test.com", true, "MCP", "", "google", "mcp-sub-123", "mcp@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-dis@test.com", EmailVerified: true, Name: "MCP", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-sub-123", ProviderEmail: "mcp@test.com"})
 	store.DisableUser(ctx, user.ID)
 
 	result := svc.HandleCallback(ctx, "fake-code", "req-mcp-dis", "127.0.0.1", "mcp-client")
@@ -83,7 +83,7 @@ func TestMCP005_Recoverable_Rejected(t *testing.T) {
 	svc, store := setupMCPExtTest(t, "mcp-005-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "mcp-recover@test.com", true, "Test", "", "google", "mcp-005-sub", "mrc@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-recover@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-005-sub", ProviderEmail: "mrc@test.com"})
 	store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-005")
@@ -102,7 +102,7 @@ func TestMCPLogin_PendingDeletionSession_Rejected(t *testing.T) {
 	svc, store := setupMCPTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "mcp-login-pending@test.com", true, "MCP Pending", "", "google", "mcp-login-pending-sub", "mcp-login-pending@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-login-pending@test.com", EmailVerified: true, Name: "MCP Pending", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-login-pending-sub", ProviderEmail: "mcp-login-pending@test.com"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 	_ = store.SetUserStatus(ctx, user.ID, "pending_deletion")
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-login-pending")
@@ -122,7 +122,7 @@ func TestMCPLogin_DeletedSession_Rejected(t *testing.T) {
 	svc, store := setupMCPTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "mcp-login-deleted@test.com", true, "MCP Deleted", "", "google", "mcp-login-deleted-sub", "mcp-login-deleted@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-login-deleted@test.com", EmailVerified: true, Name: "MCP Deleted", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-login-deleted-sub", ProviderEmail: "mcp-login-deleted@test.com"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-login-deleted")
@@ -142,7 +142,7 @@ func TestMCP_DeletedUser_Rejected(t *testing.T) {
 	svc, store := setupMCPExtTest(t, "mcp-deleted-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "mcp-deleted@test.com", true, "MCP", "", "google", "mcp-deleted-sub", "mcp-deleted@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-deleted@test.com", EmailVerified: true, Name: "MCP", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-deleted-sub", ProviderEmail: "mcp-deleted@test.com"})
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-deleted")
 

--- a/internal/storage/audit_test.go
+++ b/internal/storage/audit_test.go
@@ -21,7 +21,7 @@ func TestAudit010And011_RefreshReuseAndFamilyRevoke(t *testing.T) {
 	store := New(db, clk, gen, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, "audit-refresh@test.com", true, "Refresh Audit", "", "google", "audit-refresh-sub", "audit-refresh@test.com")
+	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "audit-refresh@test.com", EmailVerified: true, Name: "Refresh Audit", AvatarURL: "", Provider: "google", ProviderUserID: "audit-refresh-sub", ProviderEmail: "audit-refresh@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}

--- a/internal/storage/expiry_test.go
+++ b/internal/storage/expiry_test.go
@@ -53,7 +53,7 @@ func TestAuthRequestByCode_Expired_Rejected(t *testing.T) {
 
 	// Create auth request + complete + save code
 	arID, _ := store.CreateTestAuthRequest(ctx, "code-expiry")
-	user, _ := store.CreateUserWithIdentity(ctx, "code-expiry@test.com", true, "Test", "", "google", "code-expiry-sub", "ce@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "code-expiry@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "code-expiry-sub", ProviderEmail: "ce@test.com"})
 	store.CompleteAuthRequest(ctx, arID, user.ID)
 	store.SaveAuthCode(ctx, arID, "test-code-expiry")
 

--- a/internal/storage/refresh_state_test.go
+++ b/internal/storage/refresh_state_test.go
@@ -23,7 +23,7 @@ func TestRefreshReuseDetection_FamilyRevoke(t *testing.T) {
 	store := New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, "reuse@test.com", true, "Test", "", "google", "reuse-sub", "ru@test.com")
+	user, _ := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "reuse@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "reuse-sub", ProviderEmail: "ru@test.com"})
 	_ = user
 
 	// Insert two tokens in the same family
@@ -116,7 +116,7 @@ func TestRefreshStateCheck_AllStates(t *testing.T) {
 			email := fmt.Sprintf("refresh-state-%d@test.com", i)
 			sub := fmt.Sprintf("refresh-state-sub-%d", i)
 
-			user, err := store.CreateUserWithIdentity(ctx, email, true, "Test", "", "google", sub, email)
+			user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: sub, ProviderEmail: email})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}
@@ -204,7 +204,7 @@ func TestAuthCodeStateCheck_AllStates(t *testing.T) {
 			email := fmt.Sprintf("authcode-state-%d@test.com", i)
 			sub := fmt.Sprintf("authcode-state-sub-%d", i)
 
-			user, err := store.CreateUserWithIdentity(ctx, email, true, "Test", "", "google", sub, email)
+			user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: sub, ProviderEmail: email})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}

--- a/internal/storage/storage_integration_test.go
+++ b/internal/storage/storage_integration_test.go
@@ -26,7 +26,7 @@ func TestCreateUserWithIdentity_Atomic(t *testing.T) {
 	s := testStorage(t)
 	ctx := context.Background()
 
-	user, err := s.CreateUserWithIdentity(ctx, "atomic@test.com", true, "Test", "", "google", "atomic-sub-1", "atomic@test.com")
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "atomic@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "atomic-sub-1", ProviderEmail: "atomic@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestCreateUserWithIdentity_Atomic(t *testing.T) {
 	}
 
 	// Duplicate email should fail
-	_, err = s.CreateUserWithIdentity(ctx, "atomic@test.com", true, "Test2", "", "google", "atomic-sub-2", "dup@test.com")
+	_, err = s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "atomic@test.com", EmailVerified: true, Name: "Test2", AvatarURL: "", Provider: "google", ProviderUserID: "atomic-sub-2", ProviderEmail: "dup@test.com"})
 	if err == nil {
 		t.Fatal("expected error for duplicate email")
 	}
@@ -65,7 +65,7 @@ func TestRefreshTokenRotation_Atomicity(t *testing.T) {
 	ctx := context.Background()
 
 	// Setup: create user
-	user, err := s.CreateUserWithIdentity(ctx, "refresh@test.com", true, "Test", "", "google", "refresh-sub", "r@test.com")
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "refresh@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "refresh-sub", ProviderEmail: "r@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestSession_CreateAndValidate(t *testing.T) {
 	s := testStorage(t)
 	ctx := context.Background()
 
-	user, err := s.CreateUserWithIdentity(ctx, "session@test.com", true, "Test", "", "google", "session-sub", "s@test.com")
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "session@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "session-sub", ProviderEmail: "s@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -10,7 +10,17 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
 
-func (s *Storage) CreateUserWithIdentity(ctx context.Context, email string, emailVerified bool, name, avatarURL, provider, providerUserID, providerEmail string) (*User, error) {
+type CreateUserWithIdentityInput struct {
+	Email         string
+	EmailVerified bool
+	Name          string
+	AvatarURL     string
+	Provider      string
+	ProviderUserID string
+	ProviderEmail string
+}
+
+func (s *Storage) CreateUserWithIdentity(ctx context.Context, input CreateUserWithIdentityInput) (*User, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -23,10 +33,10 @@ func (s *Storage) CreateUserWithIdentity(ctx context.Context, email string, emai
 
 	err = qtx.InsertUser(ctx, storeq.InsertUserParams{
 		ID:            userID,
-		Email:         email,
-		EmailVerified: emailVerified,
-		Name:          sql.NullString{String: name, Valid: true},
-		AvatarUrl:     sql.NullString{String: avatarURL, Valid: true},
+		Email:         input.Email,
+		EmailVerified: input.EmailVerified,
+		Name:          sql.NullString{String: input.Name, Valid: true},
+		AvatarUrl:     sql.NullString{String: input.AvatarURL, Valid: true},
 		CreatedAt:     now,
 	})
 	if err != nil {
@@ -40,9 +50,9 @@ func (s *Storage) CreateUserWithIdentity(ctx context.Context, email string, emai
 	err = qtx.InsertUserIdentity(ctx, storeq.InsertUserIdentityParams{
 		ID:             identityID,
 		UserID:         userID,
-		Provider:       provider,
-		ProviderUserID: providerUserID,
-		ProviderEmail:  sql.NullString{String: providerEmail, Valid: true},
+		Provider:       input.Provider,
+		ProviderUserID: input.ProviderUserID,
+		ProviderEmail:  sql.NullString{String: input.ProviderEmail, Valid: true},
 		CreatedAt:      now,
 	})
 	if err != nil {
@@ -55,9 +65,9 @@ func (s *Storage) CreateUserWithIdentity(ctx context.Context, email string, emai
 
 	return &User{
 		ID:            userID,
-		Email:         email,
-		EmailVerified: emailVerified,
-		Name:          name,
+		Email:         input.Email,
+		EmailVerified: input.EmailVerified,
+		Name:          input.Name,
 		Status:        "active",
 		CreatedAt:     now,
 		UpdatedAt:     now,


### PR DESCRIPTION
## Summary
- introduce `CreateUserWithIdentityInput` in storage to replace long parameter list
- migrate `CreateUserWithIdentity` call sites in service/integration/storage tests to the input struct
- update `LoginStore` contract and login unit-test fakes to the new signature

## Testing
- go test ./...