### PR TITLE
fix(phase0): remove id::text token revocation path

### DIFF
--- a/internal/db/queries/auth_requests.sql
+++ b/internal/db/queries/auth_requests.sql
@@ -41,7 +41,7 @@ SELECT id,
        expires_at,
        created_at
 FROM auth_requests
-WHERE code = $1::text;
+WHERE code = $1;
 
 -- name: UpdateAuthRequestCode :exec
 UPDATE auth_requests

--- a/internal/db/queries/refresh_tokens.sql
+++ b/internal/db/queries/refresh_tokens.sql
@@ -29,10 +29,10 @@ UPDATE refresh_tokens
 SET used_at = $1, revoked_at = $1
 WHERE id = $2;
 
--- name: RevokeRefreshTokenByIDText :exec
+-- name: RevokeRefreshTokenByID :exec
 UPDATE refresh_tokens
 SET revoked_at = $1
-WHERE id::text = $2 AND revoked_at IS NULL;
+WHERE id = $2 AND revoked_at IS NULL;
 
 -- name: GetRefreshTokenInfoByHashAndClientID :one
 SELECT user_id, id

--- a/internal/db/storeq/auth_requests.sql.go
+++ b/internal/db/storeq/auth_requests.sql.go
@@ -40,7 +40,7 @@ SELECT id,
        expires_at,
        created_at
 FROM auth_requests
-WHERE code = $1::text
+WHERE code = $1
 `
 
 type GetAuthRequestByCodeRow struct {
@@ -61,8 +61,8 @@ type GetAuthRequestByCodeRow struct {
 	CreatedAt           time.Time
 }
 
-func (q *Queries) GetAuthRequestByCode(ctx context.Context, dollar_1 string) (GetAuthRequestByCodeRow, error) {
-	row := q.db.QueryRowContext(ctx, getAuthRequestByCode, dollar_1)
+func (q *Queries) GetAuthRequestByCode(ctx context.Context, code sql.NullString) (GetAuthRequestByCodeRow, error) {
+	row := q.db.QueryRowContext(ctx, getAuthRequestByCode, code)
 	var i GetAuthRequestByCodeRow
 	err := row.Scan(
 		&i.ID,

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -24,7 +24,7 @@ type Querier interface {
 	DeleteSessionsByUserID(ctx context.Context, userID string) error
 	DeleteUserIdentitiesByUserID(ctx context.Context, userID string) error
 	DenyDeviceCodeByUserCode(ctx context.Context, userCode string) error
-	GetAuthRequestByCode(ctx context.Context, dollar_1 string) (GetAuthRequestByCodeRow, error)
+	GetAuthRequestByCode(ctx context.Context, code sql.NullString) (GetAuthRequestByCodeRow, error)
 	GetAuthRequestByID(ctx context.Context, id string) (GetAuthRequestByIDRow, error)
 	GetDeviceAuthorizationForUpdate(ctx context.Context, arg GetDeviceAuthorizationForUpdateParams) (GetDeviceAuthorizationForUpdateRow, error)
 	GetDeviceCodeByUserCode(ctx context.Context, userCode string) (GetDeviceCodeByUserCodeRow, error)
@@ -53,7 +53,7 @@ type Querier interface {
 	RevokeActiveRefreshTokensByUserID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDParams) error
 	RevokeRefreshFamily(ctx context.Context, arg RevokeRefreshFamilyParams) error
 	RevokeRefreshTokenByHash(ctx context.Context, arg RevokeRefreshTokenByHashParams) (int64, error)
-	RevokeRefreshTokenByIDText(ctx context.Context, arg RevokeRefreshTokenByIDTextParams) error
+	RevokeRefreshTokenByID(ctx context.Context, arg RevokeRefreshTokenByIDParams) error
 	RevokeSessionsByUserID(ctx context.Context, arg RevokeSessionsByUserIDParams) error
 	SetUserStatusByID(ctx context.Context, arg SetUserStatusByIDParams) error
 	UpdateAuthRequestCode(ctx context.Context, arg UpdateAuthRequestCodeParams) error

--- a/internal/db/storeq/refresh_tokens.sql.go
+++ b/internal/db/storeq/refresh_tokens.sql.go
@@ -171,18 +171,18 @@ func (q *Queries) RevokeRefreshTokenByHash(ctx context.Context, arg RevokeRefres
 	return result.RowsAffected()
 }
 
-const revokeRefreshTokenByIDText = `-- name: RevokeRefreshTokenByIDText :exec
+const revokeRefreshTokenByID = `-- name: RevokeRefreshTokenByID :exec
 UPDATE refresh_tokens
 SET revoked_at = $1
-WHERE id::text = $2 AND revoked_at IS NULL
+WHERE id = $2 AND revoked_at IS NULL
 `
 
-type RevokeRefreshTokenByIDTextParams struct {
+type RevokeRefreshTokenByIDParams struct {
 	RevokedAt sql.NullTime
 	ID        string
 }
 
-func (q *Queries) RevokeRefreshTokenByIDText(ctx context.Context, arg RevokeRefreshTokenByIDTextParams) error {
-	_, err := q.db.ExecContext(ctx, revokeRefreshTokenByIDText, arg.RevokedAt, arg.ID)
+func (q *Queries) RevokeRefreshTokenByID(ctx context.Context, arg RevokeRefreshTokenByIDParams) error {
+	_, err := q.db.ExecContext(ctx, revokeRefreshTokenByID, arg.RevokedAt, arg.ID)
 	return err
 }

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"github.com/zitadel/oidc/v3/pkg/op"
 
@@ -71,7 +72,7 @@ func (s *Storage) AuthRequestByID(ctx context.Context, id string) (op.AuthReques
 }
 
 func (s *Storage) AuthRequestByCode(ctx context.Context, code string) (op.AuthRequest, error) {
-	row, err := storeq.New(s.db).GetAuthRequestByCode(ctx, code)
+	row, err := storeq.New(s.db).GetAuthRequestByCode(ctx, sql.NullString{String: code, Valid: true})
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -310,10 +311,12 @@ func (s *Storage) RevokeToken(ctx context.Context, tokenOrTokenID string, userID
 	}
 
 	// Try as token ID (UUID) directly
-	_ = q.RevokeRefreshTokenByIDText(ctx, storeq.RevokeRefreshTokenByIDTextParams{
-		RevokedAt: sql.NullTime{Time: now, Valid: true},
-		ID:        tokenOrTokenID,
-	})
+	if _, err := uuid.Parse(tokenOrTokenID); err == nil {
+		_ = q.RevokeRefreshTokenByID(ctx, storeq.RevokeRefreshTokenByIDParams{
+			RevokedAt: sql.NullTime{Time: now, Valid: true},
+			ID:        tokenOrTokenID,
+		})
+	}
 
 	// RFC 7009: always return 200 regardless of whether anything was revoked
 	return nil


### PR DESCRIPTION
## 배경
Phase 0(bugfix/query)에서 우선순위가 높은 `id::text` 경로를 먼저 제거합니다.

## 변경 내용
- refresh token revoke 쿼리에서 `id::text = $2` 제거
  - `WHERE id = $2 AND revoked_at IS NULL`로 변경
- sqlc 생성 코드/querier 갱신
- `Storage.RevokeToken`에서 token ID revoke 시 UUID 형식 검증 추가
  - UUID가 아닌 경우 ID 기반 revoke 쿼리를 건너뜀
- `auth_requests` 조회 쿼리의 불필요한 `::text` 캐스트 제거

## 의도
- 컬럼 캐스트 기반 경로를 제거해 쿼리 안정성/가독성을 개선
- revocation endpoint의 RFC7009 동작(항상 200) 유지

## 검증
- `go test ./...` 통과