### PR TITLE
feat(server): signal readiness=false on SIGTERM for zero-downtime rolling updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@
 *.dll
 *.so
 *.dylib
-authgate
-app
+/authgate
+/app
 .playwright-mcp/
 /examples/cli/cli
 /examples/webapp/webapp

--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -83,9 +83,10 @@ func main() {
 	// Load client config and derive CORS allowed origins.
 	allowedOrigins := loadClientConfigIfPresent(cfg, store)
 
+	var isShuttingDown atomic.Bool
 	mux := http.NewServeMux()
 	httpMetrics := observability.NewHTTPMetrics()
-	registerRoutes(mux, cfg, db, store, provider, loginHandler, deviceHandler, accountHandler, mcpLoginHandler, consoleHandler, httpMetrics)
+	registerRoutes(mux, cfg, db, store, provider, loginHandler, deviceHandler, accountHandler, mcpLoginHandler, consoleHandler, httpMetrics, &isShuttingDown)
 
 	// Wrap the mux with CORS middleware so all endpoints benefit.
 	corsHandler := middleware.NewCORSMiddleware(allowedOrigins)(mux)
@@ -97,7 +98,7 @@ func main() {
 
 	cleanupCancel := startCleanupService(db, clk)
 	defer cleanupCancel()
-	installGracefulShutdown(srv, cfg, &inflightRequests, cleanupCancel)
+	installGracefulShutdown(srv, cfg, &inflightRequests, cleanupCancel, &isShuttingDown)
 
 	slog.Info("authgate starting", "addr", addr, "dev", cfg.DevMode, "mcp", cfg.EnableMCP, "issuer", cfg.OIDCIssuerURL, "provider", browserProvider.Name())
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -273,11 +274,12 @@ func registerRoutes(
 	mcpLoginHandler *handler.MCPLoginHandler,
 	consoleHandler *handler.ConsoleHandler,
 	httpMetrics *observability.HTTPMetrics,
+	isShuttingDown *atomic.Bool,
 ) {
 	registerOAuthMetadataRoute(mux, cfg)
 	registerProviderRoutes(mux, cfg, store, provider)
 	registerAuthgateRoutes(mux, cfg, loginHandler, deviceHandler, accountHandler, mcpLoginHandler, consoleHandler)
-	registerHealthRoutes(mux, db, httpMetrics)
+	registerHealthRoutes(mux, db, isShuttingDown, httpMetrics)
 }
 
 func registerOAuthMetadataRoute(mux *http.ServeMux, cfg *config.Config) {
@@ -367,7 +369,7 @@ func registerAuthgateRoutes(
 	mux.HandleFunc("/console/me/audit-log", consoleHandler.HandleGetAuditLog)
 }
 
-func registerHealthRoutes(mux *http.ServeMux, db *sql.DB, httpMetrics *observability.HTTPMetrics) {
+func registerHealthRoutes(mux *http.ServeMux, db *sql.DB, isShuttingDown *atomic.Bool, httpMetrics *observability.HTTPMetrics) {
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -375,6 +377,11 @@ func registerHealthRoutes(mux *http.ServeMux, db *sql.DB, httpMetrics *observabi
 	})
 	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if isShuttingDown.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"status":"shutting down"}`))
+			return
+		}
 		if err := db.PingContext(r.Context()); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte(`{"status":"not ready"}`))
@@ -413,11 +420,12 @@ func startCleanupService(db *sql.DB, clk clock.Clock) context.CancelFunc {
 	return cleanupCancel
 }
 
-func installGracefulShutdown(srv *http.Server, cfg *config.Config, inflightRequests *int64, cleanupCancel context.CancelFunc) {
+func installGracefulShutdown(srv *http.Server, cfg *config.Config, inflightRequests *int64, cleanupCancel context.CancelFunc, isShuttingDown *atomic.Bool) {
 	go func() {
 		sigCh := make(chan os.Signal, 2)
 		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 		<-sigCh
+		isShuttingDown.Store(true)
 		slog.Info("shutdown signal received", "inflight_requests", atomic.LoadInt64(inflightRequests))
 
 		go func() {


### PR DESCRIPTION
## Summary

SIGTERM 수신 시 즉시 `/ready` → 503을 반환해서 Kubernetes가 빠르게 엔드포인트에서 파드를 제거하도록 합니다.

## Why

Rolling update 시 두 가지 경로가 동시에 진행됩니다:
1. kubelet → 파드에 SIGTERM 전송
2. controller → iptables/Istio 라우팅 업데이트

이 둘 사이의 1-5초 레이스 윈도우 동안 terminating 파드로 새 요청이 유입될 수 있습니다.

## 변경 내용

- `cmd/authgate/main.go`: `isShuttingDown atomic.Bool` 추가
- SIGTERM 수신 → `isShuttingDown.Store(true)` → `/ready` 즉시 503 반환
- Kubernetes readinessProbe (5s 주기)가 503 감지 → 엔드포인트에서 파드 제거
- 그 후 `srv.Shutdown()`으로 in-flight 요청 완료 대기
- `.gitignore`: `authgate` → `/authgate` (루트 앵커) 수정

## 배포 시 추가 설정 (K8s values)

이 PR 이후 multi-cluster-gitops values에 추가 권장:
- `startupProbe`: 마이그레이션 시간 보장
- `preStop: sleep 5`: Istio 라우팅 갱신 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)