### PR TITLE
fix(test): MCP integration tests create auth requests via real /authorize

### DIFF
--- a/internal/integration/integration_helpers_test.go
+++ b/internal/integration/integration_helpers_test.go
@@ -3,6 +3,8 @@
 package integration
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -213,4 +215,78 @@ func pollDeviceToken(t *testing.T, ts *TestServer, deviceCode string) *TokenResp
 		_ = json.Unmarshal(body, tr)
 	}
 	return tr
+}
+
+// createMCPAuthRequest drives a real /authorize request through the MCP channel
+// and returns the authRequestID that the MCP login handler assigned.
+// It uses client_id=mcp-client with valid PKCE S256 params and stops at the
+// first redirect so it can extract the authRequestID before any IdP interaction.
+func createMCPAuthRequest(t *testing.T, ts *TestServer, resource string) string {
+	t.Helper()
+
+	// Generate PKCE S256 challenge.
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		t.Fatalf("createMCPAuthRequest: generate random bytes: %v", err)
+	}
+	verifier := base64.RawURLEncoding.EncodeToString(raw)
+	h := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(h[:])
+
+	params := url.Values{
+		"client_id":             {"mcp-client"},
+		"response_type":         {"code"},
+		"redirect_uri":          {ts.BaseURL + "/callback"},
+		"scope":                 {"openid profile email offline_access"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}
+	if resource != "" {
+		params.Set("resource", resource)
+	}
+
+	noFollow := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	// Step 1: GET /authorize → 302 to /mcp/login?authRequestID=xxx
+	resp1, err := noFollow.Get(ts.BaseURL + "/authorize?" + params.Encode())
+	if err != nil {
+		t.Fatalf("createMCPAuthRequest: authorize: %v", err)
+	}
+	resp1.Body.Close()
+
+	loginLoc := resp1.Header.Get("Location")
+	if loginLoc == "" {
+		t.Fatalf("createMCPAuthRequest: /authorize did not redirect, status=%d", resp1.StatusCode)
+	}
+
+	// Make absolute if relative.
+	if !strings.HasPrefix(loginLoc, "http") {
+		loginLoc = ts.BaseURL + loginLoc
+	}
+
+	// Step 2: GET /mcp/login?authRequestID=xxx → 302 to IdP with state=authRequestID
+	resp2, err := noFollow.Get(loginLoc)
+	if err != nil {
+		t.Fatalf("createMCPAuthRequest: mcp/login: %v", err)
+	}
+	resp2.Body.Close()
+
+	idpLoc := resp2.Header.Get("Location")
+	if idpLoc == "" {
+		t.Fatalf("createMCPAuthRequest: /mcp/login did not redirect, status=%d", resp2.StatusCode)
+	}
+
+	idpURL, err := url.Parse(idpLoc)
+	if err != nil {
+		t.Fatalf("createMCPAuthRequest: parse idp redirect: %v", err)
+	}
+	authRequestID := idpURL.Query().Get("state")
+	if authRequestID == "" {
+		t.Fatalf("createMCPAuthRequest: no state/authRequestID in IdP redirect: %s", idpLoc)
+	}
+	return authRequestID
 }

--- a/internal/integration/integration_mcp_test.go
+++ b/internal/integration/integration_mcp_test.go
@@ -163,15 +163,10 @@ func TestIntegration_MCPCodeExchange_StateChange_InvalidGrant(t *testing.T) {
 // device-002: device callback must reject non-existent user (no browser signup).
 func TestIntegration_MCPCallback_NewUser_Rejected(t *testing.T) {
 	ts := SetupTestServer(t)
-	ctx := context.Background()
 
-	// Create a proper auth request with a resource so the MCP callback flow
-	// reaches the user-lookup stage (resource binding validation added in PR #94
-	// requires a non-empty resource; without it the service returns 400, not 403).
-	authRequestID, err := ts.Store.CreateTestAuthRequestWithResource(ctx, "req-mcp-new", ts.BaseURL+"/mcp")
-	if err != nil {
-		t.Fatalf("create auth request: %v", err)
-	}
+	// Create a real auth request via /authorize so PKCE enforcement is exercised.
+	// Using CreateTestAuthRequestWithResource would bypass CreateAuthRequest (raw SQL).
+	authRequestID := createMCPAuthRequest(t, ts, ts.BaseURL+"/mcp")
 
 	resp, err := http.Get(ts.BaseURL + "/mcp/callback?code=fake-code&state=" + authRequestID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `createMCPAuthRequest()` helper in `internal/integration/integration_helpers_test.go` that drives a real `GET /authorize` request with `client_id=mcp-client` and valid PKCE S256 params, following redirects to extract the `authRequestID` from the MCP login redirect
- Replace `ts.Store.CreateTestAuthRequestWithResource()` call in `TestIntegration_MCPCallback_NewUser_Rejected` with `createMCPAuthRequest()` — PKCE enforcement is now exercised in the MCP callback test path
- `CreateTestAuthRequestWithResource` is retained in `internal/storage/users.go` because service-level unit tests (`internal/service/mcp_test.go`, `e2e_test.go`, `audit_test.go`, `account_test.go`) legitimately use raw seeding to test the service layer directly without going through HTTP

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 8 packages green)
- [x] `go vet -tags=integration ./internal/integration/...` clean
- [ ] Integration tests: `go test -tags=integration ./...` (requires Docker/testcontainers)

🤖 Generated with Claude Code