### PR TITLE
feat(config): add configurable db pool settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ go run ./cmd/authgate
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DATABASE_URL` | required | PostgreSQL connection string |
+| `DB_MAX_OPEN_CONNS` | `25` | DB pool `MaxOpenConns` (`0` means unlimited) |
+| `DB_MAX_IDLE_CONNS` | `25` | DB pool `MaxIdleConns` (clamped to `DB_MAX_OPEN_CONNS` when needed) |
+| `DB_CONN_MAX_LIFETIME_SEC` | `300` | DB pool `ConnMaxLifetime` in seconds |
+| `DB_CONN_MAX_IDLE_TIME_SEC` | `120` | DB pool `ConnMaxIdleTime` in seconds |
 | `SESSION_SECRET` | required | provider crypto key source (>=32 chars in prod) |
 | `PUBLIC_URL` | required | external authgate URL |
 | `OIDC_ISSUER_URL` | `http://localhost:8082` | upstream OIDC issuer |

--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -40,6 +40,10 @@ func main() {
 		log.Fatalf("db open: %v", err)
 	}
 	defer db.Close()
+	db.SetMaxOpenConns(cfg.DBMaxOpenConns)
+	db.SetMaxIdleConns(cfg.DBMaxIdleConns)
+	db.SetConnMaxLifetime(cfg.DBConnMaxLifetime)
+	db.SetConnMaxIdleTime(cfg.DBConnMaxIdleTime)
 
 	if err := db.Ping(); err != nil {
 		log.Fatalf("db ping: %v", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,10 @@ import (
 type Config struct {
 	Port                  int
 	DatabaseURL           string
+	DBMaxOpenConns        int
+	DBMaxIdleConns        int
+	DBConnMaxLifetime     time.Duration
+	DBConnMaxIdleTime     time.Duration
 	SessionSecret         string
 	PublicURL             string
 	OIDCIssuerURL         string
@@ -33,6 +37,10 @@ func Load() (*Config, error) {
 	c := &Config{
 		Port:                  envInt("PORT", 8080),
 		DatabaseURL:           os.Getenv("DATABASE_URL"),
+		DBMaxOpenConns:        envInt("DB_MAX_OPEN_CONNS", 25),
+		DBMaxIdleConns:        envInt("DB_MAX_IDLE_CONNS", 25),
+		DBConnMaxLifetime:     time.Duration(envInt("DB_CONN_MAX_LIFETIME_SEC", 300)) * time.Second,
+		DBConnMaxIdleTime:     time.Duration(envInt("DB_CONN_MAX_IDLE_TIME_SEC", 120)) * time.Second,
 		SessionSecret:         os.Getenv("SESSION_SECRET"),
 		PublicURL:             os.Getenv("PUBLIC_URL"),
 		OIDCIssuerURL:         envDefault("OIDC_ISSUER_URL", "http://localhost:8082"),
@@ -59,6 +67,21 @@ func Load() (*Config, error) {
 	}
 	if c.PublicURL == "" {
 		return nil, fmt.Errorf("PUBLIC_URL is required")
+	}
+	if c.DBMaxOpenConns < 0 {
+		return nil, fmt.Errorf("DB_MAX_OPEN_CONNS must be >= 0")
+	}
+	if c.DBMaxIdleConns < 0 {
+		return nil, fmt.Errorf("DB_MAX_IDLE_CONNS must be >= 0")
+	}
+	if c.DBConnMaxLifetime < 0 {
+		return nil, fmt.Errorf("DB_CONN_MAX_LIFETIME_SEC must be >= 0")
+	}
+	if c.DBConnMaxIdleTime < 0 {
+		return nil, fmt.Errorf("DB_CONN_MAX_IDLE_TIME_SEC must be >= 0")
+	}
+	if c.DBMaxOpenConns > 0 && c.DBMaxIdleConns > c.DBMaxOpenConns {
+		c.DBMaxIdleConns = c.DBMaxOpenConns
 	}
 
 	// Production guards

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,6 +11,8 @@ func clearEnv() {
 		"OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET",
 		"SESSION_TTL", "ACCESS_TOKEN_TTL", "REFRESH_TOKEN_TTL",
 		"DEV_MODE", "ENABLE_MCP",
+		"DB_MAX_OPEN_CONNS", "DB_MAX_IDLE_CONNS",
+		"DB_CONN_MAX_LIFETIME_SEC", "DB_CONN_MAX_IDLE_TIME_SEC",
 		"HTTP_READ_HEADER_TIMEOUT_SEC", "HTTP_READ_TIMEOUT_SEC",
 		"HTTP_WRITE_TIMEOUT_SEC", "HTTP_IDLE_TIMEOUT_SEC",
 	} {
@@ -134,6 +136,18 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.HTTPIdleTimeout.Seconds() != 60 {
 		t.Errorf("HTTPIdleTimeout = %v, want 60s", cfg.HTTPIdleTimeout)
 	}
+	if cfg.DBMaxOpenConns != 25 {
+		t.Errorf("DBMaxOpenConns = %d, want 25", cfg.DBMaxOpenConns)
+	}
+	if cfg.DBMaxIdleConns != 25 {
+		t.Errorf("DBMaxIdleConns = %d, want 25", cfg.DBMaxIdleConns)
+	}
+	if cfg.DBConnMaxLifetime.Seconds() != 300 {
+		t.Errorf("DBConnMaxLifetime = %v, want 300s", cfg.DBConnMaxLifetime)
+	}
+	if cfg.DBConnMaxIdleTime.Seconds() != 120 {
+		t.Errorf("DBConnMaxIdleTime = %v, want 120s", cfg.DBConnMaxIdleTime)
+	}
 }
 
 func TestLoad_DevModeFalseShortSessionSecret(t *testing.T) {
@@ -216,5 +230,46 @@ func TestLoad_HTTPTimeoutsFromEnv(t *testing.T) {
 	}
 	if cfg.HTTPIdleTimeout.Seconds() != 120 {
 		t.Errorf("HTTPIdleTimeout = %v, want 120s", cfg.HTTPIdleTimeout)
+	}
+}
+
+func TestLoad_DBPoolFromEnv(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("DB_MAX_OPEN_CONNS", "40")
+	os.Setenv("DB_MAX_IDLE_CONNS", "12")
+	os.Setenv("DB_CONN_MAX_LIFETIME_SEC", "600")
+	os.Setenv("DB_CONN_MAX_IDLE_TIME_SEC", "90")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DBMaxOpenConns != 40 {
+		t.Errorf("DBMaxOpenConns = %d, want 40", cfg.DBMaxOpenConns)
+	}
+	if cfg.DBMaxIdleConns != 12 {
+		t.Errorf("DBMaxIdleConns = %d, want 12", cfg.DBMaxIdleConns)
+	}
+	if cfg.DBConnMaxLifetime.Seconds() != 600 {
+		t.Errorf("DBConnMaxLifetime = %v, want 600s", cfg.DBConnMaxLifetime)
+	}
+	if cfg.DBConnMaxIdleTime.Seconds() != 90 {
+		t.Errorf("DBConnMaxIdleTime = %v, want 90s", cfg.DBConnMaxIdleTime)
+	}
+}
+
+func TestLoad_DBPoolClampIdleToOpen(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("DB_MAX_OPEN_CONNS", "10")
+	os.Setenv("DB_MAX_IDLE_CONNS", "30")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DBMaxIdleConns != 10 {
+		t.Errorf("DBMaxIdleConns = %d, want clamped 10", cfg.DBMaxIdleConns)
 	}
 }


### PR DESCRIPTION
## Summary
- add DB pool config options to runtime config
- apply DB pool settings in server startup
- add config tests for defaults/env override and idle<=open clamping
- document DB pool environment variables in README

## New Environment Variables
- DB_MAX_OPEN_CONNS (default: 25)
- DB_MAX_IDLE_CONNS (default: 25)
- DB_CONN_MAX_LIFETIME_SEC (default: 300)
- DB_CONN_MAX_IDLE_TIME_SEC (default: 120)

## Validation
- go test ./internal/config ./cmd/authgate ./internal/service ./internal/storage
