### PR TITLE
fix(console): return 404 and skip audit when revoke targets nothing

### DIFF
--- a/internal/db/queries/console.sql
+++ b/internal/db/queries/console.sql
@@ -24,7 +24,7 @@ FROM active_tokens
 LEFT JOIN last_used_tokens ON last_used_tokens.client_id = active_tokens.client_id
 ORDER BY active_tokens.client_id;
 
--- name: RevokeActiveRefreshTokensByUserIDAndClientID :exec
+-- name: RevokeActiveRefreshTokensByUserIDAndClientID :execrows
 UPDATE refresh_tokens
 SET revoked_at = $1
 WHERE user_id = $2
@@ -54,7 +54,7 @@ WHERE s.user_id = $1
   AND s.revoked_at IS NULL
 ORDER BY s.created_at DESC;
 
--- name: RevokeSessionByUserIDAndID :exec
+-- name: RevokeSessionByUserIDAndID :execrows
 UPDATE sessions
 SET revoked_at = $1
 WHERE user_id = $2

--- a/internal/db/storeq/console.sql.go
+++ b/internal/db/storeq/console.sql.go
@@ -69,7 +69,7 @@ func (q *Queries) GetActiveConnectionsByUserID(ctx context.Context, arg GetActiv
 	return items, rows.Err()
 }
 
-const revokeActiveRefreshTokensByUserIDAndClientID = `-- name: RevokeActiveRefreshTokensByUserIDAndClientID :exec
+const revokeActiveRefreshTokensByUserIDAndClientID = `-- name: RevokeActiveRefreshTokensByUserIDAndClientID :execrows
 UPDATE refresh_tokens
 SET revoked_at = $1
 WHERE user_id = $2
@@ -83,9 +83,12 @@ type RevokeActiveRefreshTokensByUserIDAndClientIDParams struct {
 	ClientID  string
 }
 
-func (q *Queries) RevokeActiveRefreshTokensByUserIDAndClientID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDAndClientIDParams) error {
-	_, err := q.db.ExecContext(ctx, revokeActiveRefreshTokensByUserIDAndClientID, arg.RevokedAt, arg.UserID, arg.ClientID)
-	return err
+func (q *Queries) RevokeActiveRefreshTokensByUserIDAndClientID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDAndClientIDParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, revokeActiveRefreshTokensByUserIDAndClientID, arg.RevokedAt, arg.UserID, arg.ClientID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const getActiveSessionsByUserID = `-- name: GetActiveSessionsByUserID :many
@@ -148,7 +151,7 @@ func (q *Queries) GetActiveSessionsByUserID(ctx context.Context, arg GetActiveSe
 	return items, rows.Err()
 }
 
-const revokeSessionByUserIDAndID = `-- name: RevokeSessionByUserIDAndID :exec
+const revokeSessionByUserIDAndID = `-- name: RevokeSessionByUserIDAndID :execrows
 UPDATE sessions
 SET revoked_at = $1
 WHERE user_id = $2
@@ -162,9 +165,12 @@ type RevokeSessionByUserIDAndIDParams struct {
 	ID        string
 }
 
-func (q *Queries) RevokeSessionByUserIDAndID(ctx context.Context, arg RevokeSessionByUserIDAndIDParams) error {
-	_, err := q.db.ExecContext(ctx, revokeSessionByUserIDAndID, arg.RevokedAt, arg.UserID, arg.ID)
-	return err
+func (q *Queries) RevokeSessionByUserIDAndID(ctx context.Context, arg RevokeSessionByUserIDAndIDParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, revokeSessionByUserIDAndID, arg.RevokedAt, arg.UserID, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const revokeOtherActiveSessionsByUserID = `-- name: RevokeOtherActiveSessionsByUserID :exec

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -55,12 +55,12 @@ type Querier interface {
 	MarkUserPendingDeletionByID(ctx context.Context, arg MarkUserPendingDeletionByIDParams) error
 	RecoverPendingDeletionUserByID(ctx context.Context, arg RecoverPendingDeletionUserByIDParams) error
 	RevokeActiveRefreshTokensByUserID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDParams) error
-	RevokeActiveRefreshTokensByUserIDAndClientID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDAndClientIDParams) error
+	RevokeActiveRefreshTokensByUserIDAndClientID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDAndClientIDParams) (int64, error)
 	RevokeOtherActiveSessionsByUserID(ctx context.Context, arg RevokeOtherActiveSessionsByUserIDParams) error
 	RevokeRefreshFamily(ctx context.Context, arg RevokeRefreshFamilyParams) error
 	RevokeRefreshTokenByHash(ctx context.Context, arg RevokeRefreshTokenByHashParams) (int64, error)
 	RevokeRefreshTokenByID(ctx context.Context, arg RevokeRefreshTokenByIDParams) error
-	RevokeSessionByUserIDAndID(ctx context.Context, arg RevokeSessionByUserIDAndIDParams) error
+	RevokeSessionByUserIDAndID(ctx context.Context, arg RevokeSessionByUserIDAndIDParams) (int64, error)
 	RevokeSessionsByUserID(ctx context.Context, arg RevokeSessionsByUserIDParams) error
 	SetUserStatusByID(ctx context.Context, arg SetUserStatusByIDParams) error
 	UpdateAuthRequestCode(ctx context.Context, arg UpdateAuthRequestCodeParams) error

--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -19,9 +19,9 @@ type ConsoleStore interface {
 	ValidateBearerTokenWithClientID(ctx context.Context, authHeader string) (*storage.User, string, error)
 	ListAllClients() []storage.ClientView
 	GetActiveConnections(ctx context.Context, userID string) ([]storage.ConnectionTokenInfo, error)
-	RevokeConnection(ctx context.Context, userID, clientID string) error
+	RevokeConnection(ctx context.Context, userID, clientID string) (int64, error)
 	GetActiveSessions(ctx context.Context, userID string) ([]storage.SessionInfo, error)
-	RevokeSession(ctx context.Context, userID, sessionID string) error
+	RevokeSession(ctx context.Context, userID, sessionID string) (int64, error)
 	RevokeOtherSessions(ctx context.Context, userID, currentSessionID string) error
 	GetAuditLog(ctx context.Context, userID string, limit, offset int) (*storage.AuditLogPage, error)
 	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
@@ -227,8 +227,12 @@ func (s *ConsoleService) RevokeConnection(ctx context.Context, sessionID, authHe
 	if auth.clientID != "" && auth.clientID == clientID {
 		return &RevokeConnectionResult{ErrorCode: http.StatusBadRequest}
 	}
-	if err := s.store.RevokeConnection(ctx, auth.user.ID, clientID); err != nil {
+	rows, err := s.store.RevokeConnection(ctx, auth.user.ID, clientID)
+	if err != nil {
 		return &RevokeConnectionResult{ErrorCode: http.StatusInternalServerError}
+	}
+	if rows == 0 {
+		return &RevokeConnectionResult{ErrorCode: http.StatusNotFound}
 	}
 	s.store.AuditLog(ctx, &auth.user.ID, "auth.connection_revoked", "", "", map[string]any{"client_id": clientID})
 	return &RevokeConnectionResult{}
@@ -245,8 +249,12 @@ func (s *ConsoleService) RevokeSession(ctx context.Context, sessionID, authHeade
 	if revokeSessionID == "" {
 		return &RevokeSessionResult{ErrorCode: http.StatusBadRequest}
 	}
-	if err := s.store.RevokeSession(ctx, auth.user.ID, revokeSessionID); err != nil {
+	rows, err := s.store.RevokeSession(ctx, auth.user.ID, revokeSessionID)
+	if err != nil {
 		return &RevokeSessionResult{ErrorCode: http.StatusInternalServerError}
+	}
+	if rows == 0 {
+		return &RevokeSessionResult{ErrorCode: http.StatusNotFound}
 	}
 	s.store.AuditLog(ctx, &auth.user.ID, "auth.session_revoked", "", "", map[string]any{"session_id": revokeSessionID})
 	return &RevokeSessionResult{}

--- a/internal/service/console_unit_test.go
+++ b/internal/service/console_unit_test.go
@@ -17,9 +17,9 @@ type fakeConsoleStore struct {
 	validateBearerWithClientFn func(ctx context.Context, authHeader string) (*storage.User, string, error)
 	listAllClientsFn           func() []storage.ClientView
 	getActiveConnFn            func(ctx context.Context, userID string) ([]storage.ConnectionTokenInfo, error)
-	revokeConnectionFn         func(ctx context.Context, userID, clientID string) error
+	revokeConnectionFn         func(ctx context.Context, userID, clientID string) (int64, error)
 	getActiveSessionsFn        func(ctx context.Context, userID string) ([]storage.SessionInfo, error)
-	revokeSessionFn            func(ctx context.Context, userID, sessionID string) error
+	revokeSessionFn            func(ctx context.Context, userID, sessionID string) (int64, error)
 	revokeOtherSessionsFn      func(ctx context.Context, userID, currentSessionID string) error
 	getAuditLogFn              func(ctx context.Context, userID string, limit, offset int) (*storage.AuditLogPage, error)
 	auditLogFn                 func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
@@ -47,13 +47,13 @@ func (f *fakeConsoleStore) ListAllClients() []storage.ClientView {
 func (f *fakeConsoleStore) GetActiveConnections(ctx context.Context, userID string) ([]storage.ConnectionTokenInfo, error) {
 	return f.getActiveConnFn(ctx, userID)
 }
-func (f *fakeConsoleStore) RevokeConnection(ctx context.Context, userID, clientID string) error {
+func (f *fakeConsoleStore) RevokeConnection(ctx context.Context, userID, clientID string) (int64, error) {
 	return f.revokeConnectionFn(ctx, userID, clientID)
 }
 func (f *fakeConsoleStore) GetActiveSessions(ctx context.Context, userID string) ([]storage.SessionInfo, error) {
 	return f.getActiveSessionsFn(ctx, userID)
 }
-func (f *fakeConsoleStore) RevokeSession(ctx context.Context, userID, sessionID string) error {
+func (f *fakeConsoleStore) RevokeSession(ctx context.Context, userID, sessionID string) (int64, error) {
 	return f.revokeSessionFn(ctx, userID, sessionID)
 }
 func (f *fakeConsoleStore) RevokeOtherSessions(ctx context.Context, userID, currentSessionID string) error {
@@ -80,11 +80,11 @@ func activeUserStore(clients []storage.ClientView, connIDs []string) *fakeConsol
 		},
 		listAllClientsFn:   func() []storage.ClientView { return clients },
 		getActiveConnFn:    func(context.Context, string) ([]storage.ConnectionTokenInfo, error) { return connections, nil },
-		revokeConnectionFn: func(context.Context, string, string) error { return nil },
+		revokeConnectionFn: func(context.Context, string, string) (int64, error) { return 1, nil },
 		getActiveSessionsFn: func(context.Context, string) ([]storage.SessionInfo, error) {
 			return nil, nil
 		},
-		revokeSessionFn:       func(context.Context, string, string) error { return nil },
+		revokeSessionFn:       func(context.Context, string, string) (int64, error) { return 1, nil },
 		revokeOtherSessionsFn: func(context.Context, string, string) error { return nil },
 		getAuditLogFn: func(context.Context, string, int, int) (*storage.AuditLogPage, error) {
 			return &storage.AuditLogPage{}, nil
@@ -109,7 +109,7 @@ func TestConsole_ListClients_InvalidSession_Unauthorized(t *testing.T) {
 		},
 		listAllClientsFn:   func() []storage.ClientView { return nil },
 		getActiveConnFn:    func(context.Context, string) ([]storage.ConnectionTokenInfo, error) { return nil, nil },
-		revokeConnectionFn: func(context.Context, string, string) error { return nil },
+		revokeConnectionFn: func(context.Context, string, string) (int64, error) { return 1, nil },
 	}
 	svc := NewConsoleService(store)
 	r := svc.ListClients(context.Background(), "sess-x", "")
@@ -125,7 +125,7 @@ func TestConsole_ListClients_DisabledUser_Forbidden(t *testing.T) {
 		},
 		listAllClientsFn:   func() []storage.ClientView { return nil },
 		getActiveConnFn:    func(context.Context, string) ([]storage.ConnectionTokenInfo, error) { return nil, nil },
-		revokeConnectionFn: func(context.Context, string, string) error { return nil },
+		revokeConnectionFn: func(context.Context, string, string) (int64, error) { return 1, nil },
 	}
 	svc := NewConsoleService(store)
 	r := svc.ListClients(context.Background(), "sess-1", "")
@@ -141,7 +141,7 @@ func TestConsole_ListClients_PendingDeletion_Forbidden(t *testing.T) {
 		},
 		listAllClientsFn:   func() []storage.ClientView { return nil },
 		getActiveConnFn:    func(context.Context, string) ([]storage.ConnectionTokenInfo, error) { return nil, nil },
-		revokeConnectionFn: func(context.Context, string, string) error { return nil },
+		revokeConnectionFn: func(context.Context, string, string) (int64, error) { return 1, nil },
 	}
 	svc := NewConsoleService(store)
 	r := svc.ListClients(context.Background(), "sess-1", "")
@@ -226,7 +226,7 @@ func TestConsole_ListConnections_DBError_InternalServerError(t *testing.T) {
 		getActiveConnFn: func(context.Context, string) ([]storage.ConnectionTokenInfo, error) {
 			return nil, errors.New("db error")
 		},
-		revokeConnectionFn: func(context.Context, string, string) error { return nil },
+		revokeConnectionFn: func(context.Context, string, string) (int64, error) { return 1, nil },
 	}
 	svc := NewConsoleService(store)
 	r := svc.ListConnections(context.Background(), "sess-1", "")
@@ -296,11 +296,11 @@ func bearerStore(user *storage.User, bearerErr error) *fakeConsoleStore {
 		},
 		listAllClientsFn:   func() []storage.ClientView { return nil },
 		getActiveConnFn:    func(context.Context, string) ([]storage.ConnectionTokenInfo, error) { return nil, nil },
-		revokeConnectionFn: func(context.Context, string, string) error { return nil },
+		revokeConnectionFn: func(context.Context, string, string) (int64, error) { return 1, nil },
 		getActiveSessionsFn: func(context.Context, string) ([]storage.SessionInfo, error) {
 			return nil, nil
 		},
-		revokeSessionFn:       func(context.Context, string, string) error { return nil },
+		revokeSessionFn:       func(context.Context, string, string) (int64, error) { return 1, nil },
 		revokeOtherSessionsFn: func(context.Context, string, string) error { return nil },
 		getAuditLogFn: func(context.Context, string, int, int) (*storage.AuditLogPage, error) {
 			return &storage.AuditLogPage{}, nil
@@ -362,7 +362,7 @@ func TestConsole_ListClients_SessionWinsOverBearer(t *testing.T) {
 		},
 		listAllClientsFn:   func() []storage.ClientView { return nil },
 		getActiveConnFn:    func(context.Context, string) ([]storage.ConnectionTokenInfo, error) { return nil, nil },
-		revokeConnectionFn: func(context.Context, string, string) error { return nil },
+		revokeConnectionFn: func(context.Context, string, string) (int64, error) { return 1, nil },
 	}
 	svc := NewConsoleService(store)
 	r := svc.ListClients(context.Background(), "sess-1", "Bearer token")
@@ -387,10 +387,10 @@ func TestConsole_RevokeConnection_NoSessionOrBearer_Unauthorized(t *testing.T) {
 func TestConsole_RevokeConnection_ValidAuth_RevokesTokens(t *testing.T) {
 	var gotUserID, gotClientID string
 	store := activeUserStore(nil, nil)
-	store.revokeConnectionFn = func(ctx context.Context, userID, clientID string) error {
+	store.revokeConnectionFn = func(ctx context.Context, userID, clientID string) (int64, error) {
 		gotUserID = userID
 		gotClientID = clientID
-		return nil
+		return 1, nil
 	}
 	svc := NewConsoleService(store)
 	r := svc.RevokeConnection(context.Background(), "sess-1", "", "app-a")
@@ -435,9 +435,9 @@ func TestConsole_RevokeConnection_OwnClient_BadRequest(t *testing.T) {
 		return &storage.User{ID: "u1", Status: "active"}, "app-a", nil
 	}
 	revokeCalled := false
-	store.revokeConnectionFn = func(context.Context, string, string) error {
+	store.revokeConnectionFn = func(context.Context, string, string) (int64, error) {
 		revokeCalled = true
-		return nil
+		return 1, nil
 	}
 	svc := NewConsoleService(store)
 	r := svc.RevokeConnection(context.Background(), "", "Bearer valid-token", "app-a")
@@ -451,13 +451,35 @@ func TestConsole_RevokeConnection_OwnClient_BadRequest(t *testing.T) {
 
 func TestConsole_RevokeConnection_DBError_InternalServerError(t *testing.T) {
 	store := activeUserStore(nil, nil)
-	store.revokeConnectionFn = func(context.Context, string, string) error {
-		return errors.New("db error")
+	store.revokeConnectionFn = func(context.Context, string, string) (int64, error) {
+		return 0, errors.New("db error")
 	}
 	svc := NewConsoleService(store)
 	r := svc.RevokeConnection(context.Background(), "sess-1", "", "app-a")
 	if r.ErrorCode != http.StatusInternalServerError {
 		t.Fatalf("want 500, got %d", r.ErrorCode)
+	}
+}
+
+func TestConsole_RevokeConnection_UnknownClient_NotFound_NoAudit(t *testing.T) {
+	auditCalled := false
+	store := activeUserStore(nil, nil)
+	store.revokeConnectionFn = func(context.Context, string, string) (int64, error) {
+		return 0, nil
+	}
+	store.auditLogFn = func(context.Context, *string, string, string, string, map[string]any) error {
+		auditCalled = true
+		return nil
+	}
+	svc := NewConsoleService(store)
+
+	r := svc.RevokeConnection(context.Background(), "sess-1", "", "unknown-client")
+
+	if r.ErrorCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", r.ErrorCode)
+	}
+	if auditCalled {
+		t.Fatal("audit should not be called")
 	}
 }
 
@@ -508,10 +530,10 @@ func TestConsole_RevokeSession_ValidAuth_RevokesAndAudits(t *testing.T) {
 	var gotUserID, gotSessionID, gotEventType string
 	var gotMetadata map[string]any
 	store := activeUserStore(nil, nil)
-	store.revokeSessionFn = func(ctx context.Context, userID, sessionID string) error {
+	store.revokeSessionFn = func(ctx context.Context, userID, sessionID string) (int64, error) {
 		gotUserID = userID
 		gotSessionID = sessionID
-		return nil
+		return 1, nil
 	}
 	store.auditLogFn = func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
 		gotEventType = eventType
@@ -528,6 +550,28 @@ func TestConsole_RevokeSession_ValidAuth_RevokesAndAudits(t *testing.T) {
 	}
 	if gotEventType != "auth.session_revoked" || gotMetadata["session_id"] != "sess-2" {
 		t.Fatalf("audit event=%q metadata=%#v", gotEventType, gotMetadata)
+	}
+}
+
+func TestConsole_RevokeSession_UnknownSession_NotFound_NoAudit(t *testing.T) {
+	auditCalled := false
+	store := activeUserStore(nil, nil)
+	store.revokeSessionFn = func(context.Context, string, string) (int64, error) {
+		return 0, nil
+	}
+	store.auditLogFn = func(context.Context, *string, string, string, string, map[string]any) error {
+		auditCalled = true
+		return nil
+	}
+	svc := NewConsoleService(store)
+
+	r := svc.RevokeSession(context.Background(), "sess-1", "", "unknown-session")
+
+	if r.ErrorCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", r.ErrorCode)
+	}
+	if auditCalled {
+		t.Fatal("audit should not be called")
 	}
 }
 

--- a/internal/storage/console.go
+++ b/internal/storage/console.go
@@ -100,7 +100,7 @@ func (s *Storage) GetActiveConnections(ctx context.Context, userID string) ([]Co
 	return connections, nil
 }
 
-func (s *Storage) RevokeConnection(ctx context.Context, userID, clientID string) error {
+func (s *Storage) RevokeConnection(ctx context.Context, userID, clientID string) (int64, error) {
 	return storeq.New(s.db).RevokeActiveRefreshTokensByUserIDAndClientID(ctx, storeq.RevokeActiveRefreshTokensByUserIDAndClientIDParams{
 		RevokedAt: sql.NullTime{Time: s.clock.Now(), Valid: true},
 		UserID:    userID,
@@ -133,7 +133,7 @@ func (s *Storage) GetActiveSessions(ctx context.Context, userID string) ([]Sessi
 	return sessions, nil
 }
 
-func (s *Storage) RevokeSession(ctx context.Context, userID, sessionID string) error {
+func (s *Storage) RevokeSession(ctx context.Context, userID, sessionID string) (int64, error) {
 	return storeq.New(s.db).RevokeSessionByUserIDAndID(ctx, storeq.RevokeSessionByUserIDAndIDParams{
 		RevokedAt: sql.NullTime{Time: s.clock.Now(), Valid: true},
 		UserID:    userID,


### PR DESCRIPTION
## Summary

`RevokeConnection` and `RevokeSession` reported success on any SQL execution that returned no error, even when the UPDATE matched zero rows because the `client_id` or `session_id` did not belong to the caller (or did not exist at all). The service therefore replied 204 and wrote an `auth.connection_revoked` / `auth.session_revoked` audit entry that did not correspond to any actual state change.

- Mark `RevokeActiveRefreshTokensByUserIDAndClientID` and `RevokeSessionByUserIDAndID` as `:execrows`.
- Propagate the row count through `Storage.RevokeConnection` and `Storage.RevokeSession`.
- `ConsoleService.RevokeConnection` / `RevokeSession` return 404 Not Found and skip the audit write when row count is zero. Successful revokes are unchanged: 204 + audit.
- `RevokeOtherActiveSessionsByUserID` is left as `:exec` because a zero-row result there is the legitimate "no other sessions" case.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./internal/service/ ./internal/handler/` — PASS
- [x] `go test -run 'TestConsole_RevokeConnection|TestConsole_RevokeSession' ./internal/service/` — 8/8 PASS, including two new tests
  - `TestConsole_RevokeConnection_UnknownClient_NotFound_NoAudit`
  - `TestConsole_RevokeSession_UnknownSession_NotFound_NoAudit`

## Behavior change

| Scenario | Before | After |
|---|---|---|
| `DELETE /console/me/connections/{client_id}` for unknown client | 204 + audit | 404, no audit |
| `DELETE /console/me/sessions/{id}` for unknown session | 204 + audit | 404, no audit |
| Same calls for owned, active target | 204 + audit | 204 + audit (unchanged) |

API consumers that relied on the previous "always 204" behavior will now see 404 for unknown targets. The audit log becomes accurate.

## Scope

Closes `finding-8` from the code-ambiguity review round. No other findings touched. `RevokeOtherSessions` intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)