### PR TITLE
test(service): add characterization tests for orphan session and double-complete

### DIFF
--- a/internal/service/orphan_session_test.go
+++ b/internal/service/orphan_session_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package service
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/kangheeyong/authgate/internal/clock"
+	"github.com/kangheeyong/authgate/internal/idgen"
+	"github.com/kangheeyong/authgate/internal/storage"
+	"github.com/kangheeyong/authgate/internal/testutil"
+	"github.com/kangheeyong/authgate/internal/upstream"
+)
+
+type expireAfterCreateSessionStore struct {
+	*storage.Storage
+	clk *clock.FixedClock
+}
+
+var _ LoginStore = (*expireAfterCreateSessionStore)(nil)
+
+func (s *expireAfterCreateSessionStore) CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error) {
+	sessionID, err := s.Storage.CreateSession(ctx, userID, ttl)
+	if err != nil {
+		return "", err
+	}
+	s.clk.T = s.clk.T.Add(11 * time.Minute)
+	return sessionID, nil
+}
+
+func setupOrphanSessionTest(t *testing.T, providerUserID, email string) (*storage.Storage, *expireAfterCreateSessionStore, *upstream.FakeProvider) {
+	t.Helper()
+
+	db := testutil.SetupPostgres(t)
+	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
+	noopChecker := func(user *storage.User) error { return nil }
+	store := storage.New(db, clk, idgen.CryptoGenerator{}, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	expiringStore := &expireAfterCreateSessionStore{Storage: store, clk: clk}
+	provider := &upstream.FakeProvider{
+		ProviderName: "google",
+		User: &upstream.UserInfo{
+			Sub:           providerUserID,
+			Email:         email,
+			EmailVerified: true,
+			Name:          "Orphan Session User",
+			Picture:       "https://example.com/photo.jpg",
+		},
+	}
+
+	return store, expiringStore, provider
+}
+
+func activeSessionCount(t *testing.T, db *sql.DB, userID string) int {
+	t.Helper()
+
+	var count int
+	if err := db.QueryRowContext(context.Background(), `SELECT count(*) FROM sessions WHERE user_id = $1 AND revoked_at IS NULL`, userID).Scan(&count); err != nil {
+		t.Fatalf("count active sessions: %v", err)
+	}
+	return count
+}
+
+func TestLoginCallback_CompleteExpiresAfterCreateSession_LeavesOrphanSession(t *testing.T) {
+	store, expiringStore, provider := setupOrphanSessionTest(t, "orphan-browser-sub", "orphan-browser@test.com")
+	svc := NewLoginService(expiringStore, provider, 24*time.Hour)
+	ctx := context.Background()
+
+	authRequestID, err := store.CreateTestAuthRequest(ctx, "orphan-browser")
+	if err != nil {
+		t.Fatalf("create auth request: %v", err)
+	}
+
+	result := svc.HandleCallback(ctx, "fake-code", authRequestID, "127.0.0.1", "test-agent")
+
+	if result.Action != ActionError {
+		t.Fatalf("action = %v, want ActionError", result.Action)
+	}
+	if result.SessionID != "" {
+		t.Fatalf("sessionID = %q, want empty", result.SessionID)
+	}
+
+	user, err := store.GetUserByProviderIdentity(ctx, "google", "orphan-browser-sub")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if got := activeSessionCount(t, store.DB(), user.ID); got != 1 {
+		// Characterization: after the fix, this should become 0.
+		t.Fatalf("active sessions = %d, want 1", got)
+	}
+}
+
+func TestMCPCallback_CompleteExpiresAfterCreateSession_LeavesOrphanSession(t *testing.T) {
+	store, expiringStore, provider := setupOrphanSessionTest(t, "orphan-mcp-sub", "orphan-mcp@test.com")
+	svc := NewMCPLoginService(expiringStore, provider, 24*time.Hour)
+	ctx := context.Background()
+
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
+		Email:          "orphan-mcp@test.com",
+		EmailVerified:  true,
+		Name:           "Orphan MCP User",
+		AvatarURL:      "",
+		Provider:       "google",
+		ProviderUserID: "orphan-mcp-sub",
+		ProviderEmail:  "orphan-mcp@test.com",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	authRequestID, err := store.CreateTestAuthRequestWithResource(ctx, "orphan-mcp", "http://localhost/mcp")
+	if err != nil {
+		t.Fatalf("create auth request: %v", err)
+	}
+
+	result := svc.HandleCallback(ctx, "fake-code", authRequestID, "127.0.0.1", "mcp-client")
+
+	if result.Action != ActionError {
+		t.Fatalf("action = %v, want ActionError", result.Action)
+	}
+	if result.SessionID != "" {
+		t.Fatalf("sessionID = %q, want empty", result.SessionID)
+	}
+	if got := activeSessionCount(t, store.DB(), user.ID); got != 1 {
+		// Characterization: after the fix, this should become 0.
+		t.Fatalf("active sessions = %d, want 1", got)
+	}
+}
+
+func TestLoginCallback_DoubleCallback_CreatesMultipleActiveSessions(t *testing.T) {
+	svc, store := setupLoginService(t)
+	ctx := context.Background()
+
+	authRequestID, err := store.CreateTestAuthRequest(ctx, "double-callback")
+	if err != nil {
+		t.Fatalf("create auth request: %v", err)
+	}
+
+	first := svc.HandleCallback(ctx, "fake-code", authRequestID, "127.0.0.1", "test-agent")
+	if first.Action != ActionAutoApprove {
+		t.Fatalf("first action = %v, want ActionAutoApprove", first.Action)
+	}
+	second := svc.HandleCallback(ctx, "fake-code", authRequestID, "127.0.0.1", "test-agent")
+	if second.Action != ActionAutoApprove {
+		t.Fatalf("second action = %v, want ActionAutoApprove", second.Action)
+	}
+
+	user, err := store.GetUserByProviderIdentity(ctx, "google", "google-sub-123")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if got := activeSessionCount(t, store.DB(), user.ID); got != 2 {
+		// Characterization: adding done=false to completion should make this 1.
+		t.Fatalf("active sessions = %d, want 2", got)
+	}
+}


### PR DESCRIPTION
## Summary

Lock the current behavior of the login callback flow with three integration tests as a safety net before the follow-up fix.

- `TestLoginCallback_CompleteExpiresAfterCreateSession_LeavesOrphanSession` — a `sessions` row remains after `CompleteAuthRequest` fails on the expiration check.
- `TestMCPCallback_CompleteExpiresAfterCreateSession_LeavesOrphanSession` — same pattern on the MCP channel.
- `TestLoginCallback_DoubleCallback_CreatesMultipleActiveSessions` — a second callback with the same `authRequestID` succeeds again and creates an extra active session, because `CompleteAuthRequestByID` has no `done = false` predicate.

This is Phase 1 of a two-phase change. Phase 2 will wrap `CreateSession` + `CompleteAuthRequest` in a single transaction and add `done = false` to the completion query. After that fix, the assertions will flip:

- `want 1 orphan` → `want 0`
- `want 2 sessions` → `want 1`

## How the tests trigger the race

An `expireAfterCreateSessionStore` wrapper delegates to the real `storage.Storage` but advances the shared `FixedClock` by 11 minutes right after `CreateSession` returns, so `GetAuthRequestModel` passes up front but `CompleteAuthRequest` trips the `expires_at > auth_time` condition and returns 0 rows. The session insert has already committed.

No production code is touched.

## Test plan

- [x] `go build -tags=integration ./...`
- [x] `go test -tags=integration -run 'TestLoginCallback_CompleteExpiresAfterCreateSession|TestMCPCallback_CompleteExpiresAfterCreateSession|TestLoginCallback_DoubleCallback' ./internal/service/` — 3/3 PASS, ~4.3s
- [x] `go test ./internal/config ./internal/clock ./internal/idgen` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)