### PR TITLE
refactor(service): split login/device flows into focused helpers

### DIFF
--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -61,49 +61,28 @@ const (
 
 // HandleDevicePage handles GET /device and GET /device?user_code=XXXX
 func (s *DeviceService) HandleDevicePage(ctx context.Context, userCode, sessionID string) *DevicePageResult {
-	// No user_code → show entry form
 	if userCode == "" {
 		return &DevicePageResult{Action: DeviceShowEntry}
 	}
 
-	// Validate user_code
-	dc, err := s.store.GetDeviceCodeByUserCode(ctx, userCode)
-	if errors.Is(err, storage.ErrNotFound) {
-		return &DevicePageResult{Action: DeviceShowEntry, Error: "Invalid code. Please check and try again."}
-	}
-	if err != nil {
-		return &DevicePageResult{Action: DeviceError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+	if result := s.validateDevicePage(ctx, userCode); result != nil {
+		return result
 	}
 
-	now := s.clock.Now()
-	if now.After(dc.ExpiresAt) {
-		return &DevicePageResult{Action: DeviceShowEntry, Error: "This code has expired. Please request a new one."}
-	}
-
-	if dc.State != "pending" {
-		return &DevicePageResult{Action: DeviceShowEntry, Error: "This code has already been used."}
-	}
-
-	// Check session
 	if sessionID == "" {
-		// No session → redirect to IdP, state=user_code
-		authURL := s.provider.AuthURL(userCode)
-		return &DevicePageResult{Action: DeviceRedirectIdP, UserCode: authURL}
+		return s.redirectDeviceToProvider(userCode)
 	}
 
-	// Session exists → check user state
 	user, err := s.store.GetValidSession(ctx, sessionID)
 	if errors.Is(err, storage.ErrNotFound) {
-		authURL := s.provider.AuthURL(userCode)
-		return &DevicePageResult{Action: DeviceRedirectIdP, UserCode: authURL}
+		return s.redirectDeviceToProvider(userCode)
 	}
 	if err != nil {
 		return &DevicePageResult{Action: DeviceError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
 	}
 
-	if CheckAccess(user.Status, "device") != AccessAllow {
-		s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", "", "", map[string]any{"status": user.Status, "channel": "device"})
-		return &DevicePageResult{Action: DeviceError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
+	if result := s.ensureDeviceSessionAccess(ctx, user); result != nil {
+		return result
 	}
 
 	return &DevicePageResult{Action: DeviceShowApprove, UserCode: userCode}
@@ -121,21 +100,14 @@ func (s *DeviceService) HandleDeviceCallback(ctx context.Context, code, userCode
 		return &DevicePageResult{Action: DeviceError, Error: "upstream_error", ErrorCode: http.StatusInternalServerError}
 	}
 
-	// Look up user
-	user, err := s.store.GetUserByProviderIdentity(ctx, s.provider.Name(), userInfo.Sub)
-	if errors.Is(err, storage.ErrNotFound) {
-		return &DevicePageResult{Action: DeviceError, Error: "account_not_found: please sign up via browser first", ErrorCode: http.StatusForbidden}
+	user, result := s.findDeviceCallbackUser(ctx, userInfo.Sub)
+	if result != nil {
+		return result
 	}
-	if err != nil {
-		return &DevicePageResult{Action: DeviceError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
-	}
-
-	if CheckAccess(user.Status, "device") != AccessAllow {
-		s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "device"})
-		return &DevicePageResult{Action: DeviceError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
+	if result := s.ensureDeviceCallbackAccess(ctx, user, ipAddress, userAgent); result != nil {
+		return result
 	}
 
-	// Create session
 	sessionID, err := s.store.CreateSession(ctx, user.ID, s.sessionTTL)
 	if err != nil {
 		return &DevicePageResult{Action: DeviceError, Error: "session creation failed", ErrorCode: http.StatusInternalServerError}
@@ -143,7 +115,6 @@ func (s *DeviceService) HandleDeviceCallback(ctx context.Context, code, userCode
 
 	s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{"channel": "device"})
 
-	// Redirect back to /device?user_code=X with session
 	return &DevicePageResult{Action: DeviceRedirectBack, UserCode: userCode, SessionID: sessionID}
 }
 
@@ -170,16 +141,76 @@ func (s *DeviceService) HandleDeviceApprove(ctx context.Context, userCode, actio
 	}
 
 	if action == "deny" {
-		s.store.DenyDeviceCode(ctx, userCode)
-		s.store.AuditLog(ctx, &user.ID, "auth.device_denied", ipAddress, userAgent, nil)
+		s.denyDeviceCode(ctx, userCode, user.ID, ipAddress, userAgent)
 		return &DeviceApproveResult{Success: false, Message: "You denied the authorization request. You can close this window."}
 	}
 
-	// Approve
-	if err := s.store.ApproveDeviceCode(ctx, userCode, user.ID); err != nil {
+	return s.approveDeviceCode(ctx, userCode, user.ID, ipAddress, userAgent)
+}
+
+func (s *DeviceService) validateDevicePage(ctx context.Context, userCode string) *DevicePageResult {
+	dc, err := s.store.GetDeviceCodeByUserCode(ctx, userCode)
+	if errors.Is(err, storage.ErrNotFound) {
+		return &DevicePageResult{Action: DeviceShowEntry, Error: "Invalid code. Please check and try again."}
+	}
+	if err != nil {
+		return &DevicePageResult{Action: DeviceError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+	}
+
+	now := s.clock.Now()
+	if now.After(dc.ExpiresAt) {
+		return &DevicePageResult{Action: DeviceShowEntry, Error: "This code has expired. Please request a new one."}
+	}
+	if dc.State != "pending" {
+		return &DevicePageResult{Action: DeviceShowEntry, Error: "This code has already been used."}
+	}
+
+	return nil
+}
+
+func (s *DeviceService) redirectDeviceToProvider(userCode string) *DevicePageResult {
+	return &DevicePageResult{Action: DeviceRedirectIdP, UserCode: s.provider.AuthURL(userCode)}
+}
+
+func (s *DeviceService) ensureDeviceSessionAccess(ctx context.Context, user *storage.User) *DevicePageResult {
+	if CheckAccess(user.Status, "device") == AccessAllow {
+		return nil
+	}
+
+	s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", "", "", map[string]any{"status": user.Status, "channel": "device"})
+	return &DevicePageResult{Action: DeviceError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
+}
+
+func (s *DeviceService) findDeviceCallbackUser(ctx context.Context, providerUserID string) (*storage.User, *DevicePageResult) {
+	user, err := s.store.GetUserByProviderIdentity(ctx, s.provider.Name(), providerUserID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, &DevicePageResult{Action: DeviceError, Error: "account_not_found: please sign up via browser first", ErrorCode: http.StatusForbidden}
+	}
+	if err != nil {
+		return nil, &DevicePageResult{Action: DeviceError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+	}
+	return user, nil
+}
+
+func (s *DeviceService) ensureDeviceCallbackAccess(ctx context.Context, user *storage.User, ipAddress, userAgent string) *DevicePageResult {
+	if CheckAccess(user.Status, "device") == AccessAllow {
+		return nil
+	}
+
+	s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "device"})
+	return &DevicePageResult{Action: DeviceError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
+}
+
+func (s *DeviceService) denyDeviceCode(ctx context.Context, userCode, userID, ipAddress, userAgent string) {
+	s.store.DenyDeviceCode(ctx, userCode)
+	s.store.AuditLog(ctx, &userID, "auth.device_denied", ipAddress, userAgent, nil)
+}
+
+func (s *DeviceService) approveDeviceCode(ctx context.Context, userCode, userID, ipAddress, userAgent string) *DeviceApproveResult {
+	if err := s.store.ApproveDeviceCode(ctx, userCode, userID); err != nil {
 		return &DeviceApproveResult{Success: false, Message: "Device code expired or already processed.", ErrorCode: http.StatusBadRequest}
 	}
 
-	s.store.AuditLog(ctx, &user.ID, "auth.device_approved", ipAddress, userAgent, nil)
+	s.store.AuditLog(ctx, &userID, "auth.device_approved", ipAddress, userAgent, nil)
 	return &DeviceApproveResult{Success: true, Message: "You have successfully authorized the CLI application. You can close this window."}
 }

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -63,35 +63,38 @@ func (s *LoginService) handleLogin(ctx context.Context, authRequestID, sessionID
 		return &LoginResult{Action: ActionError, Error: "missing authRequestID", ErrorCode: http.StatusBadRequest}
 	}
 
-	// Check session
-	if sessionID != "" {
-		user, err := s.store.GetValidSession(ctx, sessionID)
-		if err == nil {
-			// Session exists — check login state
-			return s.handleExistingSession(ctx, user, authRequestID, ipAddress, userAgent)
-		}
-		// Session invalid/expired — fall through to IdP redirect
+	if result := s.handleSessionLogin(ctx, authRequestID, sessionID, ipAddress, userAgent); result != nil {
+		return result
 	}
 
-	// No valid session — redirect to upstream IdP
-	authURL := s.browserProvider.AuthURL(authRequestID)
-	return &LoginResult{Action: ActionRedirectToIdP, RedirectURL: authURL}
+	return s.redirectToProvider(authRequestID)
+}
+
+func (s *LoginService) handleSessionLogin(ctx context.Context, authRequestID, sessionID, ipAddress, userAgent string) *LoginResult {
+	if sessionID == "" {
+		return nil
+	}
+
+	user, err := s.store.GetValidSession(ctx, sessionID)
+	if err != nil {
+		return nil
+	}
+
+	return s.handleExistingSession(ctx, user, authRequestID, ipAddress, userAgent)
 }
 
 func (s *LoginService) handleExistingSession(ctx context.Context, user *storage.User, authRequestID, ipAddress, userAgent string) *LoginResult {
 	switch CheckAccess(user.Status, "browser") {
 	case AccessDeny:
-		s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status})
+		s.auditInactiveUser(ctx, user.ID, user.Status, ipAddress, userAgent)
 		return &LoginResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
 
 	case AccessRecover:
-		if err := s.store.RecoverUser(ctx, user.ID); err != nil {
+		if err := s.recoverUser(ctx, user.ID, ipAddress, userAgent); err != nil {
 			return &LoginResult{Action: ActionError, Error: "failed to recover account", ErrorCode: http.StatusInternalServerError}
 		}
-		s.store.AuditLog(ctx, &user.ID, "auth.deletion_cancelled", ipAddress, userAgent, nil)
 	}
 
-	// Active or recovered — complete auth request
 	if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
 		return &LoginResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
 	}
@@ -124,60 +127,95 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 		return &CallbackResult{Action: ActionError, Error: fmt.Sprintf("upstream_error: %v", err), ErrorCode: http.StatusInternalServerError}
 	}
 
-	// Look up user by provider identity
-	providerName := s.browserProvider.Name()
-	user, err := s.store.GetUserByProviderIdentity(ctx, providerName, userInfo.Sub)
-	if errors.Is(err, storage.ErrNotFound) {
-		// New user — signup
-		user, err = s.store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
-			Email:          userInfo.Email,
-			EmailVerified:  userInfo.EmailVerified,
-			Name:           userInfo.Name,
-			AvatarURL:      userInfo.Picture,
-			Provider:       providerName,
-			ProviderUserID: userInfo.Sub,
-			ProviderEmail:  userInfo.Email,
-		})
-		if errors.Is(err, storage.ErrEmailConflict) {
-			return &CallbackResult{Action: ActionError, Error: "email_conflict", ErrorCode: http.StatusConflict}
-		}
-		if err != nil {
-			return &CallbackResult{Action: ActionError, Error: fmt.Sprintf("signup failed: %v", err), ErrorCode: http.StatusInternalServerError}
-		}
-		s.store.AuditLog(ctx, &user.ID, "auth.signup", ipAddress, userAgent, nil)
-	} else if err != nil {
-		return &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
-	} else {
-		s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{"channel": "browser"})
+	user, result := s.findOrCreateBrowserUser(ctx, userInfo, ipAddress, userAgent)
+	if result != nil {
+		return result
 	}
 
-	// Access check
-	switch CheckAccess(user.Status, "browser") {
-	case AccessDeny:
-		s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "browser"})
-		return &CallbackResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
-
-	case AccessRecover:
-		if err := s.store.RecoverUser(ctx, user.ID); err != nil {
-			return &CallbackResult{Action: ActionError, Error: "recovery failed", ErrorCode: http.StatusInternalServerError}
-		}
-		s.store.AuditLog(ctx, &user.ID, "auth.deletion_cancelled", ipAddress, userAgent, nil)
-		user, err = s.store.GetUserByID(ctx, user.ID)
-		if err != nil {
-			return &CallbackResult{Action: ActionError, Error: "failed to read user after recovery", ErrorCode: http.StatusInternalServerError}
-		}
+	user, result = s.ensureBrowserAccess(ctx, user, ipAddress, userAgent)
+	if result != nil {
+		return result
 	}
 
-	// Create session
 	sessionID, err := s.store.CreateSession(ctx, user.ID, s.sessionTTL)
 	if err != nil {
 		return &CallbackResult{Action: ActionError, Error: "session creation failed", ErrorCode: http.StatusInternalServerError}
 	}
 
-	// Complete auth request
 	if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
 		return &CallbackResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
 	}
 
 	return &CallbackResult{Action: ActionAutoApprove, AuthRequestID: authRequestID, SessionID: sessionID}
+}
+
+func (s *LoginService) redirectToProvider(authRequestID string) *LoginResult {
+	return &LoginResult{Action: ActionRedirectToIdP, RedirectURL: s.browserProvider.AuthURL(authRequestID)}
+}
+
+func (s *LoginService) recoverUser(ctx context.Context, userID, ipAddress, userAgent string) error {
+	if err := s.store.RecoverUser(ctx, userID); err != nil {
+		return err
+	}
+	s.store.AuditLog(ctx, &userID, "auth.deletion_cancelled", ipAddress, userAgent, nil)
+	return nil
+}
+
+func (s *LoginService) findOrCreateBrowserUser(ctx context.Context, userInfo *upstream.UserInfo, ipAddress, userAgent string) (*storage.User, *CallbackResult) {
+	providerName := s.browserProvider.Name()
+	user, err := s.store.GetUserByProviderIdentity(ctx, providerName, userInfo.Sub)
+	if errors.Is(err, storage.ErrNotFound) {
+		return s.signupBrowserUser(ctx, providerName, userInfo, ipAddress, userAgent)
+	}
+	if err != nil {
+		return nil, &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+	}
+
+	s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{"channel": "browser"})
+	return user, nil
+}
+
+func (s *LoginService) signupBrowserUser(ctx context.Context, providerName string, userInfo *upstream.UserInfo, ipAddress, userAgent string) (*storage.User, *CallbackResult) {
+	user, err := s.store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
+		Email:          userInfo.Email,
+		EmailVerified:  userInfo.EmailVerified,
+		Name:           userInfo.Name,
+		AvatarURL:      userInfo.Picture,
+		Provider:       providerName,
+		ProviderUserID: userInfo.Sub,
+		ProviderEmail:  userInfo.Email,
+	})
+	if errors.Is(err, storage.ErrEmailConflict) {
+		return nil, &CallbackResult{Action: ActionError, Error: "email_conflict", ErrorCode: http.StatusConflict}
+	}
+	if err != nil {
+		return nil, &CallbackResult{Action: ActionError, Error: fmt.Sprintf("signup failed: %v", err), ErrorCode: http.StatusInternalServerError}
+	}
+
+	s.store.AuditLog(ctx, &user.ID, "auth.signup", ipAddress, userAgent, nil)
+	return user, nil
+}
+
+func (s *LoginService) ensureBrowserAccess(ctx context.Context, user *storage.User, ipAddress, userAgent string) (*storage.User, *CallbackResult) {
+	switch CheckAccess(user.Status, "browser") {
+	case AccessDeny:
+		s.auditInactiveUser(ctx, user.ID, user.Status, ipAddress, userAgent)
+		return nil, &CallbackResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
+	case AccessRecover:
+		if err := s.recoverUser(ctx, user.ID, ipAddress, userAgent); err != nil {
+			return nil, &CallbackResult{Action: ActionError, Error: "recovery failed", ErrorCode: http.StatusInternalServerError}
+		}
+
+		recoveredUser, err := s.store.GetUserByID(ctx, user.ID)
+		if err != nil {
+			return nil, &CallbackResult{Action: ActionError, Error: "failed to read user after recovery", ErrorCode: http.StatusInternalServerError}
+		}
+		return recoveredUser, nil
+	default:
+		return user, nil
+	}
+}
+
+func (s *LoginService) auditInactiveUser(ctx context.Context, userID, status, ipAddress, userAgent string) {
+	s.store.AuditLog(ctx, &userID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": status, "channel": "browser"})
 }


### PR DESCRIPTION
## 요약
Phase 1(service) 리팩토링으로 `internal/service/login.go`, `internal/service/device.go`의 긴 흐름 함수를 단계별 helper로 분리했습니다.

## 변경 내용
- login flow
  - `handleSessionLogin`, `findOrCreateBrowserUser`, `signupBrowserUser`, `ensureBrowserAccess` 등으로 단계 분리
  - inactive/recover/audit 처리 로직을 helper로 분리
  - 불필요 forwarding helper(`completeAuthRequest`) 제거
- device flow
  - `validateDevicePage`, `redirectDeviceToProvider`, `ensureDeviceSessionAccess` 분리
  - callback 경로를 `findDeviceCallbackUser`, `ensureDeviceCallbackAccess`로 분리
  - approve/deny 경로를 각각 helper로 분리

## 의도
- 동작 변경 없이 flow 가독성과 변경 안전성을 높임
- handler/service/storage 경계는 유지

## 검증
- `go test ./internal/service/...` 통과
- `go test ./...` 통과
