### PR TITLE
fix(test): insert missing auth_request/device_code fixtures in integration tests

### DIFF
--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -101,13 +101,14 @@ func TestAudit002_LoginChannels(t *testing.T) {
 	})
 
 	t.Run("device", func(t *testing.T) {
-		svc, store, _ := setupDeviceExtTest(t, "audit-device-sub")
+		svc, store, clk := setupDeviceExtTest(t, "audit-device-sub")
 		ctx := context.Background()
 
 		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device@test.com", EmailVerified: true, Name: "Device", AvatarURL: "", Provider: "google", ProviderUserID: "audit-device-sub", ProviderEmail: "audit-device@test.com"})
 		if err != nil {
 			t.Fatalf("create user: %v", err)
 		}
+		insertDeviceCode(t, store, "AUDT-DEV", clk)
 
 		result := svc.HandleDeviceCallback(ctx, "fake-code", "AUDT-DEV", "127.0.0.1", "device-agent")
 		if result.Action != DeviceRedirectBack {
@@ -243,8 +244,12 @@ func TestAudit009_InactiveUser(t *testing.T) {
 			if err := store.SetUserStatus(ctx, user.ID, tt.status); err != nil {
 				t.Fatalf("set user status: %v", err)
 			}
+			arID, err := store.CreateTestAuthRequest(ctx, "audit-inactive-"+tt.name)
+			if err != nil {
+				t.Fatalf("create auth request: %v", err)
+			}
 
-			result := svc.HandleCallback(ctx, "fake-code", "audit-inactive", "127.0.0.1", "inactive-agent")
+			result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "inactive-agent")
 			if result.Action != ActionError {
 				t.Fatalf("action = %v, want Error", result.Action)
 			}

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -166,10 +166,11 @@ func TestDeviceCallback_NewUser_SignupRequired(t *testing.T) {
 }
 
 func TestDeviceCallback_ExistingUser_RedirectBack(t *testing.T) {
-	svc, store, _ := setupDeviceService(t)
+	svc, store, clk := setupDeviceService(t)
 	ctx := context.Background()
 
 	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-cb@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "dc@test.com"})
+	insertDeviceCode(t, store, "RDIR-CODE", clk)
 
 	result := svc.HandleDeviceCallback(ctx, "fake-code", "RDIR-CODE", "127.0.0.1", "test")
 	if result.Action != DeviceRedirectBack {

--- a/internal/service/login_test.go
+++ b/internal/service/login_test.go
@@ -141,8 +141,12 @@ func TestHandleCallback_InactiveUser_Error(t *testing.T) {
 	// Create disabled user
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "disabled@example.com", EmailVerified: true, Name: "Disabled", AvatarURL: "", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "disabled@example.com"})
 	store.DisableUser(ctx, user.ID)
+	arID, err := store.CreateTestAuthRequest(ctx, "req-disabled")
+	if err != nil {
+		t.Fatalf("create auth request: %v", err)
+	}
 
-	result := svc.HandleCallback(ctx, "fake-code", "req-disabled", "127.0.0.1", "test-agent")
+	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test-agent")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error", result.Action)


### PR DESCRIPTION
## Summary

`internal/service`의 통합 테스트 4개가 fixture를 미리 만들지 않은 채로 머지되어 있어 main CI가 5회 연속 red 상태였습니다 (`go test -tags=integration ./internal/...`). 누락된 `CreateTestAuthRequest` / `insertDeviceCode` 호출만 추가합니다 — **프로덕션 코드 변경 없음**.

## Why

각 테스트가 literal authRequestID / userCode를 사용:

| 테스트 | 사용하던 literal | 흐름 |
|---|---|---|
| `TestAudit002_LoginChannels/device` | `"AUDT-DEV"` | `GetDeviceCodeByUserCode` → `ErrNotFound` → `DeviceError` |
| `TestAudit009_InactiveUser/{disabled,deleted}` | `"audit-inactive"` | `GetAuthRequestModel` → `ErrNotFound` → 400 (audit `inactive_user` 미도달) |
| `TestDeviceCallback_ExistingUser_RedirectBack` | `"RDIR-CODE"` | 같은 device 흐름 |
| `TestHandleCallback_InactiveUser_Error` | `"req-disabled"` | 같은 auth_request 흐름 |

다른 통과하는 device 테스트 9개는 모두 `insertDeviceCode(t, store, "USER-CODE", clk)`을 명시적으로 호출. 다른 통과 audit 테스트들도 `store.CreateTestAuthRequest(ctx, ...)` → 반환된 `arID`를 callback에 사용. 즉 깨진 4개는 같은 fixture 패턴이 빠진 것.

## What changed

```diff
- svc, store, _ := setupDeviceExtTest(t, "audit-device-sub")
+ svc, store, clk := setupDeviceExtTest(t, "audit-device-sub")
  ...
+ insertDeviceCode(t, store, "AUDT-DEV", clk)
  result := svc.HandleDeviceCallback(ctx, "fake-code", "AUDT-DEV", ...)
```

```diff
+ arID, err := store.CreateTestAuthRequest(ctx, "req-disabled")
+ if err != nil { t.Fatalf("create auth request: %v", err) }
- result := svc.HandleCallback(ctx, "fake-code", "req-disabled", ...)
+ result := svc.HandleCallback(ctx, "fake-code", arID, ...)
```

같은 패턴 4곳.

## Test plan

- [x] `go build -tags=integration ./...`
- [x] `go vet -tags=integration ./...`
- [ ] CI: 4개 테스트 PASS (`TestAudit002_LoginChannels/device`, `TestAudit009_InactiveUser/disabled`, `TestAudit009_InactiveUser/deleted`, `TestDeviceCallback_ExistingUser_RedirectBack`, `TestHandleCallback_InactiveUser_Error`)

## Out of scope

main에 남아있는 다른 결함 — 별도 PR 예정:
- `TestE2E5_RecoveryThenAuthRequestRetry`, `TestBrowser007_RecoveryRetryIdempotent` — `HandleCallback` 흐름 reorder 필요 (recovery-before-completion 의미). literal로 invalid auth_request를 일부러 사용하는 시나리오라 fixture로는 해결 안 됨.
- `internal/db/queries/console.sql:7:9: column reference "user_id" is ambiguous` (SQLC 단계 실패).

🤖 Generated with [Claude Code](https://claude.com/claude-code)