### PR TITLE
feat(runtime): improve graceful shutdown handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ go run ./cmd/authgate
 | `HTTP_READ_TIMEOUT_SEC` | `15` | HTTP server `ReadTimeout` in seconds |
 | `HTTP_WRITE_TIMEOUT_SEC` | `30` | HTTP server `WriteTimeout` in seconds |
 | `HTTP_IDLE_TIMEOUT_SEC` | `60` | HTTP server `IdleTimeout` in seconds |
+| `SHUTDOWN_TIMEOUT_SEC` | `10` | graceful shutdown timeout in seconds before forced close |
 | `ENABLE_MCP` | `true` | enable MCP optional adapter routes/policies (`/mcp/*`, CIMD/resource binding) |
 | `CLIENT_CONFIG` | `/etc/authgate/clients.yaml` | YAML path for client metadata preload |
 

--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -272,9 +273,15 @@ func main() {
 
 	// Server
 	addr := fmt.Sprintf(":%d", cfg.Port)
+	var inflightRequests int64
+	trackedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&inflightRequests, 1)
+		defer atomic.AddInt64(&inflightRequests, -1)
+		mux.ServeHTTP(w, r)
+	})
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           mux,
+		Handler:           trackedHandler,
 		ReadHeaderTimeout: cfg.HTTPReadHeaderTimeout,
 		ReadTimeout:       cfg.HTTPReadTimeout,
 		WriteTimeout:      cfg.HTTPWriteTimeout,
@@ -290,13 +297,26 @@ func main() {
 
 	// Graceful shutdown
 	go func() {
-		sigCh := make(chan os.Signal, 1)
+		sigCh := make(chan os.Signal, 2)
 		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 		<-sigCh
-		slog.Info("shutting down")
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		slog.Info("shutdown signal received", "inflight_requests", atomic.LoadInt64(&inflightRequests))
+
+		// If another signal arrives while draining, force immediate close.
+		go func() {
+			<-sigCh
+			slog.Warn("second shutdown signal received; forcing close")
+			_ = srv.Close()
+		}()
+
+		cleanupCancel()
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
 		defer cancel()
-		srv.Shutdown(ctx)
+		if err := srv.Shutdown(ctx); err != nil {
+			slog.Error("graceful shutdown failed", "error", err)
+		}
+		signal.Stop(sigCh)
+		slog.Info("shutdown completed", "inflight_requests", atomic.LoadInt64(&inflightRequests))
 	}()
 
 	slog.Info("authgate starting", "addr", addr, "dev", cfg.DevMode, "mcp", cfg.EnableMCP, "issuer", cfg.OIDCIssuerURL, "provider", browserProvider.Name())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	HTTPReadTimeout       time.Duration
 	HTTPWriteTimeout      time.Duration
 	HTTPIdleTimeout       time.Duration
+	ShutdownTimeout       time.Duration
 }
 
 func Load() (*Config, error) {
@@ -59,6 +60,7 @@ func Load() (*Config, error) {
 		HTTPReadTimeout:       time.Duration(envInt("HTTP_READ_TIMEOUT_SEC", 15)) * time.Second,
 		HTTPWriteTimeout:      time.Duration(envInt("HTTP_WRITE_TIMEOUT_SEC", 30)) * time.Second,
 		HTTPIdleTimeout:       time.Duration(envInt("HTTP_IDLE_TIMEOUT_SEC", 60)) * time.Second,
+		ShutdownTimeout:       time.Duration(envInt("SHUTDOWN_TIMEOUT_SEC", 10)) * time.Second,
 	}
 
 	if c.DatabaseURL == "" {
@@ -72,6 +74,9 @@ func Load() (*Config, error) {
 	}
 	if c.OIDCHTTPTimeout <= 0 {
 		return nil, fmt.Errorf("OIDC_HTTP_TIMEOUT_SEC must be > 0")
+	}
+	if c.ShutdownTimeout <= 0 {
+		return nil, fmt.Errorf("SHUTDOWN_TIMEOUT_SEC must be > 0")
 	}
 	if c.DBMaxOpenConns < 0 {
 		return nil, fmt.Errorf("DB_MAX_OPEN_CONNS must be >= 0")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,6 +16,7 @@ func clearEnv() {
 		"DB_CONN_MAX_LIFETIME_SEC", "DB_CONN_MAX_IDLE_TIME_SEC",
 		"HTTP_READ_HEADER_TIMEOUT_SEC", "HTTP_READ_TIMEOUT_SEC",
 		"HTTP_WRITE_TIMEOUT_SEC", "HTTP_IDLE_TIMEOUT_SEC",
+		"SHUTDOWN_TIMEOUT_SEC",
 	} {
 		os.Unsetenv(key)
 	}
@@ -140,6 +141,9 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.HTTPIdleTimeout.Seconds() != 60 {
 		t.Errorf("HTTPIdleTimeout = %v, want 60s", cfg.HTTPIdleTimeout)
 	}
+	if cfg.ShutdownTimeout.Seconds() != 10 {
+		t.Errorf("ShutdownTimeout = %v, want 10s", cfg.ShutdownTimeout)
+	}
 	if cfg.DBMaxOpenConns != 25 {
 		t.Errorf("DBMaxOpenConns = %d, want 25", cfg.DBMaxOpenConns)
 	}
@@ -259,6 +263,31 @@ func TestLoad_OIDCHTTPTimeoutInvalid(t *testing.T) {
 	_, err := Load()
 	if err == nil {
 		t.Fatal("expected error: OIDC_HTTP_TIMEOUT_SEC must be > 0")
+	}
+}
+
+func TestLoad_ShutdownTimeoutFromEnv(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("SHUTDOWN_TIMEOUT_SEC", "20")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ShutdownTimeout.Seconds() != 20 {
+		t.Errorf("ShutdownTimeout = %v, want 20s", cfg.ShutdownTimeout)
+	}
+}
+
+func TestLoad_ShutdownTimeoutInvalid(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("SHUTDOWN_TIMEOUT_SEC", "0")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error: SHUTDOWN_TIMEOUT_SEC must be > 0")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add SHUTDOWN_TIMEOUT_SEC config (default: 10)
- track inflight requests in server handler wrapper
- log inflight count at shutdown start/end
- support second signal to force immediate close during drain
- use configured shutdown timeout in graceful shutdown path
- document new env var in README

## New Environment Variables
- SHUTDOWN_TIMEOUT_SEC (default: 10)

## Validation
- go test ./internal/config ./cmd/authgate ./internal/service ./internal/storage ./internal/upstream
