### PR TITLE
feat(config): add upstream oidc http timeout setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ go run ./cmd/authgate
 | `PUBLIC_URL` | required | external authgate URL |
 | `OIDC_ISSUER_URL` | `http://localhost:8082` | upstream OIDC issuer |
 | `OIDC_INTERNAL_URL` | empty | internal URL for server-to-server OIDC calls (Docker/K8s) |
+| `OIDC_HTTP_TIMEOUT_SEC` | `10` | outbound HTTP timeout for upstream OIDC discovery/token/userinfo calls |
 | `OIDC_CLIENT_ID` | `authgate` | upstream OIDC client ID |
 | `OIDC_CLIENT_SECRET` | empty | upstream OIDC client secret |
 | `PORT` | `8080` | listen port |

--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -145,6 +145,7 @@ func main() {
 	if cfg.OIDCInternalURL != "" {
 		upstreamOpts = append(upstreamOpts, upstream.WithInternalURL(cfg.OIDCInternalURL))
 	}
+	upstreamOpts = append(upstreamOpts, upstream.WithHTTPTimeout(cfg.OIDCHTTPTimeout))
 	browserProvider, err := upstream.NewOIDCProvider(ctx, cfg.OIDCIssuerURL, cfg.OIDCClientID, cfg.OIDCClientSecret, cfg.PublicURL+"/login/callback", upstreamOpts...)
 	if err != nil {
 		log.Fatalf("browser provider: %v", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	PublicURL             string
 	OIDCIssuerURL         string
 	OIDCInternalURL       string // optional: internal base URL for server-to-server OIDC calls (Docker/K8s)
+	OIDCHTTPTimeout       time.Duration
 	OIDCClientID          string
 	OIDCClientSecret      string
 	SessionTTL            time.Duration
@@ -45,6 +46,7 @@ func Load() (*Config, error) {
 		PublicURL:             os.Getenv("PUBLIC_URL"),
 		OIDCIssuerURL:         envDefault("OIDC_ISSUER_URL", "http://localhost:8082"),
 		OIDCInternalURL:       os.Getenv("OIDC_INTERNAL_URL"),
+		OIDCHTTPTimeout:       time.Duration(envInt("OIDC_HTTP_TIMEOUT_SEC", 10)) * time.Second,
 		OIDCClientID:          envDefault("OIDC_CLIENT_ID", "authgate"),
 		OIDCClientSecret:      os.Getenv("OIDC_CLIENT_SECRET"),
 		SessionTTL:            time.Duration(envInt("SESSION_TTL", 86400)) * time.Second,
@@ -67,6 +69,9 @@ func Load() (*Config, error) {
 	}
 	if c.PublicURL == "" {
 		return nil, fmt.Errorf("PUBLIC_URL is required")
+	}
+	if c.OIDCHTTPTimeout <= 0 {
+		return nil, fmt.Errorf("OIDC_HTTP_TIMEOUT_SEC must be > 0")
 	}
 	if c.DBMaxOpenConns < 0 {
 		return nil, fmt.Errorf("DB_MAX_OPEN_CONNS must be >= 0")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,7 @@ func clearEnv() {
 	for _, key := range []string{
 		"PORT", "DATABASE_URL", "SESSION_SECRET", "PUBLIC_URL",
 		"OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET",
+		"OIDC_HTTP_TIMEOUT_SEC",
 		"SESSION_TTL", "ACCESS_TOKEN_TTL", "REFRESH_TOKEN_TTL",
 		"DEV_MODE", "ENABLE_MCP",
 		"DB_MAX_OPEN_CONNS", "DB_MAX_IDLE_CONNS",
@@ -108,6 +109,9 @@ func TestLoad_Defaults(t *testing.T) {
 	}
 	if cfg.OIDCIssuerURL != "http://localhost:8082" {
 		t.Errorf("OIDCIssuerURL = %q, want http://localhost:8082", cfg.OIDCIssuerURL)
+	}
+	if cfg.OIDCHTTPTimeout.Seconds() != 10 {
+		t.Errorf("OIDCHTTPTimeout = %v, want 10s", cfg.OIDCHTTPTimeout)
 	}
 	if cfg.OIDCClientID != "authgate" {
 		t.Errorf("OIDCClientID = %q, want authgate", cfg.OIDCClientID)
@@ -230,6 +234,31 @@ func TestLoad_HTTPTimeoutsFromEnv(t *testing.T) {
 	}
 	if cfg.HTTPIdleTimeout.Seconds() != 120 {
 		t.Errorf("HTTPIdleTimeout = %v, want 120s", cfg.HTTPIdleTimeout)
+	}
+}
+
+func TestLoad_OIDCHTTPTimeoutFromEnv(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("OIDC_HTTP_TIMEOUT_SEC", "25")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.OIDCHTTPTimeout.Seconds() != 25 {
+		t.Errorf("OIDCHTTPTimeout = %v, want 25s", cfg.OIDCHTTPTimeout)
+	}
+}
+
+func TestLoad_OIDCHTTPTimeoutInvalid(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("OIDC_HTTP_TIMEOUT_SEC", "0")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error: OIDC_HTTP_TIMEOUT_SEC must be > 0")
 	}
 }
 

--- a/internal/upstream/oidc.go
+++ b/internal/upstream/oidc.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
@@ -23,6 +24,7 @@ type Option func(*options)
 type options struct {
 	rpOpts      []rp.Option
 	internalURL string
+	httpTimeout time.Duration
 }
 
 // WithRPOptions passes options to the underlying rp.NewRelyingPartyOIDC.
@@ -37,6 +39,11 @@ func WithInternalURL(internalURL string) Option {
 	return func(o *options) { o.internalURL = internalURL }
 }
 
+// WithHTTPTimeout sets outbound HTTP timeout for OIDC discovery/token/userinfo calls.
+func WithHTTPTimeout(timeout time.Duration) Option {
+	return func(o *options) { o.httpTimeout = timeout }
+}
+
 // NewOIDCProvider creates a provider by performing OIDC Discovery on the issuer URL.
 func NewOIDCProvider(ctx context.Context, issuerURL, clientID, clientSecret, redirectURI string, opts ...Option) (*OIDCProvider, error) {
 	o := &options{}
@@ -44,19 +51,27 @@ func NewOIDCProvider(ctx context.Context, issuerURL, clientID, clientSecret, red
 		opt(o)
 	}
 
+	var transport http.RoundTripper = http.DefaultTransport
 	if o.internalURL != "" {
 		issuerParsed, _ := url.Parse(issuerURL)
 		internalParsed, _ := url.Parse(o.internalURL)
 		if issuerParsed != nil && internalParsed != nil {
-			o.rpOpts = append(o.rpOpts, rp.WithHTTPClient(&http.Client{
-				Transport: &hostRewriteTransport{
-					fromHost:  issuerParsed.Host,
-					toHost:    internalParsed.Host,
-					toScheme:  internalParsed.Scheme,
-					transport: http.DefaultTransport,
-				},
-			}))
+			transport = &hostRewriteTransport{
+				fromHost:  issuerParsed.Host,
+				toHost:    internalParsed.Host,
+				toScheme:  internalParsed.Scheme,
+				transport: http.DefaultTransport,
+			}
 		}
+	}
+	if o.httpTimeout > 0 || o.internalURL != "" {
+		client := &http.Client{
+			Transport: transport,
+		}
+		if o.httpTimeout > 0 {
+			client.Timeout = o.httpTimeout
+		}
+		o.rpOpts = append(o.rpOpts, rp.WithHTTPClient(client))
 	}
 
 	scopes := []string{"openid", "email", "profile"}


### PR DESCRIPTION
## Summary
- add OIDC upstream HTTP timeout config in environment/runtime config
- wire timeout option in main for all upstream OIDC providers (browser/device/mcp)
- apply timeout to upstream OIDC HTTP client creation
- add config tests for default/override/invalid timeout
- document OIDC_HTTP_TIMEOUT_SEC in README

## New Environment Variables
- OIDC_HTTP_TIMEOUT_SEC (default: 10)

## Validation
- go test ./internal/config ./internal/upstream ./cmd/authgate ./internal/service ./internal/storage
