### PR TITLE
fix(auth): enforce PKCE S256 for all authorize requests

### DIFF
--- a/docs/spec/002-browser-login.md
+++ b/docs/spec/002-browser-login.md
@@ -10,6 +10,7 @@
 - authgate에서 zitadel/oidc는 **내장 라이브러리**다. 별도 서버가 아니다. 모든 엔드포인트는 authgate의 단일 주소에서 제공된다.
 - 앱이 `clients.yaml`에 등록되어 있어야 함
 - authgate에 OIDC 자격증명이 설정되어 있어야 함 (OIDC_ISSUER_URL, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET)
+- 모든 `/authorize` 요청은 `code_challenge` + `code_challenge_method=S256`를 반드시 포함해야 함 (client 유형과 무관)
 
 ## 클라이언트 유형
 
@@ -189,7 +190,7 @@ RecoverUser 자체는 원자적이다 (단일 UPDATE).
 
 ## 보안 요구사항
 
-- PKCE S256 필수 (plain 불허, zitadel이 강제)
+- 모든 `/authorize` 요청에서 PKCE S256 필수 (plain 불허, code_challenge 누락 불허)
 - `state` 파라미터: authRequestID를 state로 사용. CSRF 보호 역할
 - confidential 클라이언트: client_secret bcrypt 검증
 - public 클라이언트: client_secret 없음, PKCE가 유일한 보호

--- a/docs/spec/004-mcp-login.md
+++ b/docs/spec/004-mcp-login.md
@@ -60,6 +60,7 @@ MCP Authorization
 
 - authgate에서 `zitadel/oidc`는 **내장 라이브러리**다. 별도 서버가 아니다.
 - MCP 클라이언트는 OAuth 2.1 `authorization_code + PKCE(S256)`를 지원해야 한다.
+- authgate는 모든 `/authorize` 요청에 대해 `code_challenge` + `code_challenge_method=S256`를 필수로 강제한다.
 - MCP 클라이언트는 RFC 8414 metadata를 사용할 수 있어야 한다.
 - MCP 클라이언트는 CIMD (Client ID Metadata Document)를 지원해야 한다. DCR(RFC 7591)은 지원하지 않는다.
 - **성공적으로 MCP 토큰을 발급받으려면** `user.Status = 'active'` 여야 한다.

--- a/internal/integration/integration_pkce_enforcement_test.go
+++ b/internal/integration/integration_pkce_enforcement_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+
+package integration
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestPKCEEnforcement(t *testing.T) {
+	t.Run("authorize without code_challenge returns invalid_request", func(t *testing.T) {
+		ts := SetupTestServer(t)
+		client := NewOAuthClient(t, ts.BaseURL)
+
+		noFollow := *client.Client
+		noFollow.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		resp, err := noFollow.Get(client.AuthorizeURLNoPKCE())
+		if err != nil {
+			t.Fatalf("authorize without pkce: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if loc := resp.Header.Get("Location"); loc != "" {
+			u, parseErr := url.Parse(loc)
+			if parseErr != nil {
+				t.Fatalf("parse location: %v", parseErr)
+			}
+			if got := u.Query().Get("error"); got != "invalid_request" {
+				t.Fatalf("expected error=invalid_request in redirect, got %q (location=%s)", got, loc)
+			}
+			return
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		if !strings.Contains(string(body), "invalid_request") {
+			t.Fatalf("expected invalid_request in response body, status=%d body=%s", resp.StatusCode, string(body))
+		}
+	})
+
+	t.Run("authorize with S256 code_challenge succeeds", func(t *testing.T) {
+		ts := SetupTestServer(t)
+		client := NewOAuthClient(t, ts.BaseURL)
+
+		code := completeLoginFlowToCode(t, ts, client)
+		if code == "" {
+			t.Fatal("expected authorization code from redirect without error")
+		}
+	})
+}

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -16,6 +16,17 @@ import (
 // --- op.Storage: AuthStorage ---
 
 func (s *Storage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest, userID string) (op.AuthRequest, error) {
+	if req.CodeChallenge == "" {
+		err := oidc.ErrInvalidRequest()
+		err.Description = "PKCE S256 required"
+		return nil, err
+	}
+	if req.CodeChallengeMethod != oidc.CodeChallengeMethodS256 {
+		err := oidc.ErrInvalidRequest()
+		err.Description = "PKCE S256 required"
+		return nil, err
+	}
+
 	resource := ResourceFromContext(ctx)
 	if resource == "" {
 		client, err := s.resolveClient(ctx, req.ClientID)


### PR DESCRIPTION
## Summary
- Enforce PKCE on all `/authorize` requests at auth request creation (`Storage.CreateAuthRequest`)
- Reject requests missing `code_challenge` with `error=invalid_request` and message `PKCE S256 required`
- Reject requests with non-`S256` `code_challenge_method` with the same error
- Update browser and MCP specs (`docs/spec/002-browser-login.md`, `docs/spec/004-mcp-login.md`) to state PKCE S256 is mandatory
- Add integration test `TestPKCEEnforcement` covering both fail and pass cases

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (unit)
- [ ] `go test -tags=integration ./...` passes (requires Docker)
- [ ] `/authorize` without `code_challenge` → `invalid_request`
- [ ] `/authorize` with `S256` `code_challenge` → proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)