### PR TITLE
fix: harden MCP-disabled mode and add integration coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ go run ./cmd/authgate
 | `ENABLE_MCP` | `true` | enable MCP optional adapter routes/policies (`/mcp/*`, CIMD/resource binding) |
 | `CLIENT_CONFIG` | `/etc/authgate/clients.yaml` | YAML path for client metadata preload |
 
+`ENABLE_MCP=false`일 때는 `clients.yaml`의 `login_channel: mcp` 클라이언트가 허용되지 않으며 서버 시작 시 실패합니다.
+
 Production guards when `DEV_MODE=false`:
 
 - `SESSION_SECRET` must be at least 32 characters

--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -76,6 +76,9 @@ func main() {
 				log.Fatalf("client config: %v", err)
 			}
 		} else {
+			if err := storage.ValidateClientChannels(clientCfg.Clients, cfg.EnableMCP); err != nil {
+				log.Fatalf("client config: %v", err)
+			}
 			store.LoadClients(clientCfg.Clients)
 			slog.Info("client config loaded", "path", cfg.ClientConfigPath, "count", len(clientCfg.Clients))
 		}

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -57,6 +57,8 @@ authgate를 처음 배포할 때 필요한 것:
 | `ENABLE_MCP` | X | `true` | MCP optional adapter 활성화 여부 (`/mcp/*`, CIMD/resource binding) |
 | `CLIENT_CONFIG` | X | `/etc/authgate/clients.yaml` | 클라이언트 설정 YAML 파일 경로 (없으면 무시) |
 
+`ENABLE_MCP=false`인 경우 `clients.yaml`에 `login_channel: mcp` 항목이 있으면 서버 시작을 거부한다.
+
 ### 프로덕션 필수 조건
 
 `DEV_MODE=false` (기본값)일 때 다음이 강제됨:

--- a/internal/integration/integration_mcp_disabled_test.go
+++ b/internal/integration/integration_mcp_disabled_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestIntegration_MCPDisabled_MetadataAndRoutes(t *testing.T) {
+	ts := SetupTestServerWithOptions(t, SetupOptions{EnableMCP: false})
+
+	resp, err := http.Get(ts.BaseURL + "/.well-known/oauth-authorization-server")
+	if err != nil {
+		t.Fatalf("metadata request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var metadata map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&metadata); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	if v, ok := metadata["client_id_metadata_document_supported"].(bool); !ok || v {
+		t.Fatalf("client_id_metadata_document_supported = %v, want false", metadata["client_id_metadata_document_supported"])
+	}
+
+	mcpResp, err := http.Get(ts.BaseURL + "/mcp/login?authRequestID=test")
+	if err != nil {
+		t.Fatalf("mcp login request: %v", err)
+	}
+	defer mcpResp.Body.Close()
+	if mcpResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("/mcp/login status=%d, want 404", mcpResp.StatusCode)
+	}
+}
+
+func TestIntegration_MCPDisabled_BrowserFlowStillWorks(t *testing.T) {
+	ts := SetupTestServerWithOptions(t, SetupOptions{EnableMCP: false})
+	client := NewOAuthClientFor(t, ts.BaseURL, "test-client", "/login/callback")
+
+	code := completeLoginFlowToCode(t, ts, client)
+	if code == "" {
+		t.Fatal("expected authorization code for browser flow")
+	}
+
+	tokens := client.ExchangeCode(code)
+	if tokens.StatusCode != http.StatusOK {
+		t.Fatalf("browser token exchange failed: status=%d body=%s", tokens.StatusCode, tokens.RawBody)
+	}
+}
+
+func TestIntegration_MCPDisabled_MCPClientRejected(t *testing.T) {
+	ts := SetupTestServerWithOptions(t, SetupOptions{EnableMCP: false})
+	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
+
+	resp := client.StartAuthorize()
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusFound {
+		loc := resp.Header.Get("Location")
+		if strings.Contains(loc, "/mcp/login") {
+			t.Fatalf("unexpected redirect to MCP login when MCP disabled: %s", loc)
+		}
+	}
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("mcp client should be rejected when MCP disabled")
+	}
+}

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/zitadel/oidc/v3/pkg/op"
 
+	mcpadapter "github.com/kangheeyong/authgate/internal/adapter/mcp"
 	"github.com/kangheeyong/authgate/internal/clock"
 	"github.com/kangheeyong/authgate/internal/handler"
 	"github.com/kangheeyong/authgate/internal/idgen"
@@ -33,6 +34,15 @@ type TestServer struct {
 
 // SetupTestServer creates a full authgate server with testcontainers PostgreSQL.
 func SetupTestServer(t *testing.T) *TestServer {
+	return SetupTestServerWithOptions(t, SetupOptions{EnableMCP: true})
+}
+
+type SetupOptions struct {
+	EnableMCP bool
+}
+
+// SetupTestServerWithOptions creates a full authgate server with selectable optional adapters.
+func SetupTestServerWithOptions(t *testing.T, opts SetupOptions) *TestServer {
 	t.Helper()
 
 	db := testutil.SetupPostgres(t)
@@ -47,6 +57,11 @@ func SetupTestServer(t *testing.T) *TestServer {
 	}
 
 	store := storage.New(db, clk, gen, stateChecker, 15*time.Minute, 30*24*time.Hour)
+	if opts.EnableMCP {
+		cimdFetcher := storage.NewHTTPCIMDFetcher()
+		store.SetClientResolutionPolicy(mcpadapter.NewClientResolutionPolicy(storage.NewCoreClientResolutionPolicy(store), cimdFetcher))
+		store.SetResourceBindingPolicy(mcpadapter.NewResourceBindingPolicy(storage.NewCoreResourceBindingPolicy()))
+	}
 
 	// Generate signing key
 	key, err := storage.LoadOrGenerateKey(t.TempDir() + "/signing_key.pem")
@@ -72,16 +87,20 @@ func SetupTestServer(t *testing.T) *TestServer {
 			AllowedScopes:     []string{"openid", "profile", "email", "offline_access"},
 			AllowedGrantTypes: []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
 		},
-		{
-			ClientID:          "mcp-client",
-			ClientType:        "public",
-			LoginChannel:      "mcp",
-			Name:              "MCP Test",
-			RedirectURIs:      []string{srv.URL + "/callback"},
-			AllowedScopes:     []string{"openid", "profile", "email", "offline_access"},
-			AllowedGrantTypes: []string{"authorization_code", "refresh_token"},
-		},
 	})
+	if opts.EnableMCP {
+		store.LoadClients([]storage.ClientConfigEntry{
+			{
+				ClientID:          "mcp-client",
+				ClientType:        "public",
+				LoginChannel:      "mcp",
+				Name:              "MCP Test",
+				RedirectURIs:      []string{srv.URL + "/callback"},
+				AllowedScopes:     []string{"openid", "profile", "email", "offline_access"},
+				AllowedGrantTypes: []string{"authorization_code", "refresh_token"},
+			},
+		})
+	}
 
 	// zitadel OP
 	cryptoKey := sha256.Sum256([]byte("test-secret-32-chars-long-enough!"))
@@ -115,15 +134,18 @@ func SetupTestServer(t *testing.T) *TestServer {
 
 	// Services
 	loginSvc := service.NewLoginService(store, fakeProvider, 24*time.Hour)
-	mcpLoginSvc := service.NewMCPLoginService(store, fakeProvider, 24*time.Hour)
 	deviceSvc := service.NewDeviceService(store, fakeProvider, srv.URL, 24*time.Hour, clk)
 	accountSvc := service.NewAccountService(store)
 
 	// Handlers
 	loginHandler := handler.NewLoginHandler(loginSvc, true)
-	mcpLoginHandler := handler.NewMCPLoginHandler(mcpLoginSvc, true)
 	deviceHandler := handler.NewDeviceHandler(deviceSvc, true)
 	accountHandler := handler.NewAccountHandler(accountSvc, srv.URL)
+	var mcpLoginHandler *handler.MCPLoginHandler
+	if opts.EnableMCP {
+		mcpLoginSvc := service.NewMCPLoginService(store, fakeProvider, 24*time.Hour)
+		mcpLoginHandler = handler.NewMCPLoginHandler(mcpLoginSvc, true)
+	}
 
 	// Routes
 	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
@@ -141,7 +163,7 @@ func SetupTestServer(t *testing.T) *TestServer {
 			"code_challenge_methods_supported":      []string{"S256"},
 			"token_endpoint_auth_methods_supported": []string{"none", "client_secret_post"},
 			"scopes_supported":                      []string{"openid", "profile", "email", "offline_access"},
-			"client_id_metadata_document_supported": true,
+			"client_id_metadata_document_supported": opts.EnableMCP,
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(metadata)
@@ -155,6 +177,10 @@ func SetupTestServer(t *testing.T) *TestServer {
 		provider.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
 	}))
 	mux.Handle("/oauth/revoke", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !opts.EnableMCP {
+			provider.ServeHTTP(w, r)
+			return
+		}
 		if err := r.ParseForm(); err == nil {
 			clientID := strings.TrimSpace(r.Form.Get("client_id"))
 			if storage.IsCIMDClientID(clientID) {
@@ -169,8 +195,10 @@ func SetupTestServer(t *testing.T) *TestServer {
 	mux.Handle("/", provider)
 	mux.HandleFunc("/login", loginHandler.HandleLogin)
 	mux.HandleFunc("/login/callback", loginHandler.HandleCallback)
-	mux.HandleFunc("/mcp/login", mcpLoginHandler.HandleLogin)
-	mux.HandleFunc("/mcp/callback", mcpLoginHandler.HandleCallback)
+	if opts.EnableMCP {
+		mux.HandleFunc("/mcp/login", mcpLoginHandler.HandleLogin)
+		mux.HandleFunc("/mcp/callback", mcpLoginHandler.HandleCallback)
+	}
 	mux.HandleFunc("/device", deviceHandler.HandleDevicePage)
 	mux.HandleFunc("/device/approve", deviceHandler.HandleDeviceApprove)
 	mux.HandleFunc("/device/auth/callback", deviceHandler.HandleDeviceCallback)

--- a/internal/storage/clients.go
+++ b/internal/storage/clients.go
@@ -113,6 +113,19 @@ func LoadClientConfig(path string) (*ClientConfigFile, error) {
 	return &cfg, nil
 }
 
+// ValidateClientChannels enforces runtime channel constraints against loaded clients.
+func ValidateClientChannels(clients []ClientConfigEntry, enableMCP bool) error {
+	if enableMCP {
+		return nil
+	}
+	for i, c := range clients {
+		if c.LoginChannel == "mcp" {
+			return fmt.Errorf("client[%d] %q: login_channel=mcp requires ENABLE_MCP=true", i, c.ClientID)
+		}
+	}
+	return nil
+}
+
 // LoadClients loads client config entries into the in-memory client store.
 func (s *Storage) LoadClients(clients []ClientConfigEntry) {
 	for _, c := range clients {

--- a/internal/storage/clients_test.go
+++ b/internal/storage/clients_test.go
@@ -136,3 +136,34 @@ clients:
 		t.Fatalf("expected allowed_grant_types exceeds error, got: %v", err)
 	}
 }
+
+func TestValidateClientChannels_MCPDisabledRejectsMCPClient(t *testing.T) {
+	clients := []ClientConfigEntry{
+		{
+			ClientID:     "browser-client",
+			LoginChannel: "browser",
+		},
+		{
+			ClientID:     "mcp-client",
+			LoginChannel: "mcp",
+		},
+	}
+
+	err := ValidateClientChannels(clients, false)
+	if err == nil || !strings.Contains(err.Error(), "requires ENABLE_MCP=true") {
+		t.Fatalf("expected MCP disabled validation error, got: %v", err)
+	}
+}
+
+func TestValidateClientChannels_MCPEnabledAllowsMCPClient(t *testing.T) {
+	clients := []ClientConfigEntry{
+		{
+			ClientID:     "mcp-client",
+			LoginChannel: "mcp",
+		},
+	}
+
+	if err := ValidateClientChannels(clients, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- reject clients.yaml entries with login_channel: mcp when ENABLE_MCP=false
- apply MCP on/off wiring behavior consistently in integration test server setup
- add integration tests for MCP-disabled mode:
  - metadata advertises client_id_metadata_document_supported=false
  - /mcp/login is not routed (404)
  - browser login/token flow still works
  - MCP client authorize is rejected
- document MCP-disabled client-channel guard in ops docs and README

## Testing
- go test ./...
- go test -tags=integration ./internal/integration