### PR TITLE
chore(service): remove unused DeviceService.publicURL field

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -59,7 +59,7 @@ func main() {
 	loginService := service.NewLoginService(store, browserProvider, cfg.SessionTTL)
 
 	// Device service
-	deviceService := service.NewDeviceService(store, deviceProvider, cfg.PublicURL, cfg.SessionTTL, clk)
+	deviceService := service.NewDeviceService(store, deviceProvider, cfg.SessionTTL, clk)
 
 	// Account service
 	accountService := service.NewAccountService(store)

--- a/internal/handler/device_test.go
+++ b/internal/handler/device_test.go
@@ -13,7 +13,7 @@ import (
 // newTestDeviceHandler creates a DeviceHandler with a minimal DeviceService.
 // nil storage is safe as long as the code path under test exits before touching it.
 func newTestDeviceHandler() *DeviceHandler {
-	svc := service.NewDeviceService(nil, nil, "", 0, nil)
+	svc := service.NewDeviceService(nil, nil, 0, nil)
 	return NewDeviceHandler(svc, true, "authgate") // devMode=true
 }
 

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -137,7 +137,7 @@ func SetupTestServerWithOptions(t *testing.T, opts SetupOptions) *TestServer {
 
 	// Services
 	loginSvc := service.NewLoginService(store, fakeProvider, 24*time.Hour)
-	deviceSvc := service.NewDeviceService(store, fakeProvider, srv.URL, 24*time.Hour, clk)
+	deviceSvc := service.NewDeviceService(store, fakeProvider, 24*time.Hour, clk)
 	accountSvc := service.NewAccountService(store)
 
 	// Handlers

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -15,7 +15,6 @@ type DeviceService struct {
 	store      DeviceStore
 	provider   upstream.Provider
 	sessionTTL time.Duration
-	publicURL  string
 	clock      clock.Clock
 }
 
@@ -29,11 +28,10 @@ type DeviceStore interface {
 	ApproveDeviceCode(ctx context.Context, userCode, subject string) error
 }
 
-func NewDeviceService(store DeviceStore, provider upstream.Provider, publicURL string, sessionTTL time.Duration, clk clock.Clock) *DeviceService {
+func NewDeviceService(store DeviceStore, provider upstream.Provider, sessionTTL time.Duration, clk clock.Clock) *DeviceService {
 	return &DeviceService{
 		store:      store,
 		provider:   provider,
-		publicURL:  publicURL,
 		sessionTTL: sessionTTL,
 		clock:      clk,
 	}

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -31,7 +31,7 @@ func setupDeviceService(t *testing.T) (*DeviceService, *storage.Storage, clock.C
 		},
 	}
 
-	svc := NewDeviceService(store, fakeProvider, "http://localhost:8080", 24*time.Hour, clk)
+	svc := NewDeviceService(store, fakeProvider, 24*time.Hour, clk)
 	return svc, store, clk
 }
 
@@ -270,7 +270,7 @@ func TestDeviceApprove_AfterStatusTransition_Rejected(t *testing.T) {
 			svc, store, clk := setupDeviceExtTest(t, "dev-approve-"+tt.status)
 			ctx := context.Background()
 
-			user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-"+tt.status+"@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-approve-"+tt.status, ProviderEmail: "dev-approve-"+tt.status+"@test.com"})
+			user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-" + tt.status + "@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-approve-" + tt.status, ProviderEmail: "dev-approve-" + tt.status + "@test.com"})
 			sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 			insertDeviceCode(t, store, "ASTA-"+tt.status, clk)
 

--- a/internal/service/device_unit_test.go
+++ b/internal/service/device_unit_test.go
@@ -64,7 +64,7 @@ func TestDevice_HandleDevicePage_NoSession_Redirects(t *testing.T) {
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
-	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clk)
+	svc := NewDeviceService(store, provider, 24*time.Hour, clk)
 
 	result := svc.HandleDevicePage(context.Background(), "UCODE", "")
 
@@ -85,7 +85,7 @@ func TestDevice_HandleDeviceApprove_Deny(t *testing.T) {
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
-	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clock.RealClock{})
+	svc := NewDeviceService(store, provider, 24*time.Hour, clock.RealClock{})
 
 	result := svc.HandleDeviceApprove(context.Background(), "UCODE", "deny", "sess", "127.0.0.1", "ua")
 
@@ -107,7 +107,7 @@ func TestDevice_HandleDeviceApprove_ApproveError(t *testing.T) {
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
-	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clock.RealClock{})
+	svc := NewDeviceService(store, provider, 24*time.Hour, clock.RealClock{})
 
 	result := svc.HandleDeviceApprove(context.Background(), "UCODE", "approve", "sess", "127.0.0.1", "ua")
 
@@ -145,7 +145,7 @@ func TestDevice_HandleDeviceCallback_AuditLogIncludesSessionAndClient(t *testing
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
-	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clk)
+	svc := NewDeviceService(store, provider, 24*time.Hour, clk)
 
 	result := svc.HandleDeviceCallback(context.Background(), "code", "UCODE", "127.0.0.1", "ua")
 

--- a/internal/service/e2e_test.go
+++ b/internal/service/e2e_test.go
@@ -46,7 +46,7 @@ func setupE2ETest(t *testing.T) *e2eFixture {
 
 	loginSvc := NewLoginService(store, fakeProvider, 24*time.Hour)
 	mcpLoginSvc := NewMCPLoginService(store, fakeProvider, 24*time.Hour)
-	deviceSvc := NewDeviceService(store, fakeProvider, "http://localhost:8080", 24*time.Hour, clk)
+	deviceSvc := NewDeviceService(store, fakeProvider, 24*time.Hour, clk)
 	accountSvc := NewAccountService(store)
 	return &e2eFixture{
 		LoginSvc:    loginSvc,

--- a/internal/service/testhelpers_test.go
+++ b/internal/service/testhelpers_test.go
@@ -47,7 +47,7 @@ func setupDeviceExtTest(t *testing.T, sub string) (*DeviceService, *storage.Stor
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: sub, Email: sub + "@test.com", EmailVerified: true, Name: "Device Ext"},
 	}
-	svc := NewDeviceService(store, fakeProvider, "http://localhost:8080", 24*time.Hour, clk)
+	svc := NewDeviceService(store, fakeProvider, 24*time.Hour, clk)
 	return svc, store, clk
 }
 
@@ -76,7 +76,7 @@ func setupGapTest(t *testing.T) *gapFixture {
 	}
 	loginSvc := NewLoginService(store, fakeProvider, 24*time.Hour)
 	mcpLoginSvc := NewMCPLoginService(store, fakeProvider, 24*time.Hour)
-	deviceSvc := NewDeviceService(store, fakeProvider, "http://localhost:8080", 24*time.Hour, clk)
+	deviceSvc := NewDeviceService(store, fakeProvider, 24*time.Hour, clk)
 	accountSvc := NewAccountService(store)
 	return &gapFixture{
 		LoginSvc:    loginSvc,


### PR DESCRIPTION
## Summary

`NewDeviceService` accepted a `publicURL string` and stored it on the struct, but no method on `DeviceService` ever read it. The publicURL used by the device flow for Origin validation lives on `AccountHandler`, so this field was a leftover from an earlier design.

- Drop the `publicURL` field on `DeviceService`.
- Drop the `publicURL` parameter from `NewDeviceService`.
- Update every call site: `cmd/authgate/main.go`, `internal/integration/server.go`, and the affected test fixtures.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./internal/service/ ./internal/handler/` — PASS
- [ ] `TestDeviceCallback_ExistingUser_RedirectBack` still fails — confirmed pre-existing on main, unrelated to this change

## Scope

Closes `finding-10` from the code-ambiguity review round. Pure mechanical refactor, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)