### PR TITLE
refactor: make MCP adapter wiring optional with ENABLE_MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ go run ./cmd/authgate
 | `SESSION_TTL` | `86400` | session TTL in seconds |
 | `ACCESS_TOKEN_TTL` | `900` | access token TTL in seconds |
 | `REFRESH_TOKEN_TTL` | `2592000` | refresh token TTL in seconds |
+| `ENABLE_MCP` | `true` | enable MCP optional adapter routes/policies (`/mcp/*`, CIMD/resource binding) |
 | `CLIENT_CONFIG` | `/etc/authgate/clients.yaml` | YAML path for client metadata preload |
 
 Production guards when `DEV_MODE=false`:

--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -82,9 +82,11 @@ func main() {
 	}
 
 	// MCP adapter policies: enable CIMD-based client resolution and MCP-specific resource checks.
-	cimdFetcher := storage.NewHTTPCIMDFetcher()
-	store.SetClientResolutionPolicy(mcpadapter.NewClientResolutionPolicy(storage.NewCoreClientResolutionPolicy(store), cimdFetcher))
-	store.SetResourceBindingPolicy(mcpadapter.NewResourceBindingPolicy(storage.NewCoreResourceBindingPolicy()))
+	if cfg.EnableMCP {
+		cimdFetcher := storage.NewHTTPCIMDFetcher()
+		store.SetClientResolutionPolicy(mcpadapter.NewClientResolutionPolicy(storage.NewCoreClientResolutionPolicy(store), cimdFetcher))
+		store.SetResourceBindingPolicy(mcpadapter.NewResourceBindingPolicy(storage.NewCoreResourceBindingPolicy()))
+	}
 
 	// zitadel OP config
 	cryptoKey := sha256.Sum256([]byte(cfg.SessionSecret))
@@ -140,10 +142,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("browser provider: %v", err)
 	}
-	mcpProvider, err := upstream.NewOIDCProvider(ctx, cfg.OIDCIssuerURL, cfg.OIDCClientID, cfg.OIDCClientSecret, cfg.PublicURL+"/mcp/callback", upstreamOpts...)
-	if err != nil {
-		log.Fatalf("mcp provider: %v", err)
-	}
 	deviceProvider, err := upstream.NewOIDCProvider(ctx, cfg.OIDCIssuerURL, cfg.OIDCClientID, cfg.OIDCClientSecret, cfg.PublicURL+"/device/auth/callback", upstreamOpts...)
 	if err != nil {
 		log.Fatalf("device provider: %v", err)
@@ -151,7 +149,6 @@ func main() {
 
 	// Service layer
 	loginService := service.NewLoginService(store, browserProvider, cfg.SessionTTL)
-	mcpLoginService := service.NewMCPLoginService(store, mcpProvider, cfg.SessionTTL)
 
 	// Device service
 	deviceService := service.NewDeviceService(store, deviceProvider, cfg.PublicURL, cfg.SessionTTL, clk)
@@ -161,9 +158,18 @@ func main() {
 
 	// Handler layer
 	loginHandler := handler.NewLoginHandler(loginService, cfg.DevMode)
-	mcpLoginHandler := handler.NewMCPLoginHandler(mcpLoginService, cfg.DevMode)
 	deviceHandler := handler.NewDeviceHandler(deviceService, cfg.DevMode)
 	accountHandler := handler.NewAccountHandler(accountService, cfg.PublicURL)
+
+	var mcpLoginHandler *handler.MCPLoginHandler
+	if cfg.EnableMCP {
+		mcpProvider, err := upstream.NewOIDCProvider(ctx, cfg.OIDCIssuerURL, cfg.OIDCClientID, cfg.OIDCClientSecret, cfg.PublicURL+"/mcp/callback", upstreamOpts...)
+		if err != nil {
+			log.Fatalf("mcp provider: %v", err)
+		}
+		mcpLoginService := service.NewMCPLoginService(store, mcpProvider, cfg.SessionTTL)
+		mcpLoginHandler = handler.NewMCPLoginHandler(mcpLoginService, cfg.DevMode)
+	}
 
 	// Mux: zitadel owns /.well-known/*, /authorize, /oauth/*, etc.
 	// authgate adds /login, /device, /account, /health, /ready
@@ -186,13 +192,13 @@ func main() {
 			"code_challenge_methods_supported":      []string{"S256"},
 			"token_endpoint_auth_methods_supported": []string{"none", "client_secret_post"},
 			"scopes_supported":                      []string{"openid", "profile", "email", "offline_access"},
-			"client_id_metadata_document_supported": true,
+			"client_id_metadata_document_supported": cfg.EnableMCP,
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(metadata)
 	})
 
-	// Capture MCP resource hints before handing off to zitadel.
+	// Capture resource hints before handing off to zitadel.
 	mux.Handle("/authorize", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resource := storage.ResourceFromRequest(r)
 		provider.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
@@ -202,6 +208,10 @@ func main() {
 		provider.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
 	}))
 	mux.Handle("/oauth/revoke", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !cfg.EnableMCP {
+			provider.ServeHTTP(w, r)
+			return
+		}
 		// RFC 7009: revocation endpoint should still return 200 even if a CIMD
 		// client metadata document is temporarily unavailable.
 		if err := r.ParseForm(); err == nil {
@@ -222,8 +232,10 @@ func main() {
 	// authgate login routes
 	mux.HandleFunc("/login", loginHandler.HandleLogin)
 	mux.HandleFunc("/login/callback", loginHandler.HandleCallback)
-	mux.HandleFunc("/mcp/login", mcpLoginHandler.HandleLogin)
-	mux.HandleFunc("/mcp/callback", mcpLoginHandler.HandleCallback)
+	if cfg.EnableMCP {
+		mux.HandleFunc("/mcp/login", mcpLoginHandler.HandleLogin)
+		mux.HandleFunc("/mcp/callback", mcpLoginHandler.HandleCallback)
+	}
 
 	// authgate account routes
 	mux.HandleFunc("/account", accountHandler.HandleDeleteAccount)
@@ -275,7 +287,7 @@ func main() {
 		srv.Shutdown(ctx)
 	}()
 
-	slog.Info("authgate starting", "addr", addr, "dev", cfg.DevMode, "issuer", cfg.OIDCIssuerURL, "provider", browserProvider.Name())
+	slog.Info("authgate starting", "addr", addr, "dev", cfg.DevMode, "mcp", cfg.EnableMCP, "issuer", cfg.OIDCIssuerURL, "provider", browserProvider.Name())
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatalf("server: %v", err)
 	}

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -54,6 +54,7 @@ authgate를 처음 배포할 때 필요한 것:
 | `ACCESS_TOKEN_TTL` | X | `900` | access_token 수명 (초, 15분) |
 | `REFRESH_TOKEN_TTL` | X | `2592000` | refresh_token 수명 (초, 30일) |
 | `DEV_MODE` | X | `false` | true 시: insecure 허용, cookie Secure=false |
+| `ENABLE_MCP` | X | `true` | MCP optional adapter 활성화 여부 (`/mcp/*`, CIMD/resource binding) |
 | `CLIENT_CONFIG` | X | `/etc/authgate/clients.yaml` | 클라이언트 설정 YAML 파일 경로 (없으면 무시) |
 
 ### 프로덕션 필수 조건

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	AccessTokenTTL   time.Duration
 	RefreshTokenTTL  time.Duration
 	DevMode          bool
+	EnableMCP        bool
 	ClientConfigPath string
 }
 
@@ -38,6 +39,7 @@ func Load() (*Config, error) {
 		AccessTokenTTL:   time.Duration(envInt("ACCESS_TOKEN_TTL", 900)) * time.Second,
 		RefreshTokenTTL:  time.Duration(envInt("REFRESH_TOKEN_TTL", 2592000)) * time.Second,
 		DevMode:          envBool("DEV_MODE", false),
+		EnableMCP:        envBool("ENABLE_MCP", true),
 		ClientConfigPath: envDefault("CLIENT_CONFIG", "/etc/authgate/clients.yaml"),
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,7 +10,7 @@ func clearEnv() {
 		"PORT", "DATABASE_URL", "SESSION_SECRET", "PUBLIC_URL",
 		"OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET",
 		"SESSION_TTL", "ACCESS_TOKEN_TTL", "REFRESH_TOKEN_TTL",
-		"DEV_MODE",
+		"DEV_MODE", "ENABLE_MCP",
 	} {
 		os.Unsetenv(key)
 	}
@@ -117,6 +117,9 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.RefreshTokenTTL.Seconds() != 2592000 {
 		t.Errorf("RefreshTokenTTL = %v, want 2592000s", cfg.RefreshTokenTTL)
 	}
+	if !cfg.EnableMCP {
+		t.Error("EnableMCP = false, want true by default")
+	}
 }
 
 func TestLoad_DevModeFalseShortSessionSecret(t *testing.T) {
@@ -158,5 +161,19 @@ func TestLoad_Success(t *testing.T) {
 	}
 	if !cfg.DevMode {
 		t.Error("DevMode should be true")
+	}
+}
+
+func TestLoad_EnableMCPFalse(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("ENABLE_MCP", "false")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.EnableMCP {
+		t.Fatal("EnableMCP should be false")
 	}
 }


### PR DESCRIPTION
## Summary
- add ENABLE_MCP config flag (default: true) to control MCP optional adapter activation
- gate MCP-only wiring in cmd/authgate/main.go (CIMD/resource policies, /mcp/* routes, MCP provider/service/handler)
- when MCP is disabled, skip CIMD fail-open path in /oauth/revoke and serve provider directly
- update ops docs with ENABLE_MCP environment variable

## Testing
- go test ./...