### PR TITLE
fix(ci): replace deprecated coverage action with go tool summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,14 +105,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
       - uses: actions/download-artifact@v8
         with:
           name: code-coverage
-      - uses: fgrosse/go-coverage-report@v1.3.0
-        with:
-          coverage-artifact-name: code-coverage
-          coverage-file-name: coverage.out
-          root-package: github.com/kangheeyong/authgate
+      - name: Write coverage summary
+        run: |
+          if [ ! -f coverage.out ]; then
+            echo "No coverage artifact found." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          TOTAL_COVERAGE=$(go tool cover -func=coverage.out | awk '/^total:/ {print $3}')
+          echo "## Coverage Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Total coverage: ${TOTAL_COVERAGE}" >> "$GITHUB_STEP_SUMMARY"
 
   vet:
     name: Go Vet


### PR DESCRIPTION
## 원인 분석
- `Coverage Report` 잡은 `fgrosse/go-coverage-report@v1.3.0`를 사용하고 있었음.
- 해당 액션 내부에서 `tj-actions/changed-files@v42.1.0` 커밋(sha: `aa08304...`)을 호출하는데, 이 버전의 런타임은 `node20`.
- 그래서 GitHub Actions 러너에서 `Node.js 20 is deprecated` 경고가 발생.

## 왜 "No coverage report to output"가 떴는가
- 이 PR처럼 Go 코드 변경이 없는 경우(워크플로우/설정 변경만 있는 경우), 커버리지 리포트로 보여줄 대상 파일이 없어 notice가 출력됨.
- 즉 빌드 실패 원인이라기보다는 리포트 생성 조건 미충족 notice 성격.

## 변경 사항
- `.github/workflows/ci.yml`의 `coverage-report` 잡에서 `fgrosse/go-coverage-report@v1.3.0` 제거.
- 대신 `actions/setup-go@v6` + `go tool cover -func=coverage.out` 기반으로 Step Summary 작성.

## 기대 효과
- Node20 기반 서드파티 액션 경고 제거.
- 변경 파일 조건에 따른 "No coverage report to output" notice 제거.
- PR에서 최소한 총 커버리지 수치(`total`)는 안정적으로 확인 가능.
