### PR TITLE
perf(cleanup): batch cleanup deletes and audit anonymization

### DIFF
--- a/internal/db/queries/cleanup.sql
+++ b/internal/db/queries/cleanup.sql
@@ -1,22 +1,57 @@
--- name: DeleteRevokedRefreshTokensBefore :execrows
-DELETE FROM refresh_tokens
-WHERE revoked_at IS NOT NULL AND revoked_at < sqlc.arg(cutoff);
+-- name: DeleteRevokedRefreshTokensBatch :execrows
+WITH doomed AS (
+    SELECT id
+    FROM refresh_tokens
+    WHERE refresh_tokens.revoked_at IS NOT NULL AND refresh_tokens.revoked_at < sqlc.arg(cutoff)
+    LIMIT sqlc.arg(batch_size)
+)
+DELETE FROM refresh_tokens t
+USING doomed d
+WHERE t.id = d.id;
 
--- name: DeleteExpiredRefreshTokensBefore :execrows
-DELETE FROM refresh_tokens
-WHERE expires_at < sqlc.arg(cutoff);
+-- name: DeleteExpiredRefreshTokensBatch :execrows
+WITH doomed AS (
+    SELECT id
+    FROM refresh_tokens
+    WHERE refresh_tokens.expires_at < sqlc.arg(cutoff)
+    LIMIT sqlc.arg(batch_size)
+)
+DELETE FROM refresh_tokens t
+USING doomed d
+WHERE t.id = d.id;
 
--- name: DeleteExpiredOrRevokedSessions :execrows
-DELETE FROM sessions
-WHERE expires_at < sqlc.arg(cutoff) OR revoked_at IS NOT NULL;
+-- name: DeleteExpiredOrRevokedSessionsBatch :execrows
+WITH doomed AS (
+    SELECT id
+    FROM sessions
+    WHERE sessions.expires_at < sqlc.arg(cutoff) OR sessions.revoked_at IS NOT NULL
+    LIMIT sqlc.arg(batch_size)
+)
+DELETE FROM sessions t
+USING doomed d
+WHERE t.id = d.id;
 
--- name: DeleteExpiredAuthRequestsBefore :execrows
-DELETE FROM auth_requests
-WHERE expires_at < sqlc.arg(cutoff);
+-- name: DeleteExpiredAuthRequestsBatch :execrows
+WITH doomed AS (
+    SELECT id
+    FROM auth_requests
+    WHERE auth_requests.expires_at < sqlc.arg(cutoff)
+    LIMIT sqlc.arg(batch_size)
+)
+DELETE FROM auth_requests t
+USING doomed d
+WHERE t.id = d.id;
 
--- name: DeleteExpiredDeviceCodesBefore :execrows
-DELETE FROM device_codes
-WHERE expires_at < sqlc.arg(cutoff);
+-- name: DeleteExpiredDeviceCodesBatch :execrows
+WITH doomed AS (
+    SELECT id
+    FROM device_codes
+    WHERE device_codes.expires_at < sqlc.arg(cutoff)
+    LIMIT sqlc.arg(batch_size)
+)
+DELETE FROM device_codes t
+USING doomed d
+WHERE t.id = d.id;
 
 -- name: ListPendingDeletionUserIDsBefore :many
 SELECT id
@@ -50,7 +85,14 @@ WHERE id = sqlc.arg(user_id) AND status = 'pending_deletion' AND deletion_schedu
 INSERT INTO audit_log (user_id, event_type, created_at)
 VALUES (NULLIF(sqlc.arg(user_id)::text, '')::uuid, 'auth.deletion_completed', sqlc.arg(created_at));
 
--- name: AnonymizeAuditLogBefore :execrows
-UPDATE audit_log
+-- name: AnonymizeAuditLogBatch :execrows
+WITH target AS (
+    SELECT id
+    FROM audit_log
+    WHERE audit_log.created_at < sqlc.arg(cutoff) AND audit_log.user_id IS NOT NULL
+    LIMIT sqlc.arg(batch_size)
+)
+UPDATE audit_log a
 SET user_id = NULL
-WHERE created_at < sqlc.arg(cutoff) AND user_id IS NOT NULL;
+FROM target t
+WHERE a.id = t.id;

--- a/internal/db/storeq/cleanup.sql.go
+++ b/internal/db/storeq/cleanup.sql.go
@@ -11,66 +11,126 @@ import (
 	"time"
 )
 
-const anonymizeAuditLogBefore = `-- name: AnonymizeAuditLogBefore :execrows
-UPDATE audit_log
+const anonymizeAuditLogBatch = `-- name: AnonymizeAuditLogBatch :execrows
+WITH target AS (
+    SELECT id
+    FROM audit_log
+    WHERE audit_log.created_at < $1 AND audit_log.user_id IS NOT NULL
+    LIMIT $2
+)
+UPDATE audit_log a
 SET user_id = NULL
-WHERE created_at < $1 AND user_id IS NOT NULL
+FROM target t
+WHERE a.id = t.id
 `
 
-func (q *Queries) AnonymizeAuditLogBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	result, err := q.db.ExecContext(ctx, anonymizeAuditLogBefore, cutoff)
+type AnonymizeAuditLogBatchParams struct {
+	Cutoff    time.Time
+	BatchSize int32
+}
+
+func (q *Queries) AnonymizeAuditLogBatch(ctx context.Context, arg AnonymizeAuditLogBatchParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, anonymizeAuditLogBatch, arg.Cutoff, arg.BatchSize)
 	if err != nil {
 		return 0, err
 	}
 	return result.RowsAffected()
 }
 
-const deleteExpiredAuthRequestsBefore = `-- name: DeleteExpiredAuthRequestsBefore :execrows
-DELETE FROM auth_requests
-WHERE expires_at < $1
+const deleteExpiredAuthRequestsBatch = `-- name: DeleteExpiredAuthRequestsBatch :execrows
+WITH doomed AS (
+    SELECT id
+    FROM auth_requests
+    WHERE auth_requests.expires_at < $1
+    LIMIT $2
+)
+DELETE FROM auth_requests t
+USING doomed d
+WHERE t.id = d.id
 `
 
-func (q *Queries) DeleteExpiredAuthRequestsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteExpiredAuthRequestsBefore, cutoff)
+type DeleteExpiredAuthRequestsBatchParams struct {
+	Cutoff    time.Time
+	BatchSize int32
+}
+
+func (q *Queries) DeleteExpiredAuthRequestsBatch(ctx context.Context, arg DeleteExpiredAuthRequestsBatchParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteExpiredAuthRequestsBatch, arg.Cutoff, arg.BatchSize)
 	if err != nil {
 		return 0, err
 	}
 	return result.RowsAffected()
 }
 
-const deleteExpiredDeviceCodesBefore = `-- name: DeleteExpiredDeviceCodesBefore :execrows
-DELETE FROM device_codes
-WHERE expires_at < $1
+const deleteExpiredDeviceCodesBatch = `-- name: DeleteExpiredDeviceCodesBatch :execrows
+WITH doomed AS (
+    SELECT id
+    FROM device_codes
+    WHERE device_codes.expires_at < $1
+    LIMIT $2
+)
+DELETE FROM device_codes t
+USING doomed d
+WHERE t.id = d.id
 `
 
-func (q *Queries) DeleteExpiredDeviceCodesBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteExpiredDeviceCodesBefore, cutoff)
+type DeleteExpiredDeviceCodesBatchParams struct {
+	Cutoff    time.Time
+	BatchSize int32
+}
+
+func (q *Queries) DeleteExpiredDeviceCodesBatch(ctx context.Context, arg DeleteExpiredDeviceCodesBatchParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteExpiredDeviceCodesBatch, arg.Cutoff, arg.BatchSize)
 	if err != nil {
 		return 0, err
 	}
 	return result.RowsAffected()
 }
 
-const deleteExpiredOrRevokedSessions = `-- name: DeleteExpiredOrRevokedSessions :execrows
-DELETE FROM sessions
-WHERE expires_at < $1 OR revoked_at IS NOT NULL
+const deleteExpiredOrRevokedSessionsBatch = `-- name: DeleteExpiredOrRevokedSessionsBatch :execrows
+WITH doomed AS (
+    SELECT id
+    FROM sessions
+    WHERE sessions.expires_at < $1 OR sessions.revoked_at IS NOT NULL
+    LIMIT $2
+)
+DELETE FROM sessions t
+USING doomed d
+WHERE t.id = d.id
 `
 
-func (q *Queries) DeleteExpiredOrRevokedSessions(ctx context.Context, cutoff time.Time) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteExpiredOrRevokedSessions, cutoff)
+type DeleteExpiredOrRevokedSessionsBatchParams struct {
+	Cutoff    time.Time
+	BatchSize int32
+}
+
+func (q *Queries) DeleteExpiredOrRevokedSessionsBatch(ctx context.Context, arg DeleteExpiredOrRevokedSessionsBatchParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteExpiredOrRevokedSessionsBatch, arg.Cutoff, arg.BatchSize)
 	if err != nil {
 		return 0, err
 	}
 	return result.RowsAffected()
 }
 
-const deleteExpiredRefreshTokensBefore = `-- name: DeleteExpiredRefreshTokensBefore :execrows
-DELETE FROM refresh_tokens
-WHERE expires_at < $1
+const deleteExpiredRefreshTokensBatch = `-- name: DeleteExpiredRefreshTokensBatch :execrows
+WITH doomed AS (
+    SELECT id
+    FROM refresh_tokens
+    WHERE refresh_tokens.expires_at < $1
+    LIMIT $2
+)
+DELETE FROM refresh_tokens t
+USING doomed d
+WHERE t.id = d.id
 `
 
-func (q *Queries) DeleteExpiredRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteExpiredRefreshTokensBefore, cutoff)
+type DeleteExpiredRefreshTokensBatchParams struct {
+	Cutoff    time.Time
+	BatchSize int32
+}
+
+func (q *Queries) DeleteExpiredRefreshTokensBatch(ctx context.Context, arg DeleteExpiredRefreshTokensBatchParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteExpiredRefreshTokensBatch, arg.Cutoff, arg.BatchSize)
 	if err != nil {
 		return 0, err
 	}
@@ -87,13 +147,25 @@ func (q *Queries) DeleteRefreshTokensByUserID(ctx context.Context, userID string
 	return err
 }
 
-const deleteRevokedRefreshTokensBefore = `-- name: DeleteRevokedRefreshTokensBefore :execrows
-DELETE FROM refresh_tokens
-WHERE revoked_at IS NOT NULL AND revoked_at < $1
+const deleteRevokedRefreshTokensBatch = `-- name: DeleteRevokedRefreshTokensBatch :execrows
+WITH doomed AS (
+    SELECT id
+    FROM refresh_tokens
+    WHERE refresh_tokens.revoked_at IS NOT NULL AND refresh_tokens.revoked_at < $1
+    LIMIT $2
+)
+DELETE FROM refresh_tokens t
+USING doomed d
+WHERE t.id = d.id
 `
 
-func (q *Queries) DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff sql.NullTime) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteRevokedRefreshTokensBefore, cutoff)
+type DeleteRevokedRefreshTokensBatchParams struct {
+	Cutoff    sql.NullTime
+	BatchSize int32
+}
+
+func (q *Queries) DeleteRevokedRefreshTokensBatch(ctx context.Context, arg DeleteRevokedRefreshTokensBatchParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteRevokedRefreshTokensBatch, arg.Cutoff, arg.BatchSize)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -7,20 +7,19 @@ package storeq
 import (
 	"context"
 	"database/sql"
-	"time"
 )
 
 type Querier interface {
-	AnonymizeAuditLogBefore(ctx context.Context, cutoff time.Time) (int64, error)
+	AnonymizeAuditLogBatch(ctx context.Context, arg AnonymizeAuditLogBatchParams) (int64, error)
 	ApproveDeviceCodeByUserCode(ctx context.Context, arg ApproveDeviceCodeByUserCodeParams) (int64, error)
 	CompleteAuthRequestByID(ctx context.Context, arg CompleteAuthRequestByIDParams) (int64, error)
 	DeleteAuthRequestByID(ctx context.Context, id string) error
-	DeleteExpiredAuthRequestsBefore(ctx context.Context, cutoff time.Time) (int64, error)
-	DeleteExpiredDeviceCodesBefore(ctx context.Context, cutoff time.Time) (int64, error)
-	DeleteExpiredOrRevokedSessions(ctx context.Context, cutoff time.Time) (int64, error)
-	DeleteExpiredRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteExpiredAuthRequestsBatch(ctx context.Context, arg DeleteExpiredAuthRequestsBatchParams) (int64, error)
+	DeleteExpiredDeviceCodesBatch(ctx context.Context, arg DeleteExpiredDeviceCodesBatchParams) (int64, error)
+	DeleteExpiredOrRevokedSessionsBatch(ctx context.Context, arg DeleteExpiredOrRevokedSessionsBatchParams) (int64, error)
+	DeleteExpiredRefreshTokensBatch(ctx context.Context, arg DeleteExpiredRefreshTokensBatchParams) (int64, error)
 	DeleteRefreshTokensByUserID(ctx context.Context, userID string) error
-	DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff sql.NullTime) (int64, error)
+	DeleteRevokedRefreshTokensBatch(ctx context.Context, arg DeleteRevokedRefreshTokensBatchParams) (int64, error)
 	DeleteSessionsByUserID(ctx context.Context, userID string) error
 	DeleteUserIdentitiesByUserID(ctx context.Context, userID string) error
 	DenyDeviceCodeByUserCode(ctx context.Context, userCode string) error

--- a/internal/storage/cleanup_runner.go
+++ b/internal/storage/cleanup_runner.go
@@ -15,6 +15,7 @@ type CleanupRunner struct {
 }
 
 const cleanupAdvisoryLockKey int64 = 0x6175746867617465 // "authgate" hex (stable process-wide lock key)
+const cleanupBatchSize = 1000
 
 func NewCleanupRunner(db *sql.DB) *CleanupRunner {
 	return &CleanupRunner{db: db}
@@ -53,23 +54,48 @@ func (r *CleanupRunner) WithExclusiveLock(ctx context.Context, fn func(context.C
 }
 
 func (r *CleanupRunner) DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return storeq.New(r.db).DeleteRevokedRefreshTokensBefore(ctx, sql.NullTime{Time: cutoff, Valid: true})
+	return r.deleteInBatches(
+		ctx,
+		"refresh_tokens",
+		"revoked_at IS NOT NULL AND revoked_at < $1",
+		cutoff,
+	)
 }
 
 func (r *CleanupRunner) DeleteExpiredRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return storeq.New(r.db).DeleteExpiredRefreshTokensBefore(ctx, cutoff)
+	return r.deleteInBatches(
+		ctx,
+		"refresh_tokens",
+		"expires_at < $1",
+		cutoff,
+	)
 }
 
 func (r *CleanupRunner) DeleteExpiredOrRevokedSessions(ctx context.Context, cutoff time.Time) (int64, error) {
-	return storeq.New(r.db).DeleteExpiredOrRevokedSessions(ctx, cutoff)
+	return r.deleteInBatches(
+		ctx,
+		"sessions",
+		"(expires_at < $1 OR revoked_at IS NOT NULL)",
+		cutoff,
+	)
 }
 
 func (r *CleanupRunner) DeleteExpiredAuthRequestsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return storeq.New(r.db).DeleteExpiredAuthRequestsBefore(ctx, cutoff)
+	return r.deleteInBatches(
+		ctx,
+		"auth_requests",
+		"expires_at < $1",
+		cutoff,
+	)
 }
 
 func (r *CleanupRunner) DeleteExpiredDeviceCodesBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return storeq.New(r.db).DeleteExpiredDeviceCodesBefore(ctx, cutoff)
+	return r.deleteInBatches(
+		ctx,
+		"device_codes",
+		"expires_at < $1",
+		cutoff,
+	)
 }
 
 func (r *CleanupRunner) ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff time.Time) ([]string, error) {
@@ -77,7 +103,30 @@ func (r *CleanupRunner) ListPendingDeletionUserIDsBefore(ctx context.Context, cu
 }
 
 func (r *CleanupRunner) AnonymizeAuditLogBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return storeq.New(r.db).AnonymizeAuditLogBefore(ctx, cutoff)
+	var total int64
+	for {
+		rows, err := r.updateInBatches(
+			ctx,
+			`WITH target AS (
+				SELECT ctid
+				FROM audit_log
+				WHERE created_at < $1 AND user_id IS NOT NULL
+				LIMIT $2
+			)
+			UPDATE audit_log a
+			SET user_id = NULL
+			FROM target t
+			WHERE a.ctid = t.ctid`,
+			cutoff,
+		)
+		if err != nil {
+			return total, err
+		}
+		total += rows
+		if rows < cleanupBatchSize {
+			return total, nil
+		}
+	}
 }
 
 func (r *CleanupRunner) DeleteUser(
@@ -124,4 +173,44 @@ func (r *CleanupRunner) DeleteUser(
 		CreatedAt: now,
 	})
 	return nil
+}
+
+func (r *CleanupRunner) deleteInBatches(ctx context.Context, table, where string, args ...any) (int64, error) {
+	query := fmt.Sprintf(`
+		WITH doomed AS (
+			SELECT ctid
+			FROM %s
+			WHERE %s
+			LIMIT $%d
+		)
+		DELETE FROM %s t
+		USING doomed d
+		WHERE t.ctid = d.ctid
+	`, table, where, len(args)+1, table)
+
+	var total int64
+	for {
+		rows, err := r.updateInBatches(ctx, query, args...)
+		if err != nil {
+			return total, err
+		}
+		total += rows
+		if rows < cleanupBatchSize {
+			return total, nil
+		}
+	}
+}
+
+func (r *CleanupRunner) updateInBatches(ctx context.Context, query string, args ...any) (int64, error) {
+	execArgs := append(make([]any, 0, len(args)+1), args...)
+	execArgs = append(execArgs, cleanupBatchSize)
+	result, err := r.db.ExecContext(ctx, query, execArgs...)
+	if err != nil {
+		return 0, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return rows, nil
 }

--- a/internal/storage/cleanup_runner.go
+++ b/internal/storage/cleanup_runner.go
@@ -54,48 +54,93 @@ func (r *CleanupRunner) WithExclusiveLock(ctx context.Context, fn func(context.C
 }
 
 func (r *CleanupRunner) DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return r.deleteInBatches(
-		ctx,
-		"refresh_tokens",
-		"revoked_at IS NOT NULL AND revoked_at < $1",
-		cutoff,
-	)
+	q := storeq.New(r.db)
+	var total int64
+	for {
+		rows, err := q.DeleteRevokedRefreshTokensBatch(ctx, storeq.DeleteRevokedRefreshTokensBatchParams{
+			Cutoff:    sql.NullTime{Time: cutoff, Valid: true},
+			BatchSize: cleanupBatchSize,
+		})
+		if err != nil {
+			return total, err
+		}
+		total += rows
+		if rows < cleanupBatchSize {
+			return total, nil
+		}
+	}
 }
 
 func (r *CleanupRunner) DeleteExpiredRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return r.deleteInBatches(
-		ctx,
-		"refresh_tokens",
-		"expires_at < $1",
-		cutoff,
-	)
+	q := storeq.New(r.db)
+	var total int64
+	for {
+		rows, err := q.DeleteExpiredRefreshTokensBatch(ctx, storeq.DeleteExpiredRefreshTokensBatchParams{
+			Cutoff:    cutoff,
+			BatchSize: cleanupBatchSize,
+		})
+		if err != nil {
+			return total, err
+		}
+		total += rows
+		if rows < cleanupBatchSize {
+			return total, nil
+		}
+	}
 }
 
 func (r *CleanupRunner) DeleteExpiredOrRevokedSessions(ctx context.Context, cutoff time.Time) (int64, error) {
-	return r.deleteInBatches(
-		ctx,
-		"sessions",
-		"(expires_at < $1 OR revoked_at IS NOT NULL)",
-		cutoff,
-	)
+	q := storeq.New(r.db)
+	var total int64
+	for {
+		rows, err := q.DeleteExpiredOrRevokedSessionsBatch(ctx, storeq.DeleteExpiredOrRevokedSessionsBatchParams{
+			Cutoff:    cutoff,
+			BatchSize: cleanupBatchSize,
+		})
+		if err != nil {
+			return total, err
+		}
+		total += rows
+		if rows < cleanupBatchSize {
+			return total, nil
+		}
+	}
 }
 
 func (r *CleanupRunner) DeleteExpiredAuthRequestsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return r.deleteInBatches(
-		ctx,
-		"auth_requests",
-		"expires_at < $1",
-		cutoff,
-	)
+	q := storeq.New(r.db)
+	var total int64
+	for {
+		rows, err := q.DeleteExpiredAuthRequestsBatch(ctx, storeq.DeleteExpiredAuthRequestsBatchParams{
+			Cutoff:    cutoff,
+			BatchSize: cleanupBatchSize,
+		})
+		if err != nil {
+			return total, err
+		}
+		total += rows
+		if rows < cleanupBatchSize {
+			return total, nil
+		}
+	}
 }
 
 func (r *CleanupRunner) DeleteExpiredDeviceCodesBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return r.deleteInBatches(
-		ctx,
-		"device_codes",
-		"expires_at < $1",
-		cutoff,
-	)
+	q := storeq.New(r.db)
+	var total int64
+	for {
+		rows, err := q.DeleteExpiredDeviceCodesBatch(ctx, storeq.DeleteExpiredDeviceCodesBatchParams{
+			Cutoff:    cutoff,
+			BatchSize: cleanupBatchSize,
+		})
+		if err != nil {
+			return total, err
+		}
+		total += rows
+		if rows < cleanupBatchSize {
+			return total, nil
+		}
+	}
 }
 
 func (r *CleanupRunner) ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff time.Time) ([]string, error) {
@@ -103,22 +148,13 @@ func (r *CleanupRunner) ListPendingDeletionUserIDsBefore(ctx context.Context, cu
 }
 
 func (r *CleanupRunner) AnonymizeAuditLogBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	q := storeq.New(r.db)
 	var total int64
 	for {
-		rows, err := r.updateInBatches(
-			ctx,
-			`WITH target AS (
-				SELECT ctid
-				FROM audit_log
-				WHERE created_at < $1 AND user_id IS NOT NULL
-				LIMIT $2
-			)
-			UPDATE audit_log a
-			SET user_id = NULL
-			FROM target t
-			WHERE a.ctid = t.ctid`,
-			cutoff,
-		)
+		rows, err := q.AnonymizeAuditLogBatch(ctx, storeq.AnonymizeAuditLogBatchParams{
+			Cutoff:    cutoff,
+			BatchSize: cleanupBatchSize,
+		})
 		if err != nil {
 			return total, err
 		}
@@ -173,44 +209,4 @@ func (r *CleanupRunner) DeleteUser(
 		CreatedAt: now,
 	})
 	return nil
-}
-
-func (r *CleanupRunner) deleteInBatches(ctx context.Context, table, where string, args ...any) (int64, error) {
-	query := fmt.Sprintf(`
-		WITH doomed AS (
-			SELECT ctid
-			FROM %s
-			WHERE %s
-			LIMIT $%d
-		)
-		DELETE FROM %s t
-		USING doomed d
-		WHERE t.ctid = d.ctid
-	`, table, where, len(args)+1, table)
-
-	var total int64
-	for {
-		rows, err := r.updateInBatches(ctx, query, args...)
-		if err != nil {
-			return total, err
-		}
-		total += rows
-		if rows < cleanupBatchSize {
-			return total, nil
-		}
-	}
-}
-
-func (r *CleanupRunner) updateInBatches(ctx context.Context, query string, args ...any) (int64, error) {
-	execArgs := append(make([]any, 0, len(args)+1), args...)
-	execArgs = append(execArgs, cleanupBatchSize)
-	result, err := r.db.ExecContext(ctx, query, execArgs...)
-	if err != nil {
-		return 0, err
-	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return 0, err
-	}
-	return rows, nil
 }


### PR DESCRIPTION
## Summary
- change cleanup deletes to batch execution using ctid chunks
- batch token/session/auth_request/device_code cleanup deletes
- batch audit_log anonymization updates
- keep semantics of existing cleanup windows while reducing per-query lock span

## Details
- cleanup batch size: 1000 rows per statement
- total deleted/updated rows are aggregated across batches

## Validation
- go test ./internal/storage ./internal/service ./cmd/authgate
- go test ./...
