### PR TITLE
feat(audit): enrich audit_log metadata with session_id, client_id and new events

### DIFF
--- a/internal/integration/integration_audit_test.go
+++ b/internal/integration/integration_audit_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-// TestAuditEvents verifies that token.refresh and token.revoked events
+// TestAuditEvents verifies that token.refresh, token.revoked, and auth.token_revoked events
 // are recorded in audit_log after the corresponding operations.
 func TestAuditEvents(t *testing.T) {
 	ts := SetupTestServer(t)
@@ -50,7 +50,7 @@ func TestAuditEvents(t *testing.T) {
 		}
 	})
 
-	t.Run("token.revoked recorded after explicit revocation", func(t *testing.T) {
+	t.Run("token revoke events recorded after explicit revocation", func(t *testing.T) {
 		// Get a fresh set of tokens for revocation test.
 		freshTokens := completeLoginFlow(t, ts)
 		if freshTokens.StatusCode != 200 {
@@ -88,6 +88,17 @@ func TestAuditEvents(t *testing.T) {
 		}
 		if count == 0 {
 			t.Error("expected at least one token.revoked audit_log row, got 0")
+		}
+
+		err = ts.DB.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM audit_log WHERE user_id = $1::uuid AND event_type = 'auth.token_revoked'`,
+			user.ID,
+		).Scan(&count)
+		if err != nil {
+			t.Fatalf("query audit_log for auth.token_revoked: %v", err)
+		}
+		if count == 0 {
+			t.Error("expected at least one auth.token_revoked audit_log row, got 0")
 		}
 	})
 }

--- a/internal/integration/integration_audit_test.go
+++ b/internal/integration/integration_audit_test.go
@@ -80,17 +80,6 @@ func TestAuditEvents(t *testing.T) {
 		// Re-fetch user (same provider identity, same user ID).
 		var count int
 		err = ts.DB.QueryRowContext(ctx,
-			`SELECT COUNT(*) FROM audit_log WHERE user_id = $1::uuid AND event_type = 'token.revoked'`,
-			user.ID,
-		).Scan(&count)
-		if err != nil {
-			t.Fatalf("query audit_log for token.revoked: %v", err)
-		}
-		if count == 0 {
-			t.Error("expected at least one token.revoked audit_log row, got 0")
-		}
-
-		err = ts.DB.QueryRowContext(ctx,
 			`SELECT COUNT(*) FROM audit_log WHERE user_id = $1::uuid AND event_type = 'auth.token_revoked'`,
 			user.ID,
 		).Scan(&count)

--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -20,6 +20,7 @@ type ConsoleStore interface {
 	ListAllClients() []storage.ClientView
 	GetActiveConnections(ctx context.Context, userID string) ([]storage.ConnectionTokenInfo, error)
 	RevokeConnection(ctx context.Context, userID, clientID string) error
+	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
 }
 
 func NewConsoleService(store ConsoleStore) *ConsoleService {
@@ -154,5 +155,6 @@ func (s *ConsoleService) RevokeConnection(ctx context.Context, sessionID, authHe
 	if err := s.store.RevokeConnection(ctx, auth.user.ID, clientID); err != nil {
 		return &RevokeConnectionResult{ErrorCode: http.StatusInternalServerError}
 	}
+	s.store.AuditLog(ctx, &auth.user.ID, "auth.connection_revoked", "", "", map[string]any{"client_id": clientID})
 	return &RevokeConnectionResult{}
 }

--- a/internal/service/console_unit_test.go
+++ b/internal/service/console_unit_test.go
@@ -18,6 +18,7 @@ type fakeConsoleStore struct {
 	listAllClientsFn           func() []storage.ClientView
 	getActiveConnFn            func(ctx context.Context, userID string) ([]storage.ConnectionTokenInfo, error)
 	revokeConnectionFn         func(ctx context.Context, userID, clientID string) error
+	auditLogFn                 func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
 }
 
 func (f *fakeConsoleStore) GetValidSession(ctx context.Context, sessionID string) (*storage.User, error) {
@@ -44,6 +45,12 @@ func (f *fakeConsoleStore) GetActiveConnections(ctx context.Context, userID stri
 }
 func (f *fakeConsoleStore) RevokeConnection(ctx context.Context, userID, clientID string) error {
 	return f.revokeConnectionFn(ctx, userID, clientID)
+}
+func (f *fakeConsoleStore) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+	if f.auditLogFn == nil {
+		return nil
+	}
+	return f.auditLogFn(ctx, userID, eventType, ipAddress, userAgent, metadata)
 }
 
 func activeUserStore(clients []storage.ClientView, connIDs []string) *fakeConsoleStore {
@@ -360,6 +367,33 @@ func TestConsole_RevokeConnection_ValidAuth_RevokesTokens(t *testing.T) {
 	}
 	if gotUserID != "u1" || gotClientID != "app-a" {
 		t.Fatalf("revoke called with userID=%q clientID=%q", gotUserID, gotClientID)
+	}
+}
+
+func TestConsole_RevokeConnection_ValidAuth_AuditLogsConnectionRevoked(t *testing.T) {
+	var gotUserID, gotEventType string
+	var gotMetadata map[string]any
+	store := activeUserStore(nil, nil)
+	store.auditLogFn = func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+		if userID != nil {
+			gotUserID = *userID
+		}
+		gotEventType = eventType
+		gotMetadata = metadata
+		return nil
+	}
+	svc := NewConsoleService(store)
+
+	r := svc.RevokeConnection(context.Background(), "sess-1", "", "app-a")
+
+	if r.ErrorCode != 0 {
+		t.Fatalf("want success, got %d", r.ErrorCode)
+	}
+	if gotUserID != "u1" || gotEventType != "auth.connection_revoked" {
+		t.Fatalf("audit userID=%q eventType=%q", gotUserID, gotEventType)
+	}
+	if gotMetadata["client_id"] != "app-a" {
+		t.Fatalf("metadata client_id=%v, want app-a", gotMetadata["client_id"])
 	}
 }
 

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -108,12 +108,24 @@ func (s *DeviceService) HandleDeviceCallback(ctx context.Context, code, userCode
 		return result
 	}
 
+	deviceCode, err := s.store.GetDeviceCodeByUserCode(ctx, userCode)
+	if errors.Is(err, storage.ErrNotFound) {
+		return &DevicePageResult{Action: DeviceError, Error: "invalid_request", ErrorCode: http.StatusBadRequest}
+	}
+	if err != nil {
+		return &DevicePageResult{Action: DeviceError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+	}
+
 	sessionID, err := s.store.CreateSession(ctx, user.ID, s.sessionTTL)
 	if err != nil {
 		return &DevicePageResult{Action: DeviceError, Error: "session creation failed", ErrorCode: http.StatusInternalServerError}
 	}
 
-	s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{"channel": "device"})
+	s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{
+		"channel":    "device",
+		"session_id": sessionID,
+		"client_id":  deviceCode.ClientID,
+	})
 
 	return &DevicePageResult{Action: DeviceRedirectBack, UserCode: userCode, SessionID: sessionID}
 }

--- a/internal/service/device_unit_test.go
+++ b/internal/service/device_unit_test.go
@@ -119,3 +119,43 @@ func TestDevice_HandleDeviceApprove_ApproveError(t *testing.T) {
 	}
 }
 
+func TestDevice_HandleDeviceCallback_AuditLogIncludesSessionAndClient(t *testing.T) {
+	var gotEventType string
+	var gotMetadata map[string]any
+	clk := &clock.FixedClock{T: time.Date(2026, 4, 3, 0, 0, 0, 0, time.UTC)}
+	store := &fakeDeviceStore{
+		getDeviceCodeByUserCodeFn: func(context.Context, string) (*storage.DeviceCodeModel, error) {
+			return &storage.DeviceCodeModel{
+				UserCode:  "UCODE",
+				ClientID:  "device-client",
+				State:     "pending",
+				ExpiresAt: clk.Now().Add(5 * time.Minute),
+			}, nil
+		},
+		getUserByProviderIdentity: func(context.Context, string, string) (*storage.User, error) {
+			return &storage.User{ID: "u1", Status: "active"}, nil
+		},
+		createSessionFn: func(context.Context, string, time.Duration) (string, error) {
+			return "sess-1", nil
+		},
+		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+			gotEventType = eventType
+			gotMetadata = metadata
+			return nil
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
+	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clk)
+
+	result := svc.HandleDeviceCallback(context.Background(), "code", "UCODE", "127.0.0.1", "ua")
+
+	if result.Action != DeviceRedirectBack {
+		t.Fatalf("action = %v, want %v", result.Action, DeviceRedirectBack)
+	}
+	if gotEventType != "auth.login" {
+		t.Fatalf("eventType = %q, want auth.login", gotEventType)
+	}
+	if gotMetadata["channel"] != "device" || gotMetadata["session_id"] != "sess-1" || gotMetadata["client_id"] != "device-client" {
+		t.Fatalf("metadata = %#v", gotMetadata)
+	}
+}

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -128,7 +128,15 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 		return &CallbackResult{Action: ActionError, Error: "upstream_error", ErrorCode: http.StatusInternalServerError}
 	}
 
-	user, result := s.findOrCreateBrowserUser(ctx, userInfo, ipAddress, userAgent)
+	authReq, err := s.store.GetAuthRequestModel(ctx, authRequestID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return &CallbackResult{Action: ActionError, Error: "auth_request_not_found", ErrorCode: http.StatusBadRequest}
+	}
+	if err != nil {
+		return &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+	}
+
+	user, signedUp, result := s.findOrCreateBrowserUser(ctx, userInfo, ipAddress, userAgent)
 	if result != nil {
 		return result
 	}
@@ -146,6 +154,12 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 	if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
 		return &CallbackResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
 	}
+	s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{
+		"channel":    "browser",
+		"session_id": sessionID,
+		"client_id":  authReq.ClientID,
+		"signup":     signedUp,
+	})
 
 	return &CallbackResult{Action: ActionAutoApprove, AuthRequestID: authRequestID, SessionID: sessionID}
 }
@@ -162,18 +176,18 @@ func (s *LoginService) recoverUser(ctx context.Context, userID, ipAddress, userA
 	return nil
 }
 
-func (s *LoginService) findOrCreateBrowserUser(ctx context.Context, userInfo *upstream.UserInfo, ipAddress, userAgent string) (*storage.User, *CallbackResult) {
+func (s *LoginService) findOrCreateBrowserUser(ctx context.Context, userInfo *upstream.UserInfo, ipAddress, userAgent string) (*storage.User, bool, *CallbackResult) {
 	providerName := s.browserProvider.Name()
 	user, err := s.store.GetUserByProviderIdentity(ctx, providerName, userInfo.Sub)
 	if errors.Is(err, storage.ErrNotFound) {
-		return s.signupBrowserUser(ctx, providerName, userInfo, ipAddress, userAgent)
+		user, result := s.signupBrowserUser(ctx, providerName, userInfo, ipAddress, userAgent)
+		return user, true, result
 	}
 	if err != nil {
-		return nil, &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+		return nil, false, &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
 	}
 
-	s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{"channel": "browser"})
-	return user, nil
+	return user, false, nil
 }
 
 func (s *LoginService) signupBrowserUser(ctx context.Context, providerName string, userInfo *upstream.UserInfo, ipAddress, userAgent string) (*storage.User, *CallbackResult) {
@@ -193,7 +207,7 @@ func (s *LoginService) signupBrowserUser(ctx context.Context, providerName strin
 		return nil, &CallbackResult{Action: ActionError, Error: fmt.Sprintf("signup failed: %v", err), ErrorCode: http.StatusInternalServerError}
 	}
 
-	s.store.AuditLog(ctx, &user.ID, "auth.signup", ipAddress, userAgent, nil)
+	s.store.AuditLog(ctx, &user.ID, "auth.signup", ipAddress, userAgent, map[string]any{"channel": "browser"})
 	return user, nil
 }
 

--- a/internal/service/login_unit_test.go
+++ b/internal/service/login_unit_test.go
@@ -92,6 +92,9 @@ func TestLogin_HandleLogin_RecoversPendingDeletionSession(t *testing.T) {
 
 func TestLogin_HandleCallback_EmailConflict(t *testing.T) {
 	store := &fakeLoginStore{
+		getAuthRequestModelFn: func(context.Context, string) (*storage.AuthRequestModel, error) {
+			return &storage.AuthRequestModel{ID: "ar-1", ClientID: "client-a"}, nil
+		},
 		getUserByProviderIdentity: func(context.Context, string, string) (*storage.User, error) {
 			return nil, storage.ErrNotFound
 		},
@@ -117,6 +120,132 @@ func TestLogin_HandleCallback_EmailConflict(t *testing.T) {
 	}
 	if result.ErrorCode != 409 {
 		t.Fatalf("errorCode = %d, want 409", result.ErrorCode)
+	}
+}
+
+func TestLogin_HandleCallback_ExistingUser_AuditLogIncludesSessionAndClient(t *testing.T) {
+	var gotEventType string
+	var gotMetadata map[string]any
+	store := &fakeLoginStore{
+		getAuthRequestModelFn: func(context.Context, string) (*storage.AuthRequestModel, error) {
+			return &storage.AuthRequestModel{ID: "ar-1", ClientID: "client-a"}, nil
+		},
+		getUserByProviderIdentity: func(context.Context, string, string) (*storage.User, error) {
+			return &storage.User{ID: "u1", Status: "active"}, nil
+		},
+		createSessionFn: func(context.Context, string, time.Duration) (string, error) {
+			return "sess-1", nil
+		},
+		completeAuthRequestFn: func(context.Context, string, string) error {
+			return nil
+		},
+		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+			gotEventType = eventType
+			gotMetadata = metadata
+			return nil
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub-1"}}
+	svc := NewLoginService(store, provider, 24*time.Hour)
+
+	result := svc.HandleCallback(context.Background(), "code", "ar-1", "127.0.0.1", "ua")
+
+	if result.Action != ActionAutoApprove {
+		t.Fatalf("action = %v, want %v", result.Action, ActionAutoApprove)
+	}
+	if gotEventType != "auth.login" {
+		t.Fatalf("eventType = %q, want auth.login", gotEventType)
+	}
+	if gotMetadata["channel"] != "browser" || gotMetadata["session_id"] != "sess-1" || gotMetadata["client_id"] != "client-a" {
+		t.Fatalf("metadata = %#v", gotMetadata)
+	}
+}
+
+func TestLogin_HandleCallback_SignupAuditLogIncludesChannel(t *testing.T) {
+	type auditEntry struct {
+		eventType string
+		metadata  map[string]any
+	}
+	var gotEvents []auditEntry
+	store := &fakeLoginStore{
+		getAuthRequestModelFn: func(context.Context, string) (*storage.AuthRequestModel, error) {
+			return &storage.AuthRequestModel{ID: "ar-1", ClientID: "client-a"}, nil
+		},
+		getUserByProviderIdentity: func(context.Context, string, string) (*storage.User, error) {
+			return nil, storage.ErrNotFound
+		},
+		createUserWithIdentityFn: func(context.Context, storage.CreateUserWithIdentityInput) (*storage.User, error) {
+			return &storage.User{ID: "u1", Status: "active"}, nil
+		},
+		createSessionFn: func(context.Context, string, time.Duration) (string, error) {
+			return "sess-1", nil
+		},
+		completeAuthRequestFn: func(context.Context, string, string) error {
+			return nil
+		},
+		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+			gotEvents = append(gotEvents, auditEntry{eventType: eventType, metadata: metadata})
+			return nil
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub-1"}}
+	svc := NewLoginService(store, provider, 24*time.Hour)
+
+	result := svc.HandleCallback(context.Background(), "code", "ar-1", "127.0.0.1", "ua")
+
+	if result.Action != ActionAutoApprove {
+		t.Fatalf("action = %v, want %v", result.Action, ActionAutoApprove)
+	}
+	var signupEvent *auditEntry
+	for i := range gotEvents {
+		if gotEvents[i].eventType == "auth.signup" {
+			signupEvent = &gotEvents[i]
+			break
+		}
+	}
+	if signupEvent == nil {
+		t.Fatalf("auth.signup event not found in %v", gotEvents)
+	}
+	if signupEvent.metadata["channel"] != "browser" {
+		t.Fatalf("signup metadata = %#v", signupEvent.metadata)
+	}
+}
+
+func TestMCPLogin_HandleCallback_AuditLogIncludesSessionAndClient(t *testing.T) {
+	var gotEventType string
+	var gotMetadata map[string]any
+	store := &fakeLoginStore{
+		getAuthRequestModelFn: func(context.Context, string) (*storage.AuthRequestModel, error) {
+			return &storage.AuthRequestModel{ID: "ar-1", ClientID: "mcp-client", Resource: "http://localhost/mcp"}, nil
+		},
+		getUserByProviderIdentity: func(context.Context, string, string) (*storage.User, error) {
+			return &storage.User{ID: "u1", Status: "active"}, nil
+		},
+		createSessionFn: func(context.Context, string, time.Duration) (string, error) {
+			return "sess-1", nil
+		},
+		completeAuthRequestFn: func(context.Context, string, string) error {
+			return nil
+		},
+		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+			gotEventType = eventType
+			gotMetadata = metadata
+			return nil
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub-1"}}
+	svc := NewMCPLoginService(store, provider, 24*time.Hour)
+
+	result := svc.HandleCallback(context.Background(), "code", "ar-1", "127.0.0.1", "ua")
+
+	if result.Action != ActionAutoApprove {
+		t.Fatalf("action = %v, want %v", result.Action, ActionAutoApprove)
+	}
+	if gotEventType != "auth.login" {
+		t.Fatalf("eventType = %q, want auth.login", gotEventType)
+	}
+	if gotMetadata["channel"] != "mcp" || gotMetadata["session_id"] != "sess-1" || gotMetadata["client_id"] != "mcp-client" {
+		t.Fatalf("metadata = %#v", gotMetadata)
 	}
 }
 

--- a/internal/service/mcp_login.go
+++ b/internal/service/mcp_login.go
@@ -89,7 +89,6 @@ func (s *MCPLoginService) HandleCallback(ctx context.Context, code, authRequestI
 		s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "mcp"})
 		return &CallbackResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
 	}
-	s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{"channel": "mcp"})
 
 	sessionID, err := s.store.CreateSession(ctx, user.ID, s.sessionTTL)
 	if err != nil {
@@ -98,5 +97,10 @@ func (s *MCPLoginService) HandleCallback(ctx context.Context, code, authRequestI
 	if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
 		return &CallbackResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
 	}
+	s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{
+		"channel":    "mcp",
+		"session_id": sessionID,
+		"client_id":  authReq.ClientID,
+	})
 	return &CallbackResult{Action: ActionAutoApprove, AuthRequestID: authRequestID, SessionID: sessionID}
 }

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -12,6 +12,8 @@ const (
 	EventAuthRefreshReuseDetected = "auth.refresh_reuse_detected"
 	EventAuthRefreshFamilyRevoked = "auth.refresh_family_revoked"
 	EventAuthDeletionCompleted    = "auth.deletion_completed"
+	EventAuthLogout               = "auth.logout"
+	EventAuthTokenRevoked         = "auth.token_revoked"
 
 	EventTokenRefresh   = "token.refresh"
 	EventTokenRevoked   = "token.revoked"

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -243,7 +243,7 @@ func (s *Storage) TerminateSession(ctx context.Context, userID string, clientID 
 	if err != nil {
 		return err
 	}
-	s.AuditLog(ctx, &userID, EventSessionRevoked, "", "", nil)
+	s.AuditLog(ctx, &userID, EventAuthLogout, "", "", nil)
 	return nil
 }
 
@@ -252,12 +252,12 @@ func (s *Storage) RevokeToken(ctx context.Context, tokenOrTokenID string, userID
 	q := storeq.New(s.db)
 
 	if tryRevokeRefreshByHash(ctx, q, tokenOrTokenID, now) {
-		s.AuditLog(ctx, &userID, EventTokenRevoked, "", "", map[string]any{"client_id": clientID})
+		s.AuditLog(ctx, &userID, EventAuthTokenRevoked, "", "", map[string]any{"client_id": clientID})
 		return nil
 	}
 
 	if tryRevokeRefreshByIDReturning(ctx, q, tokenOrTokenID, now) {
-		s.AuditLog(ctx, &userID, EventTokenRevoked, "", "", map[string]any{"client_id": clientID})
+		s.AuditLog(ctx, &userID, EventAuthTokenRevoked, "", "", map[string]any{"client_id": clientID})
 	}
 
 	// RFC 7009: always return 200 regardless of whether anything was revoked


### PR DESCRIPTION
## Summary

audit_log metadata를 풍부하게 만들어 콘솔에서 세션 이력, 서비스 연결 이벤트를 보여줄 수 있도록 합니다.

## Changes

### 기존 이벤트 메타데이터 강화
- `auth.login` (browser/device/mcp): `session_id`, `client_id` 추가 → sessions ↔ audit_log JOIN 가능
- `auth.signup`: `{"channel": "browser"}` 추가
- `auth.login` on signup: `signup: true` 플래그 포함

### 새 이벤트
| event | 시점 |
|-------|------|
| `auth.logout` | 세션 종료 시 |
| `auth.token_revoked` | `/oauth/revoke` 호출 시 |
| `auth.connection_revoked` | 콘솔에서 서비스 접근 해제 시 |

### 중복 제거
- `session.revoked` + `auth.logout` 중복 → `auth.logout`만 유지
- `token.revoked` + `auth.token_revoked` 중복 → `auth.token_revoked`만 유지

## Review notes
- Codex 구현, Claude 리뷰/버그수정
- JWT client_id: `client_id` claim → `aud` claim (표준 OIDC)
- auth.login은 signup 시에도 기록 (`signup: true` flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)