### PR TITLE
fix(service): distinguish session-not-found from DB error in lookup paths

### DIFF
--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -98,6 +98,27 @@ type consoleAuth struct {
 	sessionID string
 }
 
+type consoleAuthError struct {
+	statusCode int
+	err        error
+}
+
+func (e *consoleAuthError) Error() string {
+	return e.err.Error()
+}
+
+func (e *consoleAuthError) Unwrap() error {
+	return e.err
+}
+
+func consoleAuthErrorCode(err error) int {
+	var authErr *consoleAuthError
+	if errors.As(err, &authErr) {
+		return authErr.statusCode
+	}
+	return http.StatusUnauthorized
+}
+
 // resolveUser tries session cookie first, then Bearer token.
 func (s *ConsoleService) resolveUser(ctx context.Context, sessionID, authHeader string) (*storage.User, error) {
 	auth, err := s.resolveAuth(ctx, sessionID, authHeader)
@@ -113,21 +134,24 @@ func (s *ConsoleService) resolveAuth(ctx context.Context, sessionID, authHeader 
 		if err == nil {
 			return &consoleAuth{user: user, sessionID: sessionID}, nil
 		}
+		if !errors.Is(err, storage.ErrNotFound) {
+			return nil, &consoleAuthError{statusCode: http.StatusInternalServerError, err: err}
+		}
 	}
 	if authHeader != "" {
 		user, clientID, err := s.store.ValidateBearerTokenWithClientID(ctx, authHeader)
 		if err != nil {
-			return nil, err
+			return nil, &consoleAuthError{statusCode: http.StatusUnauthorized, err: err}
 		}
 		return &consoleAuth{user: user, clientID: clientID}, nil
 	}
-	return nil, errors.New("unauthenticated")
+	return nil, &consoleAuthError{statusCode: http.StatusUnauthorized, err: errors.New("unauthenticated")}
 }
 
 func (s *ConsoleService) ListClients(ctx context.Context, sessionID, authHeader string) *ClientsResult {
 	user, err := s.resolveUser(ctx, sessionID, authHeader)
 	if err != nil {
-		return &ClientsResult{ErrorCode: http.StatusUnauthorized}
+		return &ClientsResult{ErrorCode: consoleAuthErrorCode(err)}
 	}
 	if CheckAccess(user.Status, "browser") != AccessAllow {
 		return &ClientsResult{ErrorCode: http.StatusForbidden}
@@ -142,7 +166,7 @@ func (s *ConsoleService) ListClients(ctx context.Context, sessionID, authHeader 
 func (s *ConsoleService) ListConnections(ctx context.Context, sessionID, authHeader string) *ConnectionsResult {
 	user, err := s.resolveUser(ctx, sessionID, authHeader)
 	if err != nil {
-		return &ConnectionsResult{ErrorCode: http.StatusUnauthorized}
+		return &ConnectionsResult{ErrorCode: consoleAuthErrorCode(err)}
 	}
 	if CheckAccess(user.Status, "browser") != AccessAllow {
 		return &ConnectionsResult{ErrorCode: http.StatusForbidden}
@@ -185,7 +209,7 @@ func (s *ConsoleService) ListConnections(ctx context.Context, sessionID, authHea
 func (s *ConsoleService) ListSessions(ctx context.Context, sessionID, authHeader string) *SessionsResult {
 	auth, err := s.resolveAuth(ctx, sessionID, authHeader)
 	if err != nil {
-		return &SessionsResult{ErrorCode: http.StatusUnauthorized}
+		return &SessionsResult{ErrorCode: consoleAuthErrorCode(err)}
 	}
 	if CheckAccess(auth.user.Status, "browser") != AccessAllow {
 		return &SessionsResult{ErrorCode: http.StatusForbidden}
@@ -216,7 +240,7 @@ func (s *ConsoleService) ListSessions(ctx context.Context, sessionID, authHeader
 func (s *ConsoleService) RevokeConnection(ctx context.Context, sessionID, authHeader, clientID string) *RevokeConnectionResult {
 	auth, err := s.resolveAuth(ctx, sessionID, authHeader)
 	if err != nil {
-		return &RevokeConnectionResult{ErrorCode: http.StatusUnauthorized}
+		return &RevokeConnectionResult{ErrorCode: consoleAuthErrorCode(err)}
 	}
 	if CheckAccess(auth.user.Status, "browser") != AccessAllow {
 		return &RevokeConnectionResult{ErrorCode: http.StatusForbidden}
@@ -237,7 +261,7 @@ func (s *ConsoleService) RevokeConnection(ctx context.Context, sessionID, authHe
 func (s *ConsoleService) RevokeSession(ctx context.Context, sessionID, authHeader, revokeSessionID string) *RevokeSessionResult {
 	auth, err := s.resolveAuth(ctx, sessionID, authHeader)
 	if err != nil {
-		return &RevokeSessionResult{ErrorCode: http.StatusUnauthorized}
+		return &RevokeSessionResult{ErrorCode: consoleAuthErrorCode(err)}
 	}
 	if CheckAccess(auth.user.Status, "browser") != AccessAllow {
 		return &RevokeSessionResult{ErrorCode: http.StatusForbidden}
@@ -255,7 +279,7 @@ func (s *ConsoleService) RevokeSession(ctx context.Context, sessionID, authHeade
 func (s *ConsoleService) RevokeOtherSessions(ctx context.Context, sessionID, authHeader string) *RevokeOtherSessionsResult {
 	auth, err := s.resolveAuth(ctx, sessionID, authHeader)
 	if err != nil {
-		return &RevokeOtherSessionsResult{ErrorCode: http.StatusUnauthorized}
+		return &RevokeOtherSessionsResult{ErrorCode: consoleAuthErrorCode(err)}
 	}
 	if CheckAccess(auth.user.Status, "browser") != AccessAllow {
 		return &RevokeOtherSessionsResult{ErrorCode: http.StatusForbidden}
@@ -272,7 +296,7 @@ func (s *ConsoleService) RevokeOtherSessions(ctx context.Context, sessionID, aut
 func (s *ConsoleService) GetAuditLog(ctx context.Context, sessionID, authHeader string, page, limit int) *AuditLogResult {
 	user, err := s.resolveUser(ctx, sessionID, authHeader)
 	if err != nil {
-		return &AuditLogResult{ErrorCode: http.StatusUnauthorized}
+		return &AuditLogResult{ErrorCode: consoleAuthErrorCode(err)}
 	}
 	if CheckAccess(user.Status, "browser") != AccessAllow {
 		return &AuditLogResult{ErrorCode: http.StatusForbidden}

--- a/internal/service/console_unit_test.go
+++ b/internal/service/console_unit_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
@@ -105,7 +106,7 @@ func TestConsole_ListClients_NoSession_Unauthorized(t *testing.T) {
 func TestConsole_ListClients_InvalidSession_Unauthorized(t *testing.T) {
 	store := &fakeConsoleStore{
 		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
-			return nil, errors.New("not found")
+			return nil, storage.ErrNotFound
 		},
 		listAllClientsFn:   func() []storage.ClientView { return nil },
 		getActiveConnFn:    func(context.Context, string) ([]storage.ConnectionTokenInfo, error) { return nil, nil },
@@ -115,6 +116,26 @@ func TestConsole_ListClients_InvalidSession_Unauthorized(t *testing.T) {
 	r := svc.ListClients(context.Background(), "sess-x", "")
 	if r.ErrorCode != http.StatusUnauthorized {
 		t.Fatalf("want 401, got %d", r.ErrorCode)
+	}
+}
+
+func TestConsole_ResolveAuth_DBErrorOnSessionLookup_Returns500(t *testing.T) {
+	store := &fakeConsoleStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return nil, fmt.Errorf("db down")
+		},
+		validateBearerFn: func(context.Context, string) (*storage.User, error) {
+			t.Fatal("bearer fallback should not be called on session lookup DB error")
+			return nil, nil
+		},
+		listAllClientsFn: func() []storage.ClientView { return nil },
+	}
+	svc := NewConsoleService(store)
+
+	r := svc.ListClients(context.Background(), "sess-1", "Bearer valid-token")
+
+	if r.ErrorCode != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", r.ErrorCode)
 	}
 }
 
@@ -289,7 +310,7 @@ func TestConsole_ListConnections_LastUsedEmptyWhenMissing(t *testing.T) {
 func bearerStore(user *storage.User, bearerErr error) *fakeConsoleStore {
 	return &fakeConsoleStore{
 		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
-			return nil, errors.New("no session")
+			return nil, storage.ErrNotFound
 		},
 		validateBearerFn: func(context.Context, string) (*storage.User, error) {
 			return user, bearerErr

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -77,8 +77,11 @@ func (s *LoginService) handleSessionLogin(ctx context.Context, authRequestID, se
 	}
 
 	user, err := s.store.GetValidSession(ctx, sessionID)
-	if err != nil {
+	if errors.Is(err, storage.ErrNotFound) {
 		return nil
+	}
+	if err != nil {
+		return &LoginResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
 	}
 
 	return s.handleExistingSession(ctx, user, authRequestID, ipAddress, userAgent)

--- a/internal/service/login_unit_test.go
+++ b/internal/service/login_unit_test.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -252,7 +252,7 @@ func TestMCPLogin_HandleCallback_AuditLogIncludesSessionAndClient(t *testing.T) 
 func TestLogin_HandleLogin_NoSession_Redirect(t *testing.T) {
 	store := &fakeLoginStore{
 		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
-			return nil, errors.New("no session")
+			return nil, storage.ErrNotFound
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "s1"}}
@@ -262,6 +262,44 @@ func TestLogin_HandleLogin_NoSession_Redirect(t *testing.T) {
 
 	if result.Action != ActionRedirectToIdP {
 		t.Fatalf("action = %v, want %v", result.Action, ActionRedirectToIdP)
+	}
+}
+
+func TestLogin_HandleLogin_DBErrorOnSessionLookup_Returns500(t *testing.T) {
+	store := &fakeLoginStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return nil, fmt.Errorf("db down")
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "s1"}}
+	svc := NewLoginService(store, provider, 24*time.Hour)
+
+	result := svc.HandleLogin(context.Background(), "ar-1", "sess-1", "127.0.0.1", "ua")
+
+	if result.Action != ActionError {
+		t.Fatalf("action = %v, want %v", result.Action, ActionError)
+	}
+	if result.ErrorCode != 500 {
+		t.Fatalf("errorCode = %d, want 500", result.ErrorCode)
+	}
+}
+
+func TestMCP_HandleLogin_DBErrorOnSessionLookup_Returns500(t *testing.T) {
+	store := &fakeLoginStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return nil, fmt.Errorf("db down")
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "s1"}}
+	svc := NewMCPLoginService(store, provider, 24*time.Hour)
+
+	result := svc.HandleLogin(context.Background(), "ar-1", "sess-1", "127.0.0.1", "ua")
+
+	if result.Action != ActionError {
+		t.Fatalf("action = %v, want %v", result.Action, ActionError)
+	}
+	if result.ErrorCode != 500 {
+		t.Fatalf("errorCode = %d, want 500", result.ErrorCode)
 	}
 }
 

--- a/internal/service/mcp_login.go
+++ b/internal/service/mcp_login.go
@@ -33,19 +33,27 @@ func (s *MCPLoginService) HandleLogin(ctx context.Context, authRequestID, sessio
 
 	if sessionID != "" {
 		user, err := s.store.GetValidSession(ctx, sessionID)
-		if err == nil {
-			if CheckAccess(user.Status, "mcp") != AccessAllow {
-				s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "mcp"})
-				return &LoginResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
+		if err != nil {
+			if !errors.Is(err, storage.ErrNotFound) {
+				return &LoginResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
 			}
-			if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
-				return &LoginResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
-			}
-			return &LoginResult{Action: ActionAutoApprove, AuthRequestID: authRequestID}
+		} else {
+			return s.handleExistingMCPSession(ctx, user, authRequestID, ipAddress, userAgent)
 		}
 	}
 
 	return &LoginResult{Action: ActionRedirectToIdP, RedirectURL: s.mcpProvider.AuthURL(authRequestID)}
+}
+
+func (s *MCPLoginService) handleExistingMCPSession(ctx context.Context, user *storage.User, authRequestID, ipAddress, userAgent string) *LoginResult {
+	if CheckAccess(user.Status, "mcp") != AccessAllow {
+		s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "mcp"})
+		return &LoginResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
+	}
+	if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
+		return &LoginResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
+	}
+	return &LoginResult{Action: ActionAutoApprove, AuthRequestID: authRequestID}
 }
 
 func (s *MCPLoginService) HandleCallback(ctx context.Context, code, authRequestID, ipAddress, userAgent string) *CallbackResult {


### PR DESCRIPTION
## Summary

Three call sites of `Storage.GetValidSession` collapsed every error into one branch: silently redirect to the IdP (login / mcp) or downgrade to Bearer auth (console). A genuine DB outage during session lookup therefore looked identical to "your cookie expired" or "no cookie sent". Users got an endless redirect loop, console traffic silently switched to Bearer-only, and the outage stayed invisible.

The storage layer already maps `sql.ErrNoRows` to `storage.ErrNotFound`, so callers can split the two cases:

- `internal/service/login.go` `handleSessionLogin`: `ErrNotFound` → fall through to IdP redirect (unchanged); any other error → 500 `internal_error`.
- `internal/service/mcp_login.go` `HandleLogin`: same predicate. The valid-session auto-approve branch is extracted to `handleExistingMCPSession` to keep the new control flow readable.
- `internal/service/console.go` `resolveAuth`: cookie path returns a `consoleAuthError` carrying an HTTP status. Cookie `ErrNotFound` keeps falling through to Bearer (no behavior change). Any other cookie error short-circuits with 500. Bearer failures and unauthenticated requests still return 401. Handlers read the status via `consoleAuthErrorCode(err)` rather than hard-coding 401.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./internal/service/ ./internal/handler/` — PASS
- [x] Three new unit tests inject a non-`ErrNotFound` error from a fake store and confirm 500 propagation:
  - `TestLogin_HandleLogin_DBErrorOnSessionLookup_Returns500`
  - `TestMCP_HandleLogin_DBErrorOnSessionLookup_Returns500`
  - `TestConsole_ResolveAuth_DBErrorOnSessionLookup_Returns500`

## Behavior change

| Scenario | Before | After |
|---|---|---|
| `/login` with valid session cookie + DB outage | 302 to IdP | 500 |
| `/mcp/login` with valid session cookie + DB outage | 302 to IdP | 500 |
| `/console/me/sessions` with valid cookie + DB outage on session lookup | 401 (Bearer fallback fails too) | 500 |
| Same calls with expired/missing cookie | unchanged | unchanged |

## Scope

Closes `finding-4` from the code-ambiguity review round. No SQL, sqlc, or storage package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)