### PR TITLE
fix(test): resolve 3 CI integration test failures

### DIFF
--- a/internal/integration/integration_mcp_test.go
+++ b/internal/integration/integration_mcp_test.go
@@ -163,7 +163,17 @@ func TestIntegration_MCPCodeExchange_StateChange_InvalidGrant(t *testing.T) {
 // device-002: device callback must reject non-existent user (no browser signup).
 func TestIntegration_MCPCallback_NewUser_Rejected(t *testing.T) {
 	ts := SetupTestServer(t)
-	resp, err := http.Get(ts.BaseURL + "/mcp/callback?code=fake-code&state=req-mcp-new")
+	ctx := context.Background()
+
+	// Create a proper auth request with a resource so the MCP callback flow
+	// reaches the user-lookup stage (resource binding validation added in PR #94
+	// requires a non-empty resource; without it the service returns 400, not 403).
+	authRequestID, err := ts.Store.CreateTestAuthRequestWithResource(ctx, "req-mcp-new", ts.BaseURL+"/mcp")
+	if err != nil {
+		t.Fatalf("create auth request: %v", err)
+	}
+
+	resp, err := http.Get(ts.BaseURL + "/mcp/callback?code=fake-code&state=" + authRequestID)
 	if err != nil {
 		t.Fatalf("mcp callback: %v", err)
 	}

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -17,6 +17,8 @@ import (
 	"github.com/kangheeyong/authgate/internal/clock"
 	"github.com/kangheeyong/authgate/internal/handler"
 	"github.com/kangheeyong/authgate/internal/idgen"
+	"golang.org/x/time/rate"
+
 	"github.com/kangheeyong/authgate/internal/middleware"
 	"github.com/kangheeyong/authgate/internal/service"
 	"github.com/kangheeyong/authgate/internal/storage"
@@ -173,10 +175,11 @@ func SetupTestServerWithOptions(t *testing.T, opts SetupOptions) *TestServer {
 		resource := storage.ResourceFromRequest(r)
 		provider.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
 	}))
-	mux.Handle("/oauth/token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tokenRateLimiter := middleware.NewRateLimiter(rate.Limit(5), 5)
+	mux.Handle("/oauth/token", tokenRateLimiter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resource := storage.ResourceFromRequest(r)
 		provider.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
-	}))
+	})))
 	mux.Handle("/oauth/revoke", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !opts.EnableMCP {
 			provider.ServeHTTP(w, r)

--- a/internal/service/account_test.go
+++ b/internal/service/account_test.go
@@ -83,10 +83,19 @@ func TestDeleteAccount_Idempotent(t *testing.T) {
 	fx := setupAccountTest(t)
 	ctx := context.Background()
 
-	_, sessionID := createUserWithSession(t, fx.Store, "idempotent@test.com", "idem-sub")
+	userID, sessionID := createUserWithSession(t, fx.Store, "idempotent@test.com", "idem-sub")
 
+	// First DELETE: sets user to pending_deletion and revokes the session.
 	fx.AccountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
-	result := fx.AccountSvc.RequestDeletion(ctx, sessionID, "127.0.0.1", "test")
+
+	// After the first DELETE the original session is revoked.
+	// Create a fresh session so the second call can authenticate.
+	sessionID2, err := fx.Store.CreateSession(ctx, userID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("create second session: %v", err)
+	}
+
+	result := fx.AccountSvc.RequestDeletion(ctx, sessionID2, "127.0.0.1", "test")
 	if !result.Success {
 		t.Errorf("expected idempotent success, got: %s", result.Message)
 	}


### PR DESCRIPTION
## Summary

- **RateLimit**: `internal/integration/server.go` — wrap `/oauth/token` with `middleware.NewRateLimiter(rate.Limit(5), 5)` so `TestRateLimiting` can observe 429 responses (the production rate limiter in `cmd/authgate/main.go` was never wired into the integration test server)
- **DeleteAccount_Idempotent**: `internal/service/account_test.go` — after the first `DELETE /account` call, `RequestDeletion` revokes all sessions (PR #93). The second call with the same revoked session ID hit `GetValidSession` → error before reaching the idempotency branch. Fix: create a fresh session before the second call so the idempotency path (`user.Status == "pending_deletion" → success`) is reachable.
- **MCPCallback_NewUser_Rejected**: `internal/integration/integration_mcp_test.go` — PR #94 added resource binding validation that returns 400 when the auth request has no resource, before reaching the user-lookup that returns 403. Fix: create a real auth request with a resource via `ts.Store.CreateTestAuthRequestWithResource` and use its ID as the `state` param so the flow reaches the user-not-found → 403 path.

Note: CORS middleware (`cors.go`) already correctly gates `Access-Control-Allow-Origin` behind the allowlist match; no change was needed there.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (all unit tests green)
- [ ] `go test -tags=integration ./internal/service/... -run TestDeleteAccount_Idempotent` passes
- [ ] `go test -tags=integration ./internal/integration/... -run TestRateLimiting` passes
- [ ] `go test -tags=integration ./internal/integration/... -run TestIntegration_MCPCallback_NewUser_Rejected` passes

🤖 Generated with Claude Code