### PR TITLE
refactor: move CIMD implementation into MCP adapter

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -86,7 +86,7 @@ func main() {
 
 	// MCP adapter policies: enable CIMD-based client resolution and MCP-specific resource checks.
 	if cfg.EnableMCP {
-		cimdFetcher := storage.NewHTTPCIMDFetcher()
+		cimdFetcher := mcpadapter.NewHTTPCIMDFetcher()
 		store.SetClientResolutionPolicy(mcpadapter.NewClientResolutionPolicy(storage.NewCoreClientResolutionPolicy(store), cimdFetcher))
 		store.SetResourceBindingPolicy(mcpadapter.NewResourceBindingPolicy(storage.NewCoreResourceBindingPolicy()))
 	}

--- a/internal/adapter/mcp/cimd.go
+++ b/internal/adapter/mcp/cimd.go
@@ -1,4 +1,4 @@
-package storage
+package mcp
 
 import (
 	"context"
@@ -8,25 +8,19 @@ import (
 	"mime"
 	"net"
 	"net/http"
-	"net/url"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/kangheeyong/authgate/internal/clock"
+	"github.com/kangheeyong/authgate/internal/storage"
 	"golang.org/x/sync/singleflight"
 )
 
 // cimdCacheEntry holds a cached CIMD client with expiration.
 type cimdCacheEntry struct {
-	client    *ClientModel
+	client    *storage.ClientModel
 	err       error
 	expiresAt time.Time
-}
-
-// CIMDFetcher fetches and validates CIMD (Client ID Metadata Document) clients.
-type CIMDFetcher interface {
-	FetchClient(ctx context.Context, clientID string) (*ClientModel, error)
 }
 
 // CIMDMetadata represents a Client ID Metadata Document (draft-ietf-oauth-client-id-metadata-document).
@@ -97,8 +91,8 @@ func NewHTTPCIMDFetcher() *HTTPCIMDFetcher {
 	}
 }
 
-func (f *HTTPCIMDFetcher) FetchClient(ctx context.Context, clientID string) (*ClientModel, error) {
-	if !isCIMDClientID(clientID) {
+func (f *HTTPCIMDFetcher) FetchClient(ctx context.Context, clientID string) (*storage.ClientModel, error) {
+	if !storage.IsCIMDClientID(clientID) {
 		return nil, fmt.Errorf("cimd: invalid client_id URL")
 	}
 
@@ -134,12 +128,12 @@ func (f *HTTPCIMDFetcher) FetchClient(ctx context.Context, clientID string) (*Cl
 	if err != nil {
 		return nil, err
 	}
-	client := v.(*ClientModel)
+	client := v.(*storage.ClientModel)
 
 	return client, nil
 }
 
-func (f *HTTPCIMDFetcher) fetchAndValidate(ctx context.Context, clientID string) (*ClientModel, error) {
+func (f *HTTPCIMDFetcher) fetchAndValidate(ctx context.Context, clientID string) (*storage.ClientModel, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, clientID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cimd: invalid URL: %w", err)
@@ -234,48 +228,15 @@ func (f *HTTPCIMDFetcher) fetchAndValidate(ctx context.Context, clientID string)
 		}
 	}
 
-	return &ClientModel{
+	return &storage.ClientModel{
 		ID:                   meta.ClientID,
 		Type:                 "public",
 		LoginChannel:         "mcp",
 		Name:                 meta.ClientName,
-		RedirectURIList:      StringArray(meta.RedirectURIs),
-		AllowedScopeList:     StringArray([]string{"openid", "profile", "email", "offline_access"}),
-		AllowedGrantTypeList: StringArray(meta.GrantTypes),
+		RedirectURIList:      storage.StringArray(meta.RedirectURIs),
+		AllowedScopeList:     storage.StringArray([]string{"openid", "profile", "email", "offline_access"}),
+		AllowedGrantTypeList: storage.StringArray(meta.GrantTypes),
 	}, nil
-}
-
-// isCIMDClientID checks if a client_id is a CIMD URL (HTTPS with path component).
-func isCIMDClientID(clientID string) bool {
-	// ParseRequestURI doesn't parse fragments, check raw string
-	if strings.Contains(clientID, "#") {
-		return false
-	}
-	u, err := url.ParseRequestURI(clientID)
-	if err != nil {
-		return false
-	}
-	if u.Scheme != "https" {
-		return false
-	}
-	if u.Host == "" || u.Hostname() == "" {
-		return false
-	}
-	if u.User != nil {
-		return false
-	}
-	if u.Path == "" || u.Path == "/" {
-		return false
-	}
-	if u.RawQuery != "" {
-		return false
-	}
-	return true
-}
-
-// IsCIMDClientID reports whether a client_id is a CIMD URL.
-func IsCIMDClientID(clientID string) bool {
-	return isCIMDClientID(clientID)
 }
 
 // isPrivateIP checks if an IP is private/loopback/link-local.

--- a/internal/adapter/mcp/cimd_client_lookup_test.go
+++ b/internal/adapter/mcp/cimd_client_lookup_test.go
@@ -1,4 +1,4 @@
-package storage
+package mcp
 
 import (
 	"context"
@@ -9,30 +9,25 @@ import (
 	"time"
 
 	"github.com/kangheeyong/authgate/internal/clock"
+	"github.com/kangheeyong/authgate/internal/idgen"
+	"github.com/kangheeyong/authgate/internal/storage"
 )
 
-type testCIMDClientResolutionPolicy struct {
-	s       *Storage
-	fetcher CIMDFetcher
-}
-
-func (p testCIMDClientResolutionPolicy) ResolveClient(ctx context.Context, clientID string) (*ClientModel, error) {
-	if v, ok := p.s.clients.Load(clientID); ok {
-		return v.(*ClientModel), nil
-	}
-	if p.fetcher != nil && IsCIMDClientID(clientID) {
-		return p.fetcher.FetchClient(ctx, clientID)
-	}
-	return nil, ErrNotFound
+func newStoreForClientLookup() *storage.Storage {
+	return storage.New(nil, clock.RealClock{}, idgen.CryptoGenerator{}, nil, time.Minute, time.Hour)
 }
 
 func TestGetClientByClientID_YAML(t *testing.T) {
-	store := &Storage{}
-	store.clients.Store("my-app", &ClientModel{
-		ID:   "my-app",
-		Name: "My App",
-		Type: "public",
-	})
+	store := newStoreForClientLookup()
+	store.LoadClients([]storage.ClientConfigEntry{{
+		ClientID:          "my-app",
+		ClientType:        "public",
+		LoginChannel:      "browser",
+		Name:              "My App",
+		RedirectURIs:      []string{"http://localhost:3000/callback"},
+		AllowedScopes:     []string{"openid"},
+		AllowedGrantTypes: []string{"authorization_code"},
+	}})
 
 	client, err := store.GetClientByClientID(context.Background(), "my-app")
 	if err != nil {
@@ -44,10 +39,10 @@ func TestGetClientByClientID_YAML(t *testing.T) {
 }
 
 func TestGetClientByClientID_NotFound(t *testing.T) {
-	store := &Storage{}
+	store := newStoreForClientLookup()
 
 	_, err := store.GetClientByClientID(context.Background(), "nonexistent")
-	if err != ErrNotFound {
+	if err != storage.ErrNotFound {
 		t.Errorf("error = %v, want ErrNotFound", err)
 	}
 }
@@ -67,9 +62,9 @@ func TestGetClientByClientID_CIMD(t *testing.T) {
 	defer srv.Close()
 	serverURL = srv.URL
 
-	store := &Storage{}
+	store := newStoreForClientLookup()
 	fetcher := &HTTPCIMDFetcher{client: srv.Client(), clock: clock.RealClock{}, cacheTTL: 5 * time.Minute}
-	store.SetClientResolutionPolicy(testCIMDClientResolutionPolicy{s: store, fetcher: fetcher})
+	store.SetClientResolutionPolicy(NewClientResolutionPolicy(storage.NewCoreClientResolutionPolicy(store), fetcher))
 
 	clientID := serverURL + "/oauth/client.json"
 	client, err := store.GetClientByClientID(context.Background(), clientID)

--- a/internal/adapter/mcp/cimd_fetcher_basic_test.go
+++ b/internal/adapter/mcp/cimd_fetcher_basic_test.go
@@ -1,4 +1,4 @@
-package storage
+package mcp
 
 import (
 	"context"
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kangheeyong/authgate/internal/clock"
+	"github.com/kangheeyong/authgate/internal/storage"
 )
 
 func TestCIMDFetcher_Success(t *testing.T) {
@@ -160,8 +161,8 @@ func TestIsCIMDClientID(t *testing.T) {
 		{"", false},
 	}
 	for _, tt := range tests {
-		if got := isCIMDClientID(tt.id); got != tt.want {
-			t.Errorf("isCIMDClientID(%q) = %v, want %v", tt.id, got, tt.want)
+		if got := storage.IsCIMDClientID(tt.id); got != tt.want {
+			t.Errorf("IsCIMDClientID(%q) = %v, want %v", tt.id, got, tt.want)
 		}
 	}
 }

--- a/internal/adapter/mcp/cimd_fetcher_cache_test.go
+++ b/internal/adapter/mcp/cimd_fetcher_cache_test.go
@@ -1,4 +1,4 @@
-package storage
+package mcp
 
 import (
 	"context"

--- a/internal/adapter/mcp/cimd_fetcher_validation_test.go
+++ b/internal/adapter/mcp/cimd_fetcher_validation_test.go
@@ -1,4 +1,4 @@
-package storage
+package mcp
 
 import (
 	"context"

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -58,7 +58,7 @@ func SetupTestServerWithOptions(t *testing.T, opts SetupOptions) *TestServer {
 
 	store := storage.New(db, clk, gen, stateChecker, 15*time.Minute, 30*24*time.Hour)
 	if opts.EnableMCP {
-		cimdFetcher := storage.NewHTTPCIMDFetcher()
+		cimdFetcher := mcpadapter.NewHTTPCIMDFetcher()
 		store.SetClientResolutionPolicy(mcpadapter.NewClientResolutionPolicy(storage.NewCoreClientResolutionPolicy(store), cimdFetcher))
 		store.SetResourceBindingPolicy(mcpadapter.NewResourceBindingPolicy(storage.NewCoreResourceBindingPolicy()))
 	}

--- a/internal/storage/cimd_contract.go
+++ b/internal/storage/cimd_contract.go
@@ -1,0 +1,44 @@
+package storage
+
+import (
+	"context"
+	"net/url"
+	"strings"
+)
+
+// CIMDFetcher fetches and validates CIMD (Client ID Metadata Document) clients.
+type CIMDFetcher interface {
+	FetchClient(ctx context.Context, clientID string) (*ClientModel, error)
+}
+
+func isCIMDClientID(clientID string) bool {
+	// ParseRequestURI doesn't parse fragments, check raw string
+	if strings.Contains(clientID, "#") {
+		return false
+	}
+	u, err := url.ParseRequestURI(clientID)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "https" {
+		return false
+	}
+	if u.Host == "" || u.Hostname() == "" {
+		return false
+	}
+	if u.User != nil {
+		return false
+	}
+	if u.Path == "" || u.Path == "/" {
+		return false
+	}
+	if u.RawQuery != "" {
+		return false
+	}
+	return true
+}
+
+// IsCIMDClientID reports whether a client_id is a CIMD URL.
+func IsCIMDClientID(clientID string) bool {
+	return isCIMDClientID(clientID)
+}


### PR DESCRIPTION
## Summary
- move HTTP CIMD fetcher implementation from storage package to internal/adapter/mcp
- keep storage package focused on contracts by introducing internal/storage/cimd_contract.go (CIMDFetcher, IsCIMDClientID)
- update main/integration wiring to construct fetcher from MCP adapter (mcp.NewHTTPCIMDFetcher)
- move CIMD fetcher and client lookup tests from storage to adapter/mcp package

## Why
- complete Phase 2 intent in architecture 002: core storage should not own MCP-specific CIMD implementation details

## Testing
- go test ./...
- go test -tags=integration ./internal/integration