### PR TITLE
refactor(examples): split bootstrap wiring in webapp and mcp-server

### DIFF
--- a/examples/mcp-server/main.go
+++ b/examples/mcp-server/main.go
@@ -277,25 +277,61 @@ func authMiddleware(verifier *JWKSVerifier, authgateURL, resourceMetadataURL, re
 }
 
 func main() {
+	cfg := loadMCPConfig()
+	handler := buildMCPHandler(cfg)
+
+	slog.Info("mcp-server starting", "addr", cfg.ListenAddr, "authgate", cfg.AuthgateURL)
+	if err := http.ListenAndServe(cfg.ListenAddr, handler); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type mcpConfig struct {
+	ListenAddr       string
+	AuthgateURL      string
+	ResourceURL      string
+	RequiredScope    string
+	JWKSURL          string
+	ResourceMetaURL  string
+	ResourceMetaPath string
+}
+
+func loadMCPConfig() mcpConfig {
 	listenAddr := envOr("LISTEN_ADDR", ":9091")
 	authgateURL := envOr("AUTHGATE_URL", "http://localhost:8080")
 	resourceURL := envOr("RESOURCE_URL", "http://localhost:9091")
 	requiredScope := envOr("REQUIRED_SCOPE", "openid")
-	jwksURL := authgateURL + "/keys"
 	resourceMetadataURL, resourceMetadataPath, err := protectedResourceMetadataURL(resourceURL)
 	if err != nil {
 		log.Fatalf("resource metadata url: %v", err)
 	}
+	return mcpConfig{
+		ListenAddr:       listenAddr,
+		AuthgateURL:      authgateURL,
+		ResourceURL:      resourceURL,
+		RequiredScope:    requiredScope,
+		JWKSURL:          authgateURL + "/keys",
+		ResourceMetaURL:  resourceMetadataURL,
+		ResourceMetaPath: resourceMetadataPath,
+	}
+}
 
-	verifier := NewJWKSVerifier(jwksURL, authgateURL, resourceURL)
+func buildMCPHandler(cfg mcpConfig) http.Handler {
+	verifier := NewJWKSVerifier(cfg.JWKSURL, cfg.AuthgateURL, cfg.ResourceURL)
+	mcpServer := buildMCPServer()
+	mcpHandler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
+		return mcpServer
+	}, nil)
+	mux := newMCPMux(cfg, mcpHandler)
+	return authMiddleware(verifier, cfg.AuthgateURL, cfg.ResourceMetaURL, cfg.RequiredScope, mux)
+}
 
-	// Create MCP server
+func buildMCPServer() *mcp.Server {
 	mcpServer := mcp.NewServer(&mcp.Implementation{
 		Name:    "authgate-mcp-server",
 		Version: "1.0.0",
 	}, nil)
 
-	// Register "me" tool — returns authenticated user info
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name:        "me",
 		Description: "Returns the currently authenticated user's information (sub, email, name)",
@@ -316,28 +352,31 @@ func main() {
 			"name":  claims.Name,
 		}
 		data, _ := json.MarshalIndent(info, "", "  ")
-
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: string(data)},
 			},
 		}, nil, nil
 	})
+	return mcpServer
+}
 
-	// Streamable HTTP handler (supports single POST JSON-RPC calls)
-	mcpHandler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
-		return mcpServer
-	}, nil)
-
+func newMCPMux(cfg mcpConfig, mcpHandler http.Handler) *http.ServeMux {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"status":"healthy"}`))
-	})
+	mux.HandleFunc("/health", handleMCPHealth)
+	mux.HandleFunc("/.well-known/oauth-authorization-server", newMCPOAuthMetadataHandler(cfg.AuthgateURL))
+	mux.HandleFunc(cfg.ResourceMetaPath, newMCPResourceMetadataHandler(cfg.AuthgateURL, cfg.ResourceURL))
+	mux.Handle("/mcp", mcpHandler)
+	return mux
+}
 
-	// RFC 8414: OAuth Authorization Server Metadata
-	// MCP clients discover authgate's OAuth endpoints via this endpoint
-	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+func handleMCPHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"status":"healthy"}`))
+}
+
+func newMCPOAuthMetadataHandler(authgateURL string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		metadata := map[string]any{
 			"issuer":                                authgateURL,
 			"authorization_endpoint":                authgateURL + "/authorize",
@@ -350,26 +389,17 @@ func main() {
 			"client_id_metadata_document_supported": true,
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(metadata)
-	})
+		_ = json.NewEncoder(w).Encode(metadata)
+	}
+}
 
-	// RFC 9728: OAuth Protected Resource Metadata (draft MCP spec)
-	mux.HandleFunc(resourceMetadataPath, func(w http.ResponseWriter, r *http.Request) {
+func newMCPResourceMetadataHandler(authgateURL, resourceURL string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		metadata := map[string]any{
 			"resource":              resourceURL,
 			"authorization_servers": []string{authgateURL},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(metadata)
-	})
-
-	mux.Handle("/mcp", mcpHandler)
-
-	// Wrap entire mux with auth middleware
-	handler := authMiddleware(verifier, authgateURL, resourceMetadataURL, requiredScope, mux)
-
-	slog.Info("mcp-server starting", "addr", listenAddr, "authgate", authgateURL)
-	if err := http.ListenAndServe(listenAddr, handler); err != nil {
-		log.Fatal(err)
+		_ = json.NewEncoder(w).Encode(metadata)
 	}
 }

--- a/examples/webapp/main.go
+++ b/examples/webapp/main.go
@@ -21,23 +21,53 @@ func envDefault(key, fallback string) string {
 }
 
 func main() {
-	listenAddr := envDefault("LISTEN_ADDR", ":9090")
-	clientID := envDefault("CLIENT_ID", "sample-app")
-	authgateInternal := envDefault("AUTHGATE_ISSUER", "http://localhost:8080")      // server-to-server
-	authgateBrowser := envDefault("AUTHGATE_BROWSER_URL", "http://localhost:8080")   // browser-facing
-	selfURL := envDefault("SELF_URL", "http://localhost:9090")
+	cfg := loadAppConfig()
+	srv := buildServer(cfg)
 
-	redirectURI := selfURL + "/auth/callback"
-	authorizeURL := authgateBrowser + "/authorize"
-	tokenURL := authgateInternal + "/oauth/token"
-	userinfoURL := authgateInternal + "/userinfo"
-	jwksURL := authgateInternal + "/keys"
+	slog.Info("sample-app starting", "addr", cfg.ListenAddr, "client_id", cfg.ClientID, "authgate", cfg.AuthgateBrowser)
+	if err := srv.ListenAndServe(); err != nil {
+		log.Fatal(fmt.Errorf("server: %w", err))
+	}
+}
+
+type appConfig struct {
+	ListenAddr       string
+	ClientID         string
+	AuthgateInternal string
+	AuthgateBrowser  string
+	SelfURL          string
+}
+
+func loadAppConfig() appConfig {
+	return appConfig{
+		ListenAddr:       envDefault("LISTEN_ADDR", ":9090"),
+		ClientID:         envDefault("CLIENT_ID", "sample-app"),
+		AuthgateInternal: envDefault("AUTHGATE_ISSUER", "http://localhost:8080"),
+		AuthgateBrowser:  envDefault("AUTHGATE_BROWSER_URL", "http://localhost:8080"),
+		SelfURL:          envDefault("SELF_URL", "http://localhost:9090"),
+	}
+}
+
+func buildServer(cfg appConfig) *http.Server {
+	redirectURI := cfg.SelfURL + "/auth/callback"
+	authorizeURL := cfg.AuthgateBrowser + "/authorize"
+	tokenURL := cfg.AuthgateInternal + "/oauth/token"
+	userinfoURL := cfg.AuthgateInternal + "/userinfo"
+	jwksURL := cfg.AuthgateInternal + "/keys"
 
 	sessions := NewSessionStore()
-	verifier := NewJWKSVerifier(jwksURL, authgateBrowser, clientID)
-	authHandler := NewAuthHandler(sessions, clientID, redirectURI, authorizeURL, tokenURL, userinfoURL)
+	verifier := NewJWKSVerifier(jwksURL, cfg.AuthgateBrowser, cfg.ClientID)
+	authHandler := NewAuthHandler(sessions, cfg.ClientID, redirectURI, authorizeURL, tokenURL, userinfoURL)
 	authMiddleware := RequireAuth(verifier, authHandler)
 
+	mux := newWebAppMux(authHandler, authMiddleware)
+	return &http.Server{
+		Addr:    cfg.ListenAddr,
+		Handler: mux,
+	}
+}
+
+func newWebAppMux(authHandler *AuthHandler, authMiddleware func(http.Handler) http.Handler) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// Auth routes (registered before catch-all)
@@ -52,14 +82,5 @@ func main() {
 	// Static files (catch-all, must be last)
 	staticContent, _ := fs.Sub(staticFS, "static")
 	mux.Handle("/", http.FileServer(http.FS(staticContent)))
-
-	srv := &http.Server{
-		Addr:    listenAddr,
-		Handler: mux,
-	}
-
-	slog.Info("sample-app starting", "addr", listenAddr, "client_id", clientID, "authgate", authgateBrowser)
-	if err := srv.ListenAndServe(); err != nil {
-		log.Fatal(fmt.Errorf("server: %w", err))
-	}
+	return mux
 }


### PR DESCRIPTION
## Summary
- refactor `examples/webapp/main.go` to separate config loading, server construction, and route wiring
- refactor `examples/mcp-server/main.go` to separate config loading, handler/server construction, and metadata/health handlers
- keep external behavior and route contracts unchanged (wiring readability cleanup only)

## Why
- reduce main function size and make startup flow easier to scan
- isolate setup responsibilities without changing architecture or runtime semantics

## Validation
- `go test ./...` in `examples/webapp`
- `go test ./...` in `examples/mcp-server`
