### PR TITLE
fix(audit): emit slog on AuditLog failure instead of silently dropping events

### DIFF
--- a/internal/service/account.go
+++ b/internal/service/account.go
@@ -14,7 +14,7 @@ type AccountService struct {
 type AccountStore interface {
 	GetValidSession(ctx context.Context, sessionID string) (*storage.User, error)
 	RequestDeletion(ctx context.Context, userID string) error
-	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any)
 }
 
 func NewAccountService(store AccountStore) *AccountService {

--- a/internal/service/account_unit_test.go
+++ b/internal/service/account_unit_test.go
@@ -12,7 +12,7 @@ import (
 type fakeAccountStore struct {
 	getValidSessionFn func(ctx context.Context, sessionID string) (*storage.User, error)
 	requestDeletionFn func(ctx context.Context, userID string) error
-	auditLogFn        func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+	auditLogFn        func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any)
 }
 
 func (f *fakeAccountStore) GetValidSession(ctx context.Context, sessionID string) (*storage.User, error) {
@@ -23,11 +23,11 @@ func (f *fakeAccountStore) RequestDeletion(ctx context.Context, userID string) e
 	return f.requestDeletionFn(ctx, userID)
 }
 
-func (f *fakeAccountStore) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+func (f *fakeAccountStore) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 	if f.auditLogFn == nil {
-		return nil
+		return
 	}
-	return f.auditLogFn(ctx, userID, eventType, ipAddress, userAgent, metadata)
+	f.auditLogFn(ctx, userID, eventType, ipAddress, userAgent, metadata)
 }
 
 func TestAccount_RequestDeletion_PendingDeletion_IsIdempotent(t *testing.T) {
@@ -67,9 +67,8 @@ func TestAccount_RequestDeletion_ActiveUser_Success(t *testing.T) {
 			calledDelete = true
 			return nil
 		},
-		auditLogFn: func(context.Context, *string, string, string, string, map[string]any) error {
+		auditLogFn: func(context.Context, *string, string, string, string, map[string]any) {
 			calledAudit = true
-			return nil
 		},
 	}
 	svc := NewAccountService(store)

--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -24,7 +24,7 @@ type ConsoleStore interface {
 	RevokeSession(ctx context.Context, userID, sessionID string) error
 	RevokeOtherSessions(ctx context.Context, userID, currentSessionID string) error
 	GetAuditLog(ctx context.Context, userID string, limit, offset int) (*storage.AuditLogPage, error)
-	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any)
 }
 
 func NewConsoleService(store ConsoleStore) *ConsoleService {

--- a/internal/service/console_unit_test.go
+++ b/internal/service/console_unit_test.go
@@ -22,7 +22,7 @@ type fakeConsoleStore struct {
 	revokeSessionFn            func(ctx context.Context, userID, sessionID string) error
 	revokeOtherSessionsFn      func(ctx context.Context, userID, currentSessionID string) error
 	getAuditLogFn              func(ctx context.Context, userID string, limit, offset int) (*storage.AuditLogPage, error)
-	auditLogFn                 func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+	auditLogFn                 func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any)
 }
 
 func (f *fakeConsoleStore) GetValidSession(ctx context.Context, sessionID string) (*storage.User, error) {
@@ -62,11 +62,11 @@ func (f *fakeConsoleStore) RevokeOtherSessions(ctx context.Context, userID, curr
 func (f *fakeConsoleStore) GetAuditLog(ctx context.Context, userID string, limit, offset int) (*storage.AuditLogPage, error) {
 	return f.getAuditLogFn(ctx, userID, limit, offset)
 }
-func (f *fakeConsoleStore) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+func (f *fakeConsoleStore) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 	if f.auditLogFn == nil {
-		return nil
+		return
 	}
-	return f.auditLogFn(ctx, userID, eventType, ipAddress, userAgent, metadata)
+	f.auditLogFn(ctx, userID, eventType, ipAddress, userAgent, metadata)
 }
 
 func activeUserStore(clients []storage.ClientView, connIDs []string) *fakeConsoleStore {
@@ -406,13 +406,12 @@ func TestConsole_RevokeConnection_ValidAuth_AuditLogsConnectionRevoked(t *testin
 	var gotUserID, gotEventType string
 	var gotMetadata map[string]any
 	store := activeUserStore(nil, nil)
-	store.auditLogFn = func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+	store.auditLogFn = func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 		if userID != nil {
 			gotUserID = *userID
 		}
 		gotEventType = eventType
 		gotMetadata = metadata
-		return nil
 	}
 	svc := NewConsoleService(store)
 
@@ -513,10 +512,9 @@ func TestConsole_RevokeSession_ValidAuth_RevokesAndAudits(t *testing.T) {
 		gotSessionID = sessionID
 		return nil
 	}
-	store.auditLogFn = func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+	store.auditLogFn = func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 		gotEventType = eventType
 		gotMetadata = metadata
-		return nil
 	}
 	svc := NewConsoleService(store)
 	r := svc.RevokeSession(context.Background(), "sess-1", "", "sess-2")

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -22,7 +22,7 @@ type DeviceService struct {
 type DeviceStore interface {
 	GetDeviceCodeByUserCode(ctx context.Context, userCode string) (*storage.DeviceCodeModel, error)
 	GetValidSession(ctx context.Context, sessionID string) (*storage.User, error)
-	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any)
 	GetUserByProviderIdentity(ctx context.Context, provider, providerUserID string) (*storage.User, error)
 	CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error)
 	DenyDeviceCode(ctx context.Context, userCode string) error

--- a/internal/service/device_unit_test.go
+++ b/internal/service/device_unit_test.go
@@ -14,7 +14,7 @@ import (
 type fakeDeviceStore struct {
 	getDeviceCodeByUserCodeFn func(ctx context.Context, userCode string) (*storage.DeviceCodeModel, error)
 	getValidSessionFn         func(ctx context.Context, sessionID string) (*storage.User, error)
-	auditLogFn                func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+	auditLogFn                func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any)
 	getUserByProviderIdentity func(ctx context.Context, provider, providerUserID string) (*storage.User, error)
 	createSessionFn           func(ctx context.Context, userID string, ttl time.Duration) (string, error)
 	denyDeviceCodeFn          func(ctx context.Context, userCode string) error
@@ -29,11 +29,11 @@ func (f *fakeDeviceStore) GetValidSession(ctx context.Context, sessionID string)
 	return f.getValidSessionFn(ctx, sessionID)
 }
 
-func (f *fakeDeviceStore) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+func (f *fakeDeviceStore) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 	if f.auditLogFn == nil {
-		return nil
+		return
 	}
-	return f.auditLogFn(ctx, userID, eventType, ipAddress, userAgent, metadata)
+	f.auditLogFn(ctx, userID, eventType, ipAddress, userAgent, metadata)
 }
 
 func (f *fakeDeviceStore) GetUserByProviderIdentity(ctx context.Context, provider, providerUserID string) (*storage.User, error) {
@@ -138,10 +138,9 @@ func TestDevice_HandleDeviceCallback_AuditLogIncludesSessionAndClient(t *testing
 		createSessionFn: func(context.Context, string, time.Duration) (string, error) {
 			return "sess-1", nil
 		},
-		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 			gotEventType = eventType
 			gotMetadata = metadata
-			return nil
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -19,7 +19,7 @@ type LoginService struct {
 
 type LoginStore interface {
 	GetValidSession(ctx context.Context, sessionID string) (*storage.User, error)
-	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any)
 	RecoverUser(ctx context.Context, userID string) error
 	CompleteAuthRequest(ctx context.Context, authRequestID, userID string) error
 	GetUserByProviderIdentity(ctx context.Context, provider, providerUserID string) (*storage.User, error)

--- a/internal/service/login_unit_test.go
+++ b/internal/service/login_unit_test.go
@@ -12,7 +12,7 @@ import (
 
 type fakeLoginStore struct {
 	getValidSessionFn         func(ctx context.Context, sessionID string) (*storage.User, error)
-	auditLogFn                func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error
+	auditLogFn                func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any)
 	recoverUserFn             func(ctx context.Context, userID string) error
 	completeAuthRequestFn     func(ctx context.Context, authRequestID, userID string) error
 	getUserByProviderIdentity func(ctx context.Context, provider, providerUserID string) (*storage.User, error)
@@ -26,11 +26,11 @@ func (f *fakeLoginStore) GetValidSession(ctx context.Context, sessionID string) 
 	return f.getValidSessionFn(ctx, sessionID)
 }
 
-func (f *fakeLoginStore) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+func (f *fakeLoginStore) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 	if f.auditLogFn == nil {
-		return nil
+		return
 	}
-	return f.auditLogFn(ctx, userID, eventType, ipAddress, userAgent, metadata)
+	f.auditLogFn(ctx, userID, eventType, ipAddress, userAgent, metadata)
 }
 
 func (f *fakeLoginStore) RecoverUser(ctx context.Context, userID string) error {
@@ -139,10 +139,9 @@ func TestLogin_HandleCallback_ExistingUser_AuditLogIncludesSessionAndClient(t *t
 		completeAuthRequestFn: func(context.Context, string, string) error {
 			return nil
 		},
-		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 			gotEventType = eventType
 			gotMetadata = metadata
-			return nil
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub-1"}}
@@ -183,9 +182,8 @@ func TestLogin_HandleCallback_SignupAuditLogIncludesChannel(t *testing.T) {
 		completeAuthRequestFn: func(context.Context, string, string) error {
 			return nil
 		},
-		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 			gotEvents = append(gotEvents, auditEntry{eventType: eventType, metadata: metadata})
-			return nil
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub-1"}}
@@ -227,10 +225,9 @@ func TestMCPLogin_HandleCallback_AuditLogIncludesSessionAndClient(t *testing.T) 
 		completeAuthRequestFn: func(context.Context, string, string) error {
 			return nil
 		},
-		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 			gotEventType = eventType
 			gotMetadata = metadata
-			return nil
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub-1"}}

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net"
 	"net/netip"
 	"strings"
@@ -49,30 +50,48 @@ func normalizeIPAddress(addr string) string {
 	return ""
 }
 
-func (s *Storage) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+// AuditLog records a security/audit event on a best-effort basis. Failures are
+// logged via slog.ErrorContext but never propagated: callers have already
+// committed the underlying business transaction (login, token issue, etc.) and
+// must not be failed by an audit-write error. The metadata payload is *not*
+// included in failure logs to avoid leaking session/family identifiers.
+func (s *Storage) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 	ipAddress = normalizeIPAddress(ipAddress)
 	var metaJSON []byte
 	if metadata != nil {
-		var err error
-		metaJSON, err = json.Marshal(metadata)
+		marshaled, err := json.Marshal(metadata)
 		if err != nil {
-			return err
+			slog.ErrorContext(ctx, "audit log: marshal metadata",
+				"event_type", eventType,
+				"user_id", userIDLogValue(userID),
+				"error", err,
+			)
+			return
 		}
+		metaJSON = marshaled
 	}
 
-	userIDValue := ""
-	if userID != nil {
-		userIDValue = *userID
-	}
-
-	return storeq.New(s.db).InsertAuditLog(ctx, storeq.InsertAuditLogParams{
-		UserID:    userIDValue,
+	if err := storeq.New(s.db).InsertAuditLog(ctx, storeq.InsertAuditLogParams{
+		UserID:    userIDLogValue(userID),
 		EventType: eventType,
 		IpAddress: nilIfEmpty(ipAddress),
 		UserAgent: nilIfEmpty(userAgent),
 		Metadata:  nilIfEmptyBytes(metaJSON),
 		CreatedAt: s.clock.Now(),
-	})
+	}); err != nil {
+		slog.ErrorContext(ctx, "audit log: insert",
+			"event_type", eventType,
+			"user_id", userIDLogValue(userID),
+			"error", err,
+		)
+	}
+}
+
+func userIDLogValue(userID *string) string {
+	if userID == nil {
+		return ""
+	}
+	return *userID
 }
 
 func nilIfEmpty(s string) *string {

--- a/internal/storage/audit_failure_unit_test.go
+++ b/internal/storage/audit_failure_unit_test.go
@@ -1,0 +1,129 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/kangheeyong/authgate/internal/clock"
+	"github.com/kangheeyong/authgate/internal/idgen"
+)
+
+// captureSlog swaps the slog default with a JSON handler writing into buf for
+// the duration of the test, then restores the previous default.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
+}
+
+func newClosedAuditStorage(t *testing.T) *Storage {
+	t.Helper()
+	db, err := sql.Open("pgx", "postgres://localhost:1/authgate_audit_test")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close: %v", err)
+	}
+	clk := &clock.FixedClock{T: time.Date(2026, 4, 29, 0, 0, 0, 0, time.UTC)}
+	return New(db, clk, idgen.CryptoGenerator{}, func(*User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
+}
+
+// TestAuditLog_InsertFailure_DoesNotPropagateAndIsLogged asserts that when the
+// underlying INSERT fails (here: closed *sql.DB), AuditLog still returns to the
+// caller without panicking and emits an ERROR-level slog entry naming the
+// event_type and user_id. Caller-provided metadata must NOT appear in the log.
+func TestAuditLog_InsertFailure_DoesNotPropagateAndIsLogged(t *testing.T) {
+	buf := captureSlog(t)
+	store := newClosedAuditStorage(t)
+
+	uid := "11111111-1111-4111-8111-111111111111"
+	const familySecret = "family-secret-should-not-be-logged"
+
+	// Should not panic; the new signature has no error return so the caller is
+	// structurally protected. We additionally verify an ERROR log was emitted.
+	store.AuditLog(context.Background(), &uid, "auth.login", "127.0.0.1", "test-agent", map[string]any{
+		"family_id": familySecret,
+		"client_id": "test-client",
+	})
+
+	logs := buf.String()
+	if !strings.Contains(logs, `"msg":"audit log: insert"`) {
+		t.Fatalf("expected insert-failure log message, got: %s", logs)
+	}
+	if !strings.Contains(logs, `"level":"ERROR"`) {
+		t.Fatalf("expected ERROR level log, got: %s", logs)
+	}
+	if !strings.Contains(logs, `"event_type":"auth.login"`) {
+		t.Fatalf("expected event_type attr, got: %s", logs)
+	}
+	if !strings.Contains(logs, `"user_id":"`+uid+`"`) {
+		t.Fatalf("expected user_id attr, got: %s", logs)
+	}
+	if strings.Contains(logs, familySecret) {
+		t.Fatalf("metadata leaked into failure log: %s", logs)
+	}
+}
+
+// TestAuditLog_MarshalFailure_DoesNotPropagateAndIsLogged asserts that when
+// json.Marshal of the metadata fails (channel type is unsupported), AuditLog
+// logs an ERROR and returns without invoking the database insert.
+func TestAuditLog_MarshalFailure_DoesNotPropagateAndIsLogged(t *testing.T) {
+	buf := captureSlog(t)
+	store := newClosedAuditStorage(t)
+
+	uid := "22222222-2222-4222-8222-222222222222"
+	store.AuditLog(context.Background(), &uid, "auth.signup", "", "", map[string]any{
+		"unmarshalable": make(chan int),
+	})
+
+	logs := buf.String()
+	if !strings.Contains(logs, `"msg":"audit log: marshal metadata"`) {
+		t.Fatalf("expected marshal-failure log message, got: %s", logs)
+	}
+	if !strings.Contains(logs, `"level":"ERROR"`) {
+		t.Fatalf("expected ERROR level log, got: %s", logs)
+	}
+	if !strings.Contains(logs, `"event_type":"auth.signup"`) {
+		t.Fatalf("expected event_type attr, got: %s", logs)
+	}
+	if !strings.Contains(logs, `"user_id":"`+uid+`"`) {
+		t.Fatalf("expected user_id attr, got: %s", logs)
+	}
+	// Insert path must not be reached; only the marshal log should be present.
+	if strings.Contains(logs, `"msg":"audit log: insert"`) {
+		t.Fatalf("insert log should not appear when marshal fails: %s", logs)
+	}
+	// Sanity: confirm the chan value never made it past json.Marshal.
+	if _, err := json.Marshal(map[string]any{"unmarshalable": make(chan int)}); err == nil {
+		t.Fatalf("test setup invalid: chan should be unmarshalable")
+	}
+}
+
+// TestAuditLog_NilUserID_LogsEmpty asserts the signature change is safe when
+// userID is nil — the failure log emits an empty user_id rather than panicking.
+func TestAuditLog_NilUserID_LogsEmpty(t *testing.T) {
+	buf := captureSlog(t)
+	store := newClosedAuditStorage(t)
+
+	store.AuditLog(context.Background(), nil, "auth.refresh_reuse_detected", "", "", nil)
+
+	logs := buf.String()
+	if !strings.Contains(logs, `"msg":"audit log: insert"`) {
+		t.Fatalf("expected insert-failure log message, got: %s", logs)
+	}
+	if !strings.Contains(logs, `"user_id":""`) {
+		t.Fatalf("expected empty user_id attr for nil pointer, got: %s", logs)
+	}
+}

--- a/internal/storage/cleanup_runner.go
+++ b/internal/storage/cleanup_runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/kangheeyong/authgate/internal/db/storeq"
@@ -119,9 +120,15 @@ func (r *CleanupRunner) DeleteUser(
 		return err
 	}
 
-	_ = storeq.New(r.db).InsertDeletionCompletedAudit(ctx, storeq.InsertDeletionCompletedAuditParams{
+	if err := storeq.New(r.db).InsertDeletionCompletedAudit(ctx, storeq.InsertDeletionCompletedAuditParams{
 		UserID:    userID,
 		CreatedAt: now,
-	})
+	}); err != nil {
+		slog.ErrorContext(ctx, "audit log: insert deletion_completed",
+			"event_type", EventAuthDeletionCompleted,
+			"user_id", userID,
+			"error", err,
+		)
+	}
 	return nil
 }


### PR DESCRIPTION
## Summary

`Storage.AuditLog`이 반환하던 `error`를 모든 호출자가 무시하고 있어 DB 일시 장애·`json.Marshal` 실패·`inet` 캐스팅 실패가 발생해도 보안 이벤트가 **침묵으로 누락**되던 구조를 정리합니다.

정책: **best-effort + structured slog logging**. 비즈니스 트랜잭션이 이미 커밋된 시점에 audit이 실패해도 호출자에게 에러를 전파하면 안 됨 → 인터페이스에서 `error`를 제거해 silent drop을 구조적으로 불가능하게 하고, 실패는 `slog.ErrorContext`로 남깁니다.

## Why

`internal/storage/audit.go:52` `(s *Storage) AuditLog(...) error`가 `error`를 반환하지만 호출자 11곳이 모두 statement로 호출 → Go 컴파일러가 반환값을 침묵으로 폐기.

영향받던 보안 이벤트:
- `auth.login`, `auth.logout`, `auth.signup`
- `auth.token_revoked`, `token.refresh`, `auth.refresh_reuse_detected`, `auth.refresh_family_revoked`
- `auth.session_revoked`, `auth.connection_revoked`
- `auth.deletion_requested`, `auth.deletion_cancelled`, `auth.deletion_completed`, `auth.inactive_user`
- `auth.device_approved`, `auth.device_denied`

## What changed

- `internal/storage/audit.go`
  - `AuditLog` 시그니처에서 `error` 반환 제거
  - `json.Marshal` 실패와 `InsertAuditLog` 실패를 각각 `slog.ErrorContext`로 기록
  - 로그 어트리뷰트는 `event_type`, `user_id`, `error`만 — **metadata 본문은 의도적으로 제외** (`session_id`/`family_id`/`client_id` 누설 방지)
  - `userIDLogValue` 헬퍼로 nil 가드 일원화
- `internal/storage/cleanup_runner.go` — 기존 `_ = InsertDeletionCompletedAudit(...)` silent ignore도 동일 정책으로 교체 (`EventAuthDeletionCompleted` 상수 참조)
- `internal/service/{account,console,device,login}.go` — 4개 인터페이스 선언에서 `error` 제거
- 4개 unit test fake store + 7개 인라인 함수 본문 시그니처 정리

## Tests

`internal/storage/audit_failure_unit_test.go` 신규 — closed `*sql.DB`로 결정론적 실패 재현 (Docker 불필요):

| 테스트 | 검증 |
|---|---|
| `TestAuditLog_InsertFailure_DoesNotPropagateAndIsLogged` | 호출자 panic-free + ERROR 로그 emit + `event_type`/`user_id` 어트리뷰트 + `family_id` secret이 로그에 누설되지 않음 |
| `TestAuditLog_MarshalFailure_DoesNotPropagateAndIsLogged` | metadata에 `chan int` 주입 시 marshal 실패 → ERROR 로그 + insert 경로 미도달 |
| `TestAuditLog_NilUserID_LogsEmpty` | `userID=nil` 시 panic 없이 빈 `user_id` 로그 |

기존 service-layer audit 테스트(`audit_test.go`, `*_unit_test.go`)는 시그니처 변경에 맞춰 동기화되었고 모두 통과.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./...` 전체 통과
- [x] 신규 실패 테스트 3개 verbose PASS 확인
- [ ] (CI) `go test -tags=integration ./...` — testcontainers 포함

## Out of scope (후속 별도 PR 예정)

코드 리뷰에서 식별된 후속 작업 — 본 PR과 분리:
- (LOW) context cancellation 케이스 테스트 보강
- (LOW) 성공 경로 무로그 회귀 테스트
- (MEDIUM) `auth.refresh_reuse_detected` ↔ `auth.refresh_family_revoked` 부분 실패 관측성 (best-effort 정책의 한계)
- 이전 분석에서 별도 P1으로 식별된: PII 보존 정책 재검토, `(user_id, created_at DESC, id DESC)` 인덱스, 이벤트 상수 카탈로그 통합

🤖 Generated with [Claude Code](https://claude.com/claude-code)