### PR TITLE
feat(console): add Bearer token auth to console API endpoints

### DIFF
--- a/internal/handler/console.go
+++ b/internal/handler/console.go
@@ -9,8 +9,8 @@ import (
 )
 
 type consoleServicer interface {
-	ListClients(ctx context.Context, sessionID string) *service.ClientsResult
-	ListConnections(ctx context.Context, sessionID string) *service.ConnectionsResult
+	ListClients(ctx context.Context, sessionID, authHeader string) *service.ClientsResult
+	ListConnections(ctx context.Context, sessionID, authHeader string) *service.ConnectionsResult
 }
 
 type ConsoleHandler struct {
@@ -26,7 +26,7 @@ func (h *ConsoleHandler) HandleListClients(w http.ResponseWriter, r *http.Reques
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
-	result := h.svc.ListClients(r.Context(), getSessionCookie(r))
+	result := h.svc.ListClients(r.Context(), getSessionCookie(r), r.Header.Get("Authorization"))
 	w.Header().Set("Content-Type", "application/json")
 	if result.ErrorCode != 0 {
 		w.WriteHeader(result.ErrorCode)
@@ -41,7 +41,7 @@ func (h *ConsoleHandler) HandleListConnections(w http.ResponseWriter, r *http.Re
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
-	result := h.svc.ListConnections(r.Context(), getSessionCookie(r))
+	result := h.svc.ListConnections(r.Context(), getSessionCookie(r), r.Header.Get("Authorization"))
 	w.Header().Set("Content-Type", "application/json")
 	if result.ErrorCode != 0 {
 		w.WriteHeader(result.ErrorCode)

--- a/internal/handler/device_test.go
+++ b/internal/handler/device_test.go
@@ -14,7 +14,7 @@ import (
 // nil storage is safe as long as the code path under test exits before touching it.
 func newTestDeviceHandler() *DeviceHandler {
 	svc := service.NewDeviceService(nil, nil, "", 0, nil)
-	return NewDeviceHandler(svc, true) // devMode=true
+	return NewDeviceHandler(svc, true, "authgate") // devMode=true
 }
 
 // ── Method guard ──────────────────────────────────────────────────────────────

--- a/internal/handler/login_test.go
+++ b/internal/handler/login_test.go
@@ -11,7 +11,7 @@ import (
 
 func newTestLoginHandler(devMode bool) *LoginHandler {
 	svc := service.NewLoginService(nil, nil, 0)
-	return NewLoginHandler(svc, devMode)
+	return NewLoginHandler(svc, devMode, "authgate")
 }
 
 func TestLogin_MissingAuthRequestID_ReturnsBadRequest(t *testing.T) {

--- a/internal/handler/mcp_login_test.go
+++ b/internal/handler/mcp_login_test.go
@@ -10,7 +10,7 @@ import (
 
 func newTestMCPLoginHandler(devMode bool) *MCPLoginHandler {
 	svc := service.NewMCPLoginService(nil, nil, 0)
-	return NewMCPLoginHandler(svc, devMode)
+	return NewMCPLoginHandler(svc, devMode, "authgate")
 }
 
 func TestMCPLogin_MissingAuthRequestID_ReturnsBadRequest(t *testing.T) {

--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/kangheeyong/authgate/internal/storage"
@@ -13,6 +14,7 @@ type ConsoleService struct {
 
 type ConsoleStore interface {
 	GetValidSession(ctx context.Context, sessionID string) (*storage.User, error)
+	ValidateBearerToken(ctx context.Context, authHeader string) (*storage.User, error)
 	ListAllClients() []storage.ClientView
 	GetActiveConnections(ctx context.Context, userID string) ([]string, error)
 }
@@ -37,11 +39,22 @@ type ConnectionView struct {
 	URL      string `json:"url,omitempty"`
 }
 
-func (s *ConsoleService) ListClients(ctx context.Context, sessionID string) *ClientsResult {
-	if sessionID == "" {
-		return &ClientsResult{ErrorCode: http.StatusUnauthorized}
+// resolveUser tries session cookie first, then Bearer token.
+func (s *ConsoleService) resolveUser(ctx context.Context, sessionID, authHeader string) (*storage.User, error) {
+	if sessionID != "" {
+		user, err := s.store.GetValidSession(ctx, sessionID)
+		if err == nil {
+			return user, nil
+		}
 	}
-	user, err := s.store.GetValidSession(ctx, sessionID)
+	if authHeader != "" {
+		return s.store.ValidateBearerToken(ctx, authHeader)
+	}
+	return nil, errors.New("unauthenticated")
+}
+
+func (s *ConsoleService) ListClients(ctx context.Context, sessionID, authHeader string) *ClientsResult {
+	user, err := s.resolveUser(ctx, sessionID, authHeader)
 	if err != nil {
 		return &ClientsResult{ErrorCode: http.StatusUnauthorized}
 	}
@@ -55,11 +68,8 @@ func (s *ConsoleService) ListClients(ctx context.Context, sessionID string) *Cli
 	return &ClientsResult{Clients: clients}
 }
 
-func (s *ConsoleService) ListConnections(ctx context.Context, sessionID string) *ConnectionsResult {
-	if sessionID == "" {
-		return &ConnectionsResult{ErrorCode: http.StatusUnauthorized}
-	}
-	user, err := s.store.GetValidSession(ctx, sessionID)
+func (s *ConsoleService) ListConnections(ctx context.Context, sessionID, authHeader string) *ConnectionsResult {
+	user, err := s.resolveUser(ctx, sessionID, authHeader)
 	if err != nil {
 		return &ConnectionsResult{ErrorCode: http.StatusUnauthorized}
 	}
@@ -72,9 +82,6 @@ func (s *ConsoleService) ListConnections(ctx context.Context, sessionID string) 
 		return &ConnectionsResult{ErrorCode: http.StatusInternalServerError}
 	}
 
-	// Enrich with client metadata from the in-memory registry.
-	// Fall back to client_id as name when the registry entry no longer exists
-	// (e.g. deleted YAML client with a lingering refresh token).
 	allClients := s.store.ListAllClients()
 	type clientMeta struct{ name, url string }
 	metaByID := make(map[string]clientMeta, len(allClients))

--- a/internal/service/console_unit_test.go
+++ b/internal/service/console_unit_test.go
@@ -10,19 +10,23 @@ import (
 )
 
 type fakeConsoleStore struct {
-	getValidSessionFn    func(ctx context.Context, sessionID string) (*storage.User, error)
-	listAllClientsFn     func() []storage.ClientView
-	getActiveConnFn      func(ctx context.Context, userID string) ([]string, error)
+	getValidSessionFn   func(ctx context.Context, sessionID string) (*storage.User, error)
+	validateBearerFn    func(ctx context.Context, authHeader string) (*storage.User, error)
+	listAllClientsFn    func() []storage.ClientView
+	getActiveConnFn     func(ctx context.Context, userID string) ([]string, error)
 }
 
 func (f *fakeConsoleStore) GetValidSession(ctx context.Context, sessionID string) (*storage.User, error) {
 	return f.getValidSessionFn(ctx, sessionID)
 }
+func (f *fakeConsoleStore) ValidateBearerToken(ctx context.Context, authHeader string) (*storage.User, error) {
+	if f.validateBearerFn != nil {
+		return f.validateBearerFn(ctx, authHeader)
+	}
+	return nil, errors.New("bearer not configured")
+}
 func (f *fakeConsoleStore) ListAllClients() []storage.ClientView {
 	return f.listAllClientsFn()
-}
-func (f *fakeConsoleStore) ValidateBearerToken(ctx context.Context, authHeader string) (*storage.User, error) {
-	return nil, errors.New("not implemented")
 }
 func (f *fakeConsoleStore) GetActiveConnections(ctx context.Context, userID string) ([]string, error) {
 	return f.getActiveConnFn(ctx, userID)
@@ -174,5 +178,85 @@ func TestConsole_ListConnections_DBError_InternalServerError(t *testing.T) {
 	r := svc.ListConnections(context.Background(), "sess-1", "")
 	if r.ErrorCode != http.StatusInternalServerError {
 		t.Fatalf("want 500, got %d", r.ErrorCode)
+	}
+}
+
+// --- Bearer auth ---
+
+func bearerStore(user *storage.User, bearerErr error) *fakeConsoleStore {
+	return &fakeConsoleStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return nil, errors.New("no session")
+		},
+		validateBearerFn: func(context.Context, string) (*storage.User, error) {
+			return user, bearerErr
+		},
+		listAllClientsFn: func() []storage.ClientView { return nil },
+		getActiveConnFn:  func(context.Context, string) ([]string, error) { return nil, nil },
+	}
+}
+
+func TestConsole_ListClients_BearerValid_ReturnsClients(t *testing.T) {
+	store := bearerStore(&storage.User{ID: "u1", Status: "active"}, nil)
+	store.listAllClientsFn = func() []storage.ClientView {
+		return []storage.ClientView{{ClientID: "app-a", Name: "App A"}}
+	}
+	svc := NewConsoleService(store)
+	r := svc.ListClients(context.Background(), "", "Bearer valid-token")
+	if r.ErrorCode != 0 {
+		t.Fatalf("want success, got %d", r.ErrorCode)
+	}
+	if len(r.Clients) != 1 {
+		t.Fatalf("want 1 client, got %d", len(r.Clients))
+	}
+}
+
+func TestConsole_ListClients_BearerInvalid_Unauthorized(t *testing.T) {
+	svc := NewConsoleService(bearerStore(nil, errors.New("invalid token")))
+	r := svc.ListClients(context.Background(), "", "Bearer bad-token")
+	if r.ErrorCode != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", r.ErrorCode)
+	}
+}
+
+func TestConsole_ListConnections_BearerValid_ReturnsConnections(t *testing.T) {
+	store := bearerStore(&storage.User{ID: "u1", Status: "active"}, nil)
+	store.getActiveConnFn = func(context.Context, string) ([]string, error) {
+		return []string{"app-a"}, nil
+	}
+	store.listAllClientsFn = func() []storage.ClientView {
+		return []storage.ClientView{{ClientID: "app-a", Name: "App A"}}
+	}
+	svc := NewConsoleService(store)
+	r := svc.ListConnections(context.Background(), "", "Bearer valid-token")
+	if r.ErrorCode != 0 {
+		t.Fatalf("want success, got %d", r.ErrorCode)
+	}
+	if len(r.Connections) != 1 || r.Connections[0].Name != "App A" {
+		t.Fatalf("unexpected connections: %+v", r.Connections)
+	}
+}
+
+func TestConsole_ListClients_SessionWinsOverBearer(t *testing.T) {
+	// session valid → bearer should never be called
+	bearerCalled := false
+	store := &fakeConsoleStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return &storage.User{ID: "u1", Status: "active"}, nil
+		},
+		validateBearerFn: func(context.Context, string) (*storage.User, error) {
+			bearerCalled = true
+			return nil, errors.New("should not be called")
+		},
+		listAllClientsFn: func() []storage.ClientView { return nil },
+		getActiveConnFn:  func(context.Context, string) ([]string, error) { return nil, nil },
+	}
+	svc := NewConsoleService(store)
+	r := svc.ListClients(context.Background(), "sess-1", "Bearer token")
+	if r.ErrorCode != 0 {
+		t.Fatalf("want success, got %d", r.ErrorCode)
+	}
+	if bearerCalled {
+		t.Fatal("bearer should not be called when session is valid")
 	}
 }

--- a/internal/service/console_unit_test.go
+++ b/internal/service/console_unit_test.go
@@ -21,6 +21,9 @@ func (f *fakeConsoleStore) GetValidSession(ctx context.Context, sessionID string
 func (f *fakeConsoleStore) ListAllClients() []storage.ClientView {
 	return f.listAllClientsFn()
 }
+func (f *fakeConsoleStore) ValidateBearerToken(ctx context.Context, authHeader string) (*storage.User, error) {
+	return nil, errors.New("not implemented")
+}
 func (f *fakeConsoleStore) GetActiveConnections(ctx context.Context, userID string) ([]string, error) {
 	return f.getActiveConnFn(ctx, userID)
 }
@@ -39,7 +42,7 @@ func activeUserStore(clients []storage.ClientView, connIDs []string) *fakeConsol
 
 func TestConsole_ListClients_NoSession_Unauthorized(t *testing.T) {
 	svc := NewConsoleService(activeUserStore(nil, nil))
-	r := svc.ListClients(context.Background(), "")
+	r := svc.ListClients(context.Background(), "", "")
 	if r.ErrorCode != http.StatusUnauthorized {
 		t.Fatalf("want 401, got %d", r.ErrorCode)
 	}
@@ -54,7 +57,7 @@ func TestConsole_ListClients_InvalidSession_Unauthorized(t *testing.T) {
 		getActiveConnFn:  func(context.Context, string) ([]string, error) { return nil, nil },
 	}
 	svc := NewConsoleService(store)
-	r := svc.ListClients(context.Background(), "sess-x")
+	r := svc.ListClients(context.Background(), "sess-x", "")
 	if r.ErrorCode != http.StatusUnauthorized {
 		t.Fatalf("want 401, got %d", r.ErrorCode)
 	}
@@ -69,7 +72,7 @@ func TestConsole_ListClients_DisabledUser_Forbidden(t *testing.T) {
 		getActiveConnFn:  func(context.Context, string) ([]string, error) { return nil, nil },
 	}
 	svc := NewConsoleService(store)
-	r := svc.ListClients(context.Background(), "sess-1")
+	r := svc.ListClients(context.Background(), "sess-1", "")
 	if r.ErrorCode != http.StatusForbidden {
 		t.Fatalf("want 403, got %d", r.ErrorCode)
 	}
@@ -84,7 +87,7 @@ func TestConsole_ListClients_PendingDeletion_Forbidden(t *testing.T) {
 		getActiveConnFn:  func(context.Context, string) ([]string, error) { return nil, nil },
 	}
 	svc := NewConsoleService(store)
-	r := svc.ListClients(context.Background(), "sess-1")
+	r := svc.ListClients(context.Background(), "sess-1", "")
 	if r.ErrorCode != http.StatusForbidden {
 		t.Fatalf("pending_deletion: want 403, got %d", r.ErrorCode)
 	}
@@ -96,7 +99,7 @@ func TestConsole_ListClients_ActiveUser_ReturnsClients(t *testing.T) {
 		{ClientID: "app-b", Name: "App B"},
 	}
 	svc := NewConsoleService(activeUserStore(clients, nil))
-	r := svc.ListClients(context.Background(), "sess-1")
+	r := svc.ListClients(context.Background(), "sess-1", "")
 	if r.ErrorCode != 0 {
 		t.Fatalf("want success, got error %d", r.ErrorCode)
 	}
@@ -107,7 +110,7 @@ func TestConsole_ListClients_ActiveUser_ReturnsClients(t *testing.T) {
 
 func TestConsole_ListClients_NilClients_ReturnsEmptySlice(t *testing.T) {
 	svc := NewConsoleService(activeUserStore(nil, nil))
-	r := svc.ListClients(context.Background(), "sess-1")
+	r := svc.ListClients(context.Background(), "sess-1", "")
 	if r.ErrorCode != 0 {
 		t.Fatalf("want success, got %d", r.ErrorCode)
 	}
@@ -120,7 +123,7 @@ func TestConsole_ListClients_NilClients_ReturnsEmptySlice(t *testing.T) {
 
 func TestConsole_ListConnections_NoSession_Unauthorized(t *testing.T) {
 	svc := NewConsoleService(activeUserStore(nil, nil))
-	r := svc.ListConnections(context.Background(), "")
+	r := svc.ListConnections(context.Background(), "", "")
 	if r.ErrorCode != http.StatusUnauthorized {
 		t.Fatalf("want 401, got %d", r.ErrorCode)
 	}
@@ -131,7 +134,7 @@ func TestConsole_ListConnections_ActiveUser_EnrichesName(t *testing.T) {
 		{ClientID: "app-a", Name: "App A"},
 	}
 	svc := NewConsoleService(activeUserStore(clients, []string{"app-a"}))
-	r := svc.ListConnections(context.Background(), "sess-1")
+	r := svc.ListConnections(context.Background(), "sess-1", "")
 	if r.ErrorCode != 0 {
 		t.Fatalf("want success, got %d", r.ErrorCode)
 	}
@@ -145,7 +148,7 @@ func TestConsole_ListConnections_ActiveUser_EnrichesName(t *testing.T) {
 
 func TestConsole_ListConnections_UnknownClient_FallsBackToClientID(t *testing.T) {
 	svc := NewConsoleService(activeUserStore(nil, []string{"ghost-client"}))
-	r := svc.ListConnections(context.Background(), "sess-1")
+	r := svc.ListConnections(context.Background(), "sess-1", "")
 	if r.ErrorCode != 0 {
 		t.Fatalf("want success, got %d", r.ErrorCode)
 	}
@@ -168,7 +171,7 @@ func TestConsole_ListConnections_DBError_InternalServerError(t *testing.T) {
 		},
 	}
 	svc := NewConsoleService(store)
-	r := svc.ListConnections(context.Background(), "sess-1")
+	r := svc.ListConnections(context.Background(), "sess-1", "")
 	if r.ErrorCode != http.StatusInternalServerError {
 		t.Fatalf("want 500, got %d", r.ErrorCode)
 	}

--- a/internal/storage/console.go
+++ b/internal/storage/console.go
@@ -2,8 +2,13 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"sort"
+	"strings"
+	"time"
 
+	jose "github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
 	"github.com/kangheeyong/authgate/internal/db/storeq"
 )
 
@@ -47,4 +52,38 @@ func (s *Storage) GetActiveConnections(ctx context.Context, userID string) ([]st
 		UserID:    userID,
 		ExpiresAt: s.clock.Now(),
 	})
+}
+
+// ValidateBearerToken validates an access token JWT and returns the associated user.
+// The token is verified against the current signing key using RS256.
+func (s *Storage) ValidateBearerToken(ctx context.Context, authHeader string) (*User, error) {
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+	if token == authHeader || token == "" {
+		return nil, errors.New("missing bearer token")
+	}
+	if s.signingKey == nil {
+		return nil, errors.New("signing key not configured")
+	}
+
+	tok, err := josejwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256})
+	if err != nil {
+		return nil, errors.New("invalid token format")
+	}
+
+	var claims josejwt.Claims
+	if err := tok.Claims(s.signingKey.Public(), &claims); err != nil {
+		return nil, errors.New("invalid token signature")
+	}
+
+	if err := claims.ValidateWithLeeway(josejwt.Expected{
+		Time: s.clock.Now(),
+	}, time.Second*5); err != nil {
+		return nil, errors.New("token validation failed: " + err.Error())
+	}
+
+	if claims.Subject == "" {
+		return nil, errors.New("missing sub claim")
+	}
+
+	return s.GetUserByID(ctx, claims.Subject)
 }


### PR DESCRIPTION
## Summary

`GET /console/clients`와 `GET /console/me/connections`에 Bearer token 인증 추가.

기존 session cookie 인증 유지 + `Authorization: Bearer <access_token>` 헤더도 수락.

## Why

authgate-console(Next.js)이 `/console/me/connections`를 서버사이드에서 호출할 때 `authgate_session` 쿠키가 cross-origin 제약(`SameSite=Lax`)으로 전달 안 됨. access token(JWT)을 Bearer로 전달하면 서버사이드에서도 호출 가능.

## Auth resolution order

```
1. authgate_session cookie (session cookie)
2. Authorization: Bearer <access_token> (fallback)
```

## Changes

- `storage/console.go` — `ValidateBearerToken(ctx, authHeader)` 추가 (RS256 JWT 검증 → sub → GetUserByID)
- `service/console.go` — `ConsoleStore` 인터페이스에 `ValidateBearerToken` 추가, `ListClients`/`ListConnections` authHeader 파라미터 추가
- `handler/console.go` — `Authorization` 헤더 추출해서 service로 전달
- 테스트 파일 업데이트 (fakeConsoleStore + 핸들러 생성자 brandName 파라미터)

## Test plan

- [ ] Bearer token으로 `/console/me/connections` 호출 시 200 + 정상 응답
- [ ] 만료된 토큰 → 401
- [ ] 기존 session cookie 인증 여전히 동작
- [ ] 기존 테스트 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)