### PR TITLE
fix(test): add resource parameter to existing MCP integration tests

### DIFF
--- a/internal/service/account_test.go
+++ b/internal/service/account_test.go
@@ -223,7 +223,7 @@ func TestAccount004b_PendingDeletion_MCPRejected(t *testing.T) {
 	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pd-mcp@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "pdm@test.com"})
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
-	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "pd-mcp")
+	arID, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "pd-mcp", "http://localhost/mcp")
 	result := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -128,7 +128,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		if err != nil {
 			t.Fatalf("create user: %v", err)
 		}
-		arID, _ := store.CreateTestAuthRequest(ctx, "audit-mcp")
+		arID, _ := store.CreateTestAuthRequestWithResource(ctx, "audit-mcp", "http://localhost/mcp")
 
 		result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-agent")
 		if result.Action != ActionAutoApprove {
@@ -328,7 +328,7 @@ func TestAuditSecurity_MCPInactiveUser_Metadata(t *testing.T) {
 			if err := store.SetUserStatus(ctx, user.ID, tt.status); err != nil {
 				t.Fatalf("set status %s: %v", tt.status, err)
 			}
-			arID, _ := store.CreateTestAuthRequest(ctx, "audit-mcp-"+tt.name)
+			arID, _ := store.CreateTestAuthRequestWithResource(ctx, "audit-mcp-"+tt.name, "http://localhost/mcp")
 
 			result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-agent")
 			if result.Action != ActionError {

--- a/internal/service/e2e_test.go
+++ b/internal/service/e2e_test.go
@@ -100,7 +100,7 @@ func TestE2E1_SignupToAllChannels(t *testing.T) {
 	}
 
 	// 4. MCP → auto-approve
-	arID3, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e1-mcp")
+	arID3, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "e2e1-mcp", "http://localhost/mcp")
 	mcpResult := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arID3, "127.0.0.1", "mcp-client")
 	if mcpResult.Action != ActionAutoApprove {
 		t.Fatalf("step 4: mcp action = %v, want AutoApprove", mcpResult.Action)
@@ -122,7 +122,7 @@ func TestE2E2_SignupAbandonAndReturn(t *testing.T) {
 		t.Fatalf("device before signup: action=%v, want DeviceError", devResult.Action)
 	}
 
-	arIDMCP, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e2-mcp-pre")
+	arIDMCP, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "e2e2-mcp-pre", "http://localhost/mcp")
 	mcpResult := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP, "127.0.0.1", "mcp")
 	if mcpResult.Action != ActionError {
 		t.Fatalf("mcp before signup: action=%v, want ActionError", mcpResult.Action)
@@ -143,7 +143,7 @@ func TestE2E2_SignupAbandonAndReturn(t *testing.T) {
 	}
 
 	// 가입 후 MCP 정상 동작
-	arIDMCP2, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e2-mcp-post")
+	arIDMCP2, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "e2e2-mcp-post", "http://localhost/mcp")
 	mcpResult2 := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP2, "127.0.0.1", "mcp")
 	if mcpResult2.Action != ActionAutoApprove {
 		t.Fatalf("mcp after signup: action=%v, want ActionAutoApprove", mcpResult2.Action)
@@ -182,7 +182,7 @@ func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
 	if devResult.Action != DeviceError || devResult.ErrorCode != 403 {
 		t.Fatalf("step 3: device should reject pending_deletion user, got action=%v code=%d", devResult.Action, devResult.ErrorCode)
 	}
-	arIDMCP, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e4-mcp")
+	arIDMCP, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "e2e4-mcp", "http://localhost/mcp")
 	mcpResult := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP, "127.0.0.1", "mcp-client")
 	if mcpResult.Action != ActionError || mcpResult.ErrorCode != 403 {
 		t.Fatalf("step 3: mcp should reject pending_deletion user, got action=%v code=%d", mcpResult.Action, mcpResult.ErrorCode)
@@ -205,7 +205,7 @@ func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
 	if devResult2.Action != DeviceRedirectBack {
 		t.Fatalf("step 5: device should succeed after recovery, got action=%v", devResult2.Action)
 	}
-	arIDMCP2, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e4-mcp-ok")
+	arIDMCP2, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "e2e4-mcp-ok", "http://localhost/mcp")
 	mcpResult2 := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP2, "127.0.0.1", "mcp-client")
 	if mcpResult2.Action != ActionAutoApprove {
 		t.Fatalf("step 5: mcp should succeed after recovery, got action=%v", mcpResult2.Action)

--- a/internal/service/mcp_test.go
+++ b/internal/service/mcp_test.go
@@ -38,7 +38,7 @@ func TestMCP_CompleteUser_AutoApprove(t *testing.T) {
 	ctx := context.Background()
 
 	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-ok@test.com", EmailVerified: true, Name: "MCP", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-sub-123", ProviderEmail: "mcp@test.com"})
-	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-ok")
+	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-ok", "http://localhost/mcp")
 
 	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
 
@@ -48,10 +48,11 @@ func TestMCP_CompleteUser_AutoApprove(t *testing.T) {
 }
 
 func TestMCP_NewUser_SignupRequired(t *testing.T) {
-	svc, _ := setupMCPTest(t)
+	svc, store := setupMCPTest(t)
 	ctx := context.Background()
 
-	result := svc.HandleCallback(ctx, "fake-code", "req-mcp-new", "127.0.0.1", "mcp-client")
+	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-new", "http://localhost/mcp")
+	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error (MCP new user)", result.Action)
@@ -68,7 +69,8 @@ func TestMCP_DisabledUser_Rejected(t *testing.T) {
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-dis@test.com", EmailVerified: true, Name: "MCP", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-sub-123", ProviderEmail: "mcp@test.com"})
 	store.DisableUser(ctx, user.ID)
 
-	result := svc.HandleCallback(ctx, "fake-code", "req-mcp-dis", "127.0.0.1", "mcp-client")
+	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-dis", "http://localhost/mcp")
+	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error (disabled user)", result.Action)
@@ -86,7 +88,7 @@ func TestMCP005_Recoverable_Rejected(t *testing.T) {
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-recover@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-005-sub", ProviderEmail: "mrc@test.com"})
 	store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
-	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-005")
+	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-005", "http://localhost/mcp")
 	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
@@ -148,11 +150,12 @@ func TestMCPLogin_DeletedSession_Rejected(t *testing.T) {
 }
 
 func TestMCPCallback_UpstreamError_Sanitized(t *testing.T) {
-	svc, _ := setupMCPTest(t)
+	svc, store := setupMCPTest(t)
 	ctx := context.Background()
 	svc.mcpProvider = &upstream.FakeProvider{ProviderName: "google"}
 
-	result := svc.HandleCallback(ctx, "fake-code", "req-upstream", "127.0.0.1", "mcp-client")
+	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "upstream-err", "http://localhost/mcp")
+	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Fatalf("action = %v, want ActionError", result.Action)
@@ -169,7 +172,7 @@ func TestMCP_DeletedUser_Rejected(t *testing.T) {
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-deleted@test.com", EmailVerified: true, Name: "MCP", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-deleted-sub", ProviderEmail: "mcp-deleted@test.com"})
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
-	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-deleted")
+	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-deleted", "http://localhost/mcp")
 
 	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
 

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -255,6 +255,20 @@ func (s *Storage) CreateTestAuthRequest(ctx context.Context, label string) (stri
 	return id, err
 }
 
+// CreateTestAuthRequestWithResource creates a minimal auth request with a resource field set,
+// for testing MCP flows that require resource binding validation.
+func (s *Storage) CreateTestAuthRequestWithResource(ctx context.Context, label, resource string) (string, error) {
+	id := s.idgen.NewUUID()
+	now := s.clock.Now()
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO auth_requests (id, client_id, redirect_uri, scopes, state, nonce, code_challenge, code_challenge_method, resource, expires_at, created_at)`+
+		` VALUES ($1, 'test-app', 'http://localhost/callback', '{openid}', $2, 'test-nonce', 'E9Melhoa2OwvFrEMT', 'S256', $3, $4, $5)`,
+		id, label, resource, now.Add(10*time.Minute), now,
+	)
+	return id, err
+}
+
+
 // Session management
 
 func (s *Storage) CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error) {


### PR DESCRIPTION
## Summary
- Regression from PR #94: existing MCP tests failed because auth requests were created without a `resource` field, causing `HandleCallback` to reject them with 400 `invalid_target` before reaching user-lookup logic
- Added `CreateTestAuthRequestWithResource(ctx, label, resource string)` helper to `internal/storage/users.go`
- Updated all MCP `HandleCallback` call sites in `mcp_test.go`, `e2e_test.go`, `audit_test.go`, and `account_test.go` to use the new helper with `resource=http://localhost/mcp`
- No change to validation logic in `mcp_login.go` — tests now comply with Spec 004

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all non-integration tests green)
- [ ] CI integration tests pass (`go test -tags=integration ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)