### PR TITLE
feat(config): make http server timeouts configurable via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ go run ./cmd/authgate
 | `SESSION_TTL` | `86400` | session TTL in seconds |
 | `ACCESS_TOKEN_TTL` | `900` | access token TTL in seconds |
 | `REFRESH_TOKEN_TTL` | `2592000` | refresh token TTL in seconds |
+| `HTTP_READ_HEADER_TIMEOUT_SEC` | `5` | HTTP server `ReadHeaderTimeout` in seconds |
+| `HTTP_READ_TIMEOUT_SEC` | `15` | HTTP server `ReadTimeout` in seconds |
+| `HTTP_WRITE_TIMEOUT_SEC` | `30` | HTTP server `WriteTimeout` in seconds |
+| `HTTP_IDLE_TIMEOUT_SEC` | `60` | HTTP server `IdleTimeout` in seconds |
 | `ENABLE_MCP` | `true` | enable MCP optional adapter routes/policies (`/mcp/*`, CIMD/resource binding) |
 | `CLIENT_CONFIG` | `/etc/authgate/clients.yaml` | YAML path for client metadata preload |
 

--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -268,8 +268,12 @@ func main() {
 	// Server
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	srv := &http.Server{
-		Addr:    addr,
-		Handler: mux,
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: cfg.HTTPReadHeaderTimeout,
+		ReadTimeout:       cfg.HTTPReadTimeout,
+		WriteTimeout:      cfg.HTTPWriteTimeout,
+		IdleTimeout:       cfg.HTTPIdleTimeout,
 	}
 
 	// Cleanup service

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,38 +9,46 @@ import (
 )
 
 type Config struct {
-	Port             int
-	DatabaseURL      string
-	SessionSecret    string
-	PublicURL        string
-	OIDCIssuerURL    string
-	OIDCInternalURL  string // optional: internal base URL for server-to-server OIDC calls (Docker/K8s)
-	OIDCClientID     string
-	OIDCClientSecret string
-	SessionTTL       time.Duration
-	AccessTokenTTL   time.Duration
-	RefreshTokenTTL  time.Duration
-	DevMode          bool
-	EnableMCP        bool
-	ClientConfigPath string
+	Port                  int
+	DatabaseURL           string
+	SessionSecret         string
+	PublicURL             string
+	OIDCIssuerURL         string
+	OIDCInternalURL       string // optional: internal base URL for server-to-server OIDC calls (Docker/K8s)
+	OIDCClientID          string
+	OIDCClientSecret      string
+	SessionTTL            time.Duration
+	AccessTokenTTL        time.Duration
+	RefreshTokenTTL       time.Duration
+	DevMode               bool
+	EnableMCP             bool
+	ClientConfigPath      string
+	HTTPReadHeaderTimeout time.Duration
+	HTTPReadTimeout       time.Duration
+	HTTPWriteTimeout      time.Duration
+	HTTPIdleTimeout       time.Duration
 }
 
 func Load() (*Config, error) {
 	c := &Config{
-		Port:             envInt("PORT", 8080),
-		DatabaseURL:      os.Getenv("DATABASE_URL"),
-		SessionSecret:    os.Getenv("SESSION_SECRET"),
-		PublicURL:        os.Getenv("PUBLIC_URL"),
-		OIDCIssuerURL:    envDefault("OIDC_ISSUER_URL", "http://localhost:8082"),
-		OIDCInternalURL:  os.Getenv("OIDC_INTERNAL_URL"),
-		OIDCClientID:     envDefault("OIDC_CLIENT_ID", "authgate"),
-		OIDCClientSecret: os.Getenv("OIDC_CLIENT_SECRET"),
-		SessionTTL:       time.Duration(envInt("SESSION_TTL", 86400)) * time.Second,
-		AccessTokenTTL:   time.Duration(envInt("ACCESS_TOKEN_TTL", 900)) * time.Second,
-		RefreshTokenTTL:  time.Duration(envInt("REFRESH_TOKEN_TTL", 2592000)) * time.Second,
-		DevMode:          envBool("DEV_MODE", false),
-		EnableMCP:        envBool("ENABLE_MCP", true),
-		ClientConfigPath: envDefault("CLIENT_CONFIG", "/etc/authgate/clients.yaml"),
+		Port:                  envInt("PORT", 8080),
+		DatabaseURL:           os.Getenv("DATABASE_URL"),
+		SessionSecret:         os.Getenv("SESSION_SECRET"),
+		PublicURL:             os.Getenv("PUBLIC_URL"),
+		OIDCIssuerURL:         envDefault("OIDC_ISSUER_URL", "http://localhost:8082"),
+		OIDCInternalURL:       os.Getenv("OIDC_INTERNAL_URL"),
+		OIDCClientID:          envDefault("OIDC_CLIENT_ID", "authgate"),
+		OIDCClientSecret:      os.Getenv("OIDC_CLIENT_SECRET"),
+		SessionTTL:            time.Duration(envInt("SESSION_TTL", 86400)) * time.Second,
+		AccessTokenTTL:        time.Duration(envInt("ACCESS_TOKEN_TTL", 900)) * time.Second,
+		RefreshTokenTTL:       time.Duration(envInt("REFRESH_TOKEN_TTL", 2592000)) * time.Second,
+		DevMode:               envBool("DEV_MODE", false),
+		EnableMCP:             envBool("ENABLE_MCP", true),
+		ClientConfigPath:      envDefault("CLIENT_CONFIG", "/etc/authgate/clients.yaml"),
+		HTTPReadHeaderTimeout: time.Duration(envInt("HTTP_READ_HEADER_TIMEOUT_SEC", 5)) * time.Second,
+		HTTPReadTimeout:       time.Duration(envInt("HTTP_READ_TIMEOUT_SEC", 15)) * time.Second,
+		HTTPWriteTimeout:      time.Duration(envInt("HTTP_WRITE_TIMEOUT_SEC", 30)) * time.Second,
+		HTTPIdleTimeout:       time.Duration(envInt("HTTP_IDLE_TIMEOUT_SEC", 60)) * time.Second,
 	}
 
 	if c.DatabaseURL == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,6 +11,8 @@ func clearEnv() {
 		"OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET",
 		"SESSION_TTL", "ACCESS_TOKEN_TTL", "REFRESH_TOKEN_TTL",
 		"DEV_MODE", "ENABLE_MCP",
+		"HTTP_READ_HEADER_TIMEOUT_SEC", "HTTP_READ_TIMEOUT_SEC",
+		"HTTP_WRITE_TIMEOUT_SEC", "HTTP_IDLE_TIMEOUT_SEC",
 	} {
 		os.Unsetenv(key)
 	}
@@ -120,6 +122,18 @@ func TestLoad_Defaults(t *testing.T) {
 	if !cfg.EnableMCP {
 		t.Error("EnableMCP = false, want true by default")
 	}
+	if cfg.HTTPReadHeaderTimeout.Seconds() != 5 {
+		t.Errorf("HTTPReadHeaderTimeout = %v, want 5s", cfg.HTTPReadHeaderTimeout)
+	}
+	if cfg.HTTPReadTimeout.Seconds() != 15 {
+		t.Errorf("HTTPReadTimeout = %v, want 15s", cfg.HTTPReadTimeout)
+	}
+	if cfg.HTTPWriteTimeout.Seconds() != 30 {
+		t.Errorf("HTTPWriteTimeout = %v, want 30s", cfg.HTTPWriteTimeout)
+	}
+	if cfg.HTTPIdleTimeout.Seconds() != 60 {
+		t.Errorf("HTTPIdleTimeout = %v, want 60s", cfg.HTTPIdleTimeout)
+	}
 }
 
 func TestLoad_DevModeFalseShortSessionSecret(t *testing.T) {
@@ -175,5 +189,32 @@ func TestLoad_EnableMCPFalse(t *testing.T) {
 	}
 	if cfg.EnableMCP {
 		t.Fatal("EnableMCP should be false")
+	}
+}
+
+func TestLoad_HTTPTimeoutsFromEnv(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("HTTP_READ_HEADER_TIMEOUT_SEC", "7")
+	os.Setenv("HTTP_READ_TIMEOUT_SEC", "20")
+	os.Setenv("HTTP_WRITE_TIMEOUT_SEC", "40")
+	os.Setenv("HTTP_IDLE_TIMEOUT_SEC", "120")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.HTTPReadHeaderTimeout.Seconds() != 7 {
+		t.Errorf("HTTPReadHeaderTimeout = %v, want 7s", cfg.HTTPReadHeaderTimeout)
+	}
+	if cfg.HTTPReadTimeout.Seconds() != 20 {
+		t.Errorf("HTTPReadTimeout = %v, want 20s", cfg.HTTPReadTimeout)
+	}
+	if cfg.HTTPWriteTimeout.Seconds() != 40 {
+		t.Errorf("HTTPWriteTimeout = %v, want 40s", cfg.HTTPWriteTimeout)
+	}
+	if cfg.HTTPIdleTimeout.Seconds() != 120 {
+		t.Errorf("HTTPIdleTimeout = %v, want 120s", cfg.HTTPIdleTimeout)
 	}
 }


### PR DESCRIPTION
## Summary
- add configurable HTTP server timeout settings in config
- wire server timeout fields in main from config values
- add config tests for default and env override timeout behavior
- document new timeout env vars in README

## New Environment Variables
- HTTP_READ_HEADER_TIMEOUT_SEC (default: 5)
- HTTP_READ_TIMEOUT_SEC (default: 15)
- HTTP_WRITE_TIMEOUT_SEC (default: 30)
- HTTP_IDLE_TIMEOUT_SEC (default: 60)

## Validation
- go test ./internal/config ./cmd/authgate ./internal/service ./internal/storage
