### PR TITLE
fix(deps): bump Go to 1.25.9 for stdlib vulnerability fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kangheeyong/authgate
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/go-jose/go-jose/v4 v4.1.3


### PR DESCRIPTION
## Summary
- Go 1.25.8 → 1.25.9로 업그레이드
- CI govulncheck 실패 해결 (4건 stdlib 취약점)

| CVE | 패키지 | 수정 버전 |
|-----|--------|----------|
| GO-2026-4947 | crypto/x509 | go1.25.9 |
| GO-2026-4946 | crypto/x509 | go1.25.9 |
| GO-2026-4870 | crypto/tls | go1.25.9 |
| GO-2026-4865 | html/template | go1.25.9 |

## Test plan
- [x] `go build ./cmd/authgate/` 성공
- [ ] CI govulncheck PASS 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)