### PR TITLE
fix(ci): upgrade GitHub actions to Node 24 and disable flaky cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,10 @@ jobs:
     runs-on: arc-runner-set-authgate
     container: catthehacker/ubuntu:act-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-go@v5.2.0
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
 
       - name: Install sqlc
         run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.28.0
@@ -82,11 +81,10 @@ jobs:
     runs-on: arc-runner-set-authgate
     container: catthehacker/ubuntu:act-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-go@v5.2.0
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
 
       - name: Build
         run: go build ./...
@@ -95,7 +93,7 @@ jobs:
         run: go test -coverprofile=coverage.out -tags=integration ./internal/...
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: code-coverage
           path: coverage.out
@@ -106,8 +104,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: code-coverage
       - uses: fgrosse/go-coverage-report@v1.3.0
@@ -121,11 +119,10 @@ jobs:
     runs-on: arc-runner-set-authgate
     container: catthehacker/ubuntu:act-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-go@v5.2.0
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
       - run: go vet ./...
 
   vuln:
@@ -133,11 +130,10 @@ jobs:
     runs-on: arc-runner-set-authgate
     container: catthehacker/ubuntu:act-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-go@v5.2.0
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
       - run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           # integration/test utility packages pull docker/testcontainers only for tests.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Read version
         id: version

--- a/.github/workflows/vuln-full-scan.yml
+++ b/.github/workflows/vuln-full-scan.yml
@@ -15,11 +15,10 @@ jobs:
     runs-on: arc-runner-set-authgate
     container: catthehacker/ubuntu:act-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-go@v5.2.0
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -32,7 +31,7 @@ jobs:
 
       - name: Upload full scan report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: govulncheck-full-report
           path: govulncheck-full.txt


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions that were pinned to Node 20-era majors to Node 24-compatible majors.
- Remove `cache: true` from `actions/setup-go` in CI/vuln scan workflows to avoid repeated cache service `400` restore/save failures.

## Changes
- `.github/workflows/ci.yml`
  - `actions/checkout@v4.2.2` -> `actions/checkout@v6`
  - `actions/setup-go@v5.2.0` -> `actions/setup-go@v6`
  - `actions/upload-artifact@v4` -> `actions/upload-artifact@v7`
  - `actions/download-artifact@v4` -> `actions/download-artifact@v8`
  - removed `cache: true` from setup-go steps
- `.github/workflows/vuln-full-scan.yml`
  - `actions/checkout@v4.2.2` -> `actions/checkout@v6`
  - `actions/setup-go@v5.2.0` -> `actions/setup-go@v6`
  - `actions/upload-artifact@v4` -> `actions/upload-artifact@v7`
  - removed `cache: true`
- `.github/workflows/release.yml`
  - `actions/checkout@v4` -> `actions/checkout@v6`

## Root cause
- CI logs showed Node 20 deprecation warnings because several actions were still on majors built for Node 20.
- Cache restore/save failed with `400` and transient service-unavailable HTML responses, indicating flaky cache backend/network path for these runners.

## Validation
- Confirmed workflow refs and diffs locally.
- `actionlint` is not installed in the local environment, so full lint validation was not run locally.

## Impact
- Removes Node 20 deprecation warnings for these actions.
- Prevents cache-related CI noise/failure path by disabling setup-go cache for now.
