### PR TITLE
feat(cleanup): add advisory lock for single-runner execution

### DIFF
--- a/internal/service/cleanup.go
+++ b/internal/service/cleanup.go
@@ -9,8 +9,7 @@ import (
 )
 
 type cleanupRunner interface {
-	TryAdvisoryLock(ctx context.Context) (bool, error)
-	ReleaseAdvisoryLock(ctx context.Context) error
+	WithExclusiveLock(ctx context.Context, fn func(context.Context) error) (bool, error)
 	DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteExpiredRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteExpiredOrRevokedSessions(ctx context.Context, cutoff time.Time) (int64, error)
@@ -56,21 +55,18 @@ func (c *CleanupService) Start(ctx context.Context) {
 }
 
 func (c *CleanupService) runAll(ctx context.Context) {
-	acquired, err := c.runner.TryAdvisoryLock(ctx)
+	acquired, err := c.runner.WithExclusiveLock(ctx, c.runAllLocked)
 	if err != nil {
-		slog.Error("cleanup advisory lock failed", "error", err)
+		slog.Error("cleanup run failed", "error", err)
 		return
 	}
 	if !acquired {
 		slog.Info("cleanup skipped: advisory lock not acquired")
 		return
 	}
-	defer func() {
-		if err := c.runner.ReleaseAdvisoryLock(ctx); err != nil {
-			slog.Error("cleanup advisory unlock failed", "error", err)
-		}
-	}()
+}
 
+func (c *CleanupService) runAllLocked(ctx context.Context) error {
 	now := c.clock.Now()
 
 	// 1. Token cleanup: revoked/expired refresh_tokens after 30 days
@@ -127,6 +123,7 @@ func (c *CleanupService) runAll(ctx context.Context) {
 	} else if n > 0 {
 		slog.Info("audit_log anonymization", "anonymized", n)
 	}
+	return nil
 }
 
 // deleteUser performs Spec 006 stage 3: explicit DELETE of child records + PII scrub.

--- a/internal/service/cleanup.go
+++ b/internal/service/cleanup.go
@@ -9,6 +9,8 @@ import (
 )
 
 type cleanupRunner interface {
+	TryAdvisoryLock(ctx context.Context) (bool, error)
+	ReleaseAdvisoryLock(ctx context.Context) error
 	DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteExpiredRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteExpiredOrRevokedSessions(ctx context.Context, cutoff time.Time) (int64, error)
@@ -54,6 +56,21 @@ func (c *CleanupService) Start(ctx context.Context) {
 }
 
 func (c *CleanupService) runAll(ctx context.Context) {
+	acquired, err := c.runner.TryAdvisoryLock(ctx)
+	if err != nil {
+		slog.Error("cleanup advisory lock failed", "error", err)
+		return
+	}
+	if !acquired {
+		slog.Info("cleanup skipped: advisory lock not acquired")
+		return
+	}
+	defer func() {
+		if err := c.runner.ReleaseAdvisoryLock(ctx); err != nil {
+			slog.Error("cleanup advisory unlock failed", "error", err)
+		}
+	}()
+
 	now := c.clock.Now()
 
 	// 1. Token cleanup: revoked/expired refresh_tokens after 30 days

--- a/internal/service/cleanup_unit_test.go
+++ b/internal/service/cleanup_unit_test.go
@@ -9,22 +9,21 @@ import (
 )
 
 type cleanupRunnerStub struct {
-	tryLockOK       bool
-	tryLockErr      error
-	releaseErr      error
-	tryLockCalls    int
-	releaseCalls    int
+	lockAcquired    bool
+	lockErr         error
+	lockCalls       int
 	cleanupCallHits int
 }
 
-func (s *cleanupRunnerStub) TryAdvisoryLock(ctx context.Context) (bool, error) {
-	s.tryLockCalls++
-	return s.tryLockOK, s.tryLockErr
-}
-
-func (s *cleanupRunnerStub) ReleaseAdvisoryLock(ctx context.Context) error {
-	s.releaseCalls++
-	return s.releaseErr
+func (s *cleanupRunnerStub) WithExclusiveLock(ctx context.Context, fn func(context.Context) error) (bool, error) {
+	s.lockCalls++
+	if s.lockErr != nil {
+		return false, s.lockErr
+	}
+	if !s.lockAcquired {
+		return false, nil
+	}
+	return true, fn(ctx)
 }
 
 func (s *cleanupRunnerStub) DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -68,35 +67,29 @@ func (s *cleanupRunnerStub) DeleteUser(ctx context.Context, userID string, now t
 }
 
 func TestCleanupRunAll_SkipsWhenAdvisoryLockNotAcquired(t *testing.T) {
-	runner := &cleanupRunnerStub{tryLockOK: false}
+	runner := &cleanupRunnerStub{lockAcquired: false}
 	svc := NewCleanupService(runner, &clock.FixedClock{T: time.Now()}, time.Minute)
 
 	svc.RunOnce(context.Background())
 
-	if runner.tryLockCalls != 1 {
-		t.Fatalf("try lock calls = %d, want 1", runner.tryLockCalls)
+	if runner.lockCalls != 1 {
+		t.Fatalf("lock calls = %d, want 1", runner.lockCalls)
 	}
 	if runner.cleanupCallHits != 0 {
 		t.Fatalf("cleanup calls = %d, want 0 when lock not acquired", runner.cleanupCallHits)
 	}
-	if runner.releaseCalls != 0 {
-		t.Fatalf("release calls = %d, want 0 when lock not acquired", runner.releaseCalls)
-	}
 }
 
 func TestCleanupRunAll_ReleasesLockAfterRun(t *testing.T) {
-	runner := &cleanupRunnerStub{tryLockOK: true}
+	runner := &cleanupRunnerStub{lockAcquired: true}
 	svc := NewCleanupService(runner, &clock.FixedClock{T: time.Now()}, time.Minute)
 
 	svc.RunOnce(context.Background())
 
-	if runner.tryLockCalls != 1 {
-		t.Fatalf("try lock calls = %d, want 1", runner.tryLockCalls)
+	if runner.lockCalls != 1 {
+		t.Fatalf("lock calls = %d, want 1", runner.lockCalls)
 	}
 	if runner.cleanupCallHits == 0 {
 		t.Fatal("cleanup calls = 0, want > 0 when lock acquired")
-	}
-	if runner.releaseCalls != 1 {
-		t.Fatalf("release calls = %d, want 1", runner.releaseCalls)
 	}
 }

--- a/internal/service/cleanup_unit_test.go
+++ b/internal/service/cleanup_unit_test.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kangheeyong/authgate/internal/clock"
+)
+
+type cleanupRunnerStub struct {
+	tryLockOK       bool
+	tryLockErr      error
+	releaseErr      error
+	tryLockCalls    int
+	releaseCalls    int
+	cleanupCallHits int
+}
+
+func (s *cleanupRunnerStub) TryAdvisoryLock(ctx context.Context) (bool, error) {
+	s.tryLockCalls++
+	return s.tryLockOK, s.tryLockErr
+}
+
+func (s *cleanupRunnerStub) ReleaseAdvisoryLock(ctx context.Context) error {
+	s.releaseCalls++
+	return s.releaseErr
+}
+
+func (s *cleanupRunnerStub) DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	s.cleanupCallHits++
+	return 0, nil
+}
+
+func (s *cleanupRunnerStub) DeleteExpiredRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	s.cleanupCallHits++
+	return 0, nil
+}
+
+func (s *cleanupRunnerStub) DeleteExpiredOrRevokedSessions(ctx context.Context, cutoff time.Time) (int64, error) {
+	s.cleanupCallHits++
+	return 0, nil
+}
+
+func (s *cleanupRunnerStub) DeleteExpiredAuthRequestsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	s.cleanupCallHits++
+	return 0, nil
+}
+
+func (s *cleanupRunnerStub) DeleteExpiredDeviceCodesBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	s.cleanupCallHits++
+	return 0, nil
+}
+
+func (s *cleanupRunnerStub) ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff time.Time) ([]string, error) {
+	s.cleanupCallHits++
+	return nil, nil
+}
+
+func (s *cleanupRunnerStub) AnonymizeAuditLogBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	s.cleanupCallHits++
+	return 0, nil
+}
+
+func (s *cleanupRunnerStub) DeleteUser(ctx context.Context, userID string, now time.Time, hook func(ctx context.Context, userID string) error) error {
+	s.cleanupCallHits++
+	return nil
+}
+
+func TestCleanupRunAll_SkipsWhenAdvisoryLockNotAcquired(t *testing.T) {
+	runner := &cleanupRunnerStub{tryLockOK: false}
+	svc := NewCleanupService(runner, &clock.FixedClock{T: time.Now()}, time.Minute)
+
+	svc.RunOnce(context.Background())
+
+	if runner.tryLockCalls != 1 {
+		t.Fatalf("try lock calls = %d, want 1", runner.tryLockCalls)
+	}
+	if runner.cleanupCallHits != 0 {
+		t.Fatalf("cleanup calls = %d, want 0 when lock not acquired", runner.cleanupCallHits)
+	}
+	if runner.releaseCalls != 0 {
+		t.Fatalf("release calls = %d, want 0 when lock not acquired", runner.releaseCalls)
+	}
+}
+
+func TestCleanupRunAll_ReleasesLockAfterRun(t *testing.T) {
+	runner := &cleanupRunnerStub{tryLockOK: true}
+	svc := NewCleanupService(runner, &clock.FixedClock{T: time.Now()}, time.Minute)
+
+	svc.RunOnce(context.Background())
+
+	if runner.tryLockCalls != 1 {
+		t.Fatalf("try lock calls = %d, want 1", runner.tryLockCalls)
+	}
+	if runner.cleanupCallHits == 0 {
+		t.Fatal("cleanup calls = 0, want > 0 when lock acquired")
+	}
+	if runner.releaseCalls != 1 {
+		t.Fatalf("release calls = %d, want 1", runner.releaseCalls)
+	}
+}

--- a/internal/storage/cleanup_runner.go
+++ b/internal/storage/cleanup_runner.go
@@ -13,8 +13,27 @@ type CleanupRunner struct {
 	db *sql.DB
 }
 
+const cleanupAdvisoryLockKey int64 = 0x6175746867617465 // "authgate" hex (stable process-wide lock key)
+
 func NewCleanupRunner(db *sql.DB) *CleanupRunner {
 	return &CleanupRunner{db: db}
+}
+
+func (r *CleanupRunner) TryAdvisoryLock(ctx context.Context) (bool, error) {
+	var acquired bool
+	err := r.db.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, cleanupAdvisoryLockKey).Scan(&acquired)
+	if err != nil {
+		return false, err
+	}
+	return acquired, nil
+}
+
+func (r *CleanupRunner) ReleaseAdvisoryLock(ctx context.Context) error {
+	var released bool
+	if err := r.db.QueryRowContext(ctx, `SELECT pg_advisory_unlock($1)`, cleanupAdvisoryLockKey).Scan(&released); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (r *CleanupRunner) DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {

--- a/internal/storage/cleanup_runner.go
+++ b/internal/storage/cleanup_runner.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/kangheeyong/authgate/internal/db/storeq"
@@ -19,21 +20,36 @@ func NewCleanupRunner(db *sql.DB) *CleanupRunner {
 	return &CleanupRunner{db: db}
 }
 
-func (r *CleanupRunner) TryAdvisoryLock(ctx context.Context) (bool, error) {
-	var acquired bool
-	err := r.db.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, cleanupAdvisoryLockKey).Scan(&acquired)
+func (r *CleanupRunner) WithExclusiveLock(ctx context.Context, fn func(context.Context) error) (bool, error) {
+	conn, err := r.db.Conn(ctx)
 	if err != nil {
 		return false, err
 	}
-	return acquired, nil
-}
+	defer conn.Close()
 
-func (r *CleanupRunner) ReleaseAdvisoryLock(ctx context.Context) error {
-	var released bool
-	if err := r.db.QueryRowContext(ctx, `SELECT pg_advisory_unlock($1)`, cleanupAdvisoryLockKey).Scan(&released); err != nil {
-		return err
+	var acquired bool
+	if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, cleanupAdvisoryLockKey).Scan(&acquired); err != nil {
+		return false, err
 	}
-	return nil
+	if !acquired {
+		return false, nil
+	}
+
+	runErr := fn(ctx)
+
+	var released bool
+	unlockErr := conn.QueryRowContext(ctx, `SELECT pg_advisory_unlock($1)`, cleanupAdvisoryLockKey).Scan(&released)
+
+	if runErr != nil {
+		return true, runErr
+	}
+	if unlockErr != nil {
+		return true, unlockErr
+	}
+	if !released {
+		return true, fmt.Errorf("cleanup advisory unlock failed")
+	}
+	return true, nil
 }
 
 func (r *CleanupRunner) DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {


### PR DESCRIPTION
## Summary
- add PostgreSQL advisory lock acquisition/release in cleanup runner
- gate cleanup execution on advisory lock in cleanup service
- skip cleanup run when lock is held by another instance
- add unit tests for lock-not-acquired and lock-release behavior

## Why
- prevent duplicated cleanup work in multi-pod deployment
- make cleanup execution single-runner per interval across replicas

## Validation
- go test ./internal/service ./internal/storage ./cmd/authgate