### PR TITLE
fix(storage): stop false-positive audit on revoke by unknown token id

### DIFF
--- a/docs/spec/005-token-lifecycle.md
+++ b/docs/spec/005-token-lifecycle.md
@@ -213,6 +213,7 @@ sequenceDiagram
 
 **RFC 7009 준수**: 토큰이 존재하지 않거나 이미 폐기된 경우에도 200 OK 반환.
 토큰 존재 여부를 외부에 노출하지 않는다.
+단, `auth.token_revoked` audit log는 실제 refresh token row가 폐기된 경우에만 기록한다.
 
 ## 토큰 저장 보안
 

--- a/internal/db/queries/refresh_tokens.sql
+++ b/internal/db/queries/refresh_tokens.sql
@@ -29,7 +29,7 @@ UPDATE refresh_tokens
 SET used_at = $1, revoked_at = $1
 WHERE id = $2;
 
--- name: RevokeRefreshTokenByID :exec
+-- name: RevokeRefreshTokenByID :execrows
 UPDATE refresh_tokens
 SET revoked_at = $1
 WHERE id = $2 AND revoked_at IS NULL;

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -59,7 +59,7 @@ type Querier interface {
 	RevokeOtherActiveSessionsByUserID(ctx context.Context, arg RevokeOtherActiveSessionsByUserIDParams) error
 	RevokeRefreshFamily(ctx context.Context, arg RevokeRefreshFamilyParams) error
 	RevokeRefreshTokenByHash(ctx context.Context, arg RevokeRefreshTokenByHashParams) (int64, error)
-	RevokeRefreshTokenByID(ctx context.Context, arg RevokeRefreshTokenByIDParams) error
+	RevokeRefreshTokenByID(ctx context.Context, arg RevokeRefreshTokenByIDParams) (int64, error)
 	RevokeSessionByUserIDAndID(ctx context.Context, arg RevokeSessionByUserIDAndIDParams) error
 	RevokeSessionsByUserID(ctx context.Context, arg RevokeSessionsByUserIDParams) error
 	SetUserStatusByID(ctx context.Context, arg SetUserStatusByIDParams) error

--- a/internal/db/storeq/refresh_tokens.sql.go
+++ b/internal/db/storeq/refresh_tokens.sql.go
@@ -171,7 +171,7 @@ func (q *Queries) RevokeRefreshTokenByHash(ctx context.Context, arg RevokeRefres
 	return result.RowsAffected()
 }
 
-const revokeRefreshTokenByID = `-- name: RevokeRefreshTokenByID :exec
+const revokeRefreshTokenByID = `-- name: RevokeRefreshTokenByID :execrows
 UPDATE refresh_tokens
 SET revoked_at = $1
 WHERE id = $2 AND revoked_at IS NULL
@@ -182,7 +182,10 @@ type RevokeRefreshTokenByIDParams struct {
 	ID        string
 }
 
-func (q *Queries) RevokeRefreshTokenByID(ctx context.Context, arg RevokeRefreshTokenByIDParams) error {
-	_, err := q.db.ExecContext(ctx, revokeRefreshTokenByID, arg.RevokedAt, arg.ID)
-	return err
+func (q *Queries) RevokeRefreshTokenByID(ctx context.Context, arg RevokeRefreshTokenByIDParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, revokeRefreshTokenByID, arg.RevokedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }

--- a/internal/storage/revoke_false_positive_test.go
+++ b/internal/storage/revoke_false_positive_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRevokeToken_UnknownUUID_NoAudit(t *testing.T) {
+	s := testStorage(t)
+	ctx := context.Background()
+
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+		Email:          "revoke-unknown@test.com",
+		EmailVerified:  true,
+		Name:           "Revoke Unknown",
+		Provider:       "google",
+		ProviderUserID: "revoke-unknown-sub",
+		ProviderEmail:  "revoke-unknown@test.com",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	errOIDC := s.RevokeToken(ctx, "00000000-0000-0000-0000-000000000001", user.ID, "test-client")
+	if errOIDC != nil {
+		t.Fatalf("revoke token: %v", errOIDC)
+	}
+
+	if got := countTokenRevokedAudit(t, s, user.ID); got != 0 {
+		t.Fatalf("auth.token_revoked audit count = %d, want 0", got)
+	}
+}
+
+func TestRevokeToken_ValidRefreshTokenID_Audits(t *testing.T) {
+	s := testStorage(t)
+	ctx := context.Background()
+
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+		Email:          "revoke-valid@test.com",
+		EmailVerified:  true,
+		Name:           "Revoke Valid",
+		Provider:       "google",
+		ProviderUserID: "revoke-valid-sub",
+		ProviderEmail:  "revoke-valid@test.com",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	now := s.clock.Now()
+	refreshTokenID := s.idgen.NewUUID()
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO refresh_tokens (id, token_hash, family_id, user_id, client_id, scopes, expires_at, created_at)
+		 VALUES ($1, $2, uuid_generate_v4(), $3, 'test-client', '{openid}', $4, $5)`,
+		refreshTokenID, hashToken("revoke-valid-refresh-token"), user.ID, now.Add(30*24*time.Hour), now,
+	)
+	if err != nil {
+		t.Fatalf("insert refresh token: %v", err)
+	}
+
+	errOIDC := s.RevokeToken(ctx, refreshTokenID, user.ID, "test-client")
+	if errOIDC != nil {
+		t.Fatalf("revoke token: %v", errOIDC)
+	}
+
+	if got := countTokenRevokedAudit(t, s, user.ID); got != 1 {
+		t.Fatalf("auth.token_revoked audit count = %d, want 1", got)
+	}
+
+	var revoked bool
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT revoked_at IS NOT NULL FROM refresh_tokens WHERE id = $1`,
+		refreshTokenID,
+	).Scan(&revoked); err != nil {
+		t.Fatalf("query revoked_at: %v", err)
+	}
+	if !revoked {
+		t.Fatal("refresh token revoked_at is NULL, want non-NULL")
+	}
+}
+
+func countTokenRevokedAudit(t *testing.T, s *Storage, userID string) int {
+	t.Helper()
+
+	var count int
+	if err := s.db.QueryRowContext(context.Background(),
+		`SELECT count(*) FROM audit_log WHERE user_id = $1 AND event_type = 'auth.token_revoked'`,
+		userID,
+	).Scan(&count); err != nil {
+		t.Fatalf("query audit_log: %v", err)
+	}
+	return count
+}

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -450,25 +450,19 @@ func tryRevokeRefreshByHash(ctx context.Context, q *storeq.Queries, tokenOrToken
 	return rows > 0
 }
 
-func tryRevokeRefreshByID(ctx context.Context, q *storeq.Queries, tokenOrTokenID string, now time.Time) {
-	if _, err := uuid.Parse(tokenOrTokenID); err == nil {
-		_ = q.RevokeRefreshTokenByID(ctx, storeq.RevokeRefreshTokenByIDParams{
-			RevokedAt: sql.NullTime{Time: now, Valid: true},
-			ID:        tokenOrTokenID,
-		})
-	}
-}
-
 // tryRevokeRefreshByIDReturning attempts to revoke a refresh token by UUID ID and returns true if a row was affected.
 func tryRevokeRefreshByIDReturning(ctx context.Context, q *storeq.Queries, tokenOrTokenID string, now time.Time) bool {
 	if _, err := uuid.Parse(tokenOrTokenID); err != nil {
 		return false
 	}
-	err := q.RevokeRefreshTokenByID(ctx, storeq.RevokeRefreshTokenByIDParams{
+	rows, err := q.RevokeRefreshTokenByID(ctx, storeq.RevokeRefreshTokenByIDParams{
 		RevokedAt: sql.NullTime{Time: now, Valid: true},
 		ID:        tokenOrTokenID,
 	})
-	return err == nil
+	if err != nil {
+		return false
+	}
+	return rows > 0
 }
 
 // GetAuthRequestModel fetches the auth request by ID and returns the concrete model.


### PR DESCRIPTION
## Summary

`tryRevokeRefreshByIDReturning` returned `err == nil` as a success signal, but the SQL was declared `:exec` which discards rows-affected. An unknown UUID therefore looked like a successful revoke and emitted an `auth.token_revoked` audit entry that did not correspond to any actual revocation.

- Mark `RevokeRefreshTokenByID` as `:execrows`, regenerate the sqlc client, and gate success on `rows > 0`.
- Remove the dead `tryRevokeRefreshByID` helper (no callers).
- Add `internal/storage/revoke_false_positive_test.go` with two integration tests covering both the unknown-UUID and the real-token paths.

The RFC 7009 contract (`/oauth/revoke` always returns 200 regardless of whether a token existed) is preserved — only the audit log is affected.

## Doc sync

`docs/spec/005-token-lifecycle.md`: adds one line clarifying that `auth.token_revoked` is only emitted on an actual revoke, so RFC 7009's "always 200" response contract does not leak existence information through the audit log.

## Test plan

- [x] `go build ./...`
- [x] `go test -tags=integration -run 'TestRevokeToken_UnknownUUID_NoAudit|TestRevokeToken_ValidRefreshTokenID_Audits' ./internal/storage/` — 2/2 PASS
- [x] `go test -tags=integration ./internal/storage/` — PASS (noted pre-existing testcontainer flakiness on `TestGetUserByProviderIdentity_NotFound` unrelated to this change)
- [x] `go test ./internal/service/ ./internal/handler/` — PASS (no call-site changes)

## Scope

Closes `finding-7` from the code-ambiguity review round. No other findings touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)