### PR TITLE
fix(ci): restore sqlc guard and stabilize failing checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,14 @@ jobs:
 
       - name: Enforce sqlc-only runtime DB access
         run: |
-          if rg -n 'ExecContext\(|QueryRowContext\(|QueryContext\(|PrepareContext\(' \
+          if git grep -nE 'ExecContext\(|QueryRowContext\(|QueryContext\(|PrepareContext\(' -- \
             internal/storage \
-            --glob '!**/storeq/**' \
-            --glob '!**/*_test.go'; then
+            ':(exclude)internal/storage/**/storeq/**' \
+            ':(exclude)**/*_test.go'; then
             echo "Direct SQL calls are not allowed in runtime storage code. Use sqlc queries in internal/db/queries and generated storeq."
             exit 1
           fi
-          if rg -n 'parsePostgresArray|func \(a \*?StringArray\) (Scan|Value)\(' internal/storage; then
+          if git grep -nE 'parsePostgresArray|func \(a [^)]*StringArray\) (Scan|Value)\(' -- internal/storage; then
             echo "Manual postgres array parsers/scanners are not allowed. Use sqlc/driver array handling."
             exit 1
           fi

--- a/internal/db/queries/cleanup.sql
+++ b/internal/db/queries/cleanup.sql
@@ -18,6 +18,12 @@ WHERE expires_at < sqlc.arg(cutoff);
 DELETE FROM device_codes
 WHERE expires_at < sqlc.arg(cutoff);
 
+-- name: TryCleanupAdvisoryLock :one
+SELECT pg_try_advisory_lock(sqlc.arg(lock_key)::bigint);
+
+-- name: UnlockCleanupAdvisoryLock :one
+SELECT pg_advisory_unlock(sqlc.arg(lock_key)::bigint);
+
 -- name: ListPendingDeletionUserIDsBefore :many
 SELECT id
 FROM users

--- a/internal/db/queries/console.sql
+++ b/internal/db/queries/console.sql
@@ -4,18 +4,18 @@ WITH active_tokens AS (
          client_id,
          scopes
   FROM refresh_tokens
-  WHERE user_id = $1
-    AND revoked_at IS NULL
-    AND expires_at > $2
-  ORDER BY client_id, created_at DESC
+  WHERE refresh_tokens.user_id = $1
+    AND refresh_tokens.revoked_at IS NULL
+    AND refresh_tokens.expires_at > $2
+  ORDER BY refresh_tokens.client_id, refresh_tokens.created_at DESC
 ),
 last_used_tokens AS (
   SELECT client_id,
-         MAX(used_at) AS last_used
+         MAX(used_at)::timestamptz AS last_used
   FROM refresh_tokens
-  WHERE user_id = $1
-    AND used_at IS NOT NULL
-  GROUP BY client_id
+  WHERE refresh_tokens.user_id = $1
+    AND refresh_tokens.used_at IS NOT NULL
+  GROUP BY refresh_tokens.client_id
 )
 SELECT active_tokens.client_id,
        active_tokens.scopes,
@@ -27,16 +27,16 @@ ORDER BY active_tokens.client_id;
 -- name: RevokeActiveRefreshTokensByUserIDAndClientID :exec
 UPDATE refresh_tokens
 SET revoked_at = $1
-WHERE user_id = $2
-  AND client_id = $3
-  AND revoked_at IS NULL;
+WHERE refresh_tokens.user_id = $2
+  AND refresh_tokens.client_id = $3
+  AND refresh_tokens.revoked_at IS NULL;
 
 -- name: GetActiveSessionsByUserID :many
 SELECT s.id,
        s.expires_at,
-       COALESCE(login.ip_address::text, '') AS ip_address,
-       COALESCE(login.user_agent, '') AS user_agent,
-       login.created_at
+       COALESCE(login.ip_address::text, '')::text AS ip_address,
+       COALESCE(login.user_agent, '')::text AS user_agent,
+       COALESCE(login.created_at, s.created_at) AS created_at
 FROM sessions s
 LEFT JOIN LATERAL (
   SELECT audit_log.ip_address,
@@ -57,32 +57,32 @@ ORDER BY s.created_at DESC;
 -- name: RevokeSessionByUserIDAndID :exec
 UPDATE sessions
 SET revoked_at = $1
-WHERE user_id = $2
-  AND id = $3
-  AND revoked_at IS NULL;
+WHERE sessions.user_id = $2
+  AND sessions.id = $3
+  AND sessions.revoked_at IS NULL;
 
 -- name: RevokeOtherActiveSessionsByUserID :exec
 UPDATE sessions
 SET revoked_at = $1
-WHERE user_id = $2
-  AND id <> $3
-  AND expires_at > $4
-  AND revoked_at IS NULL;
+WHERE sessions.user_id = $2
+  AND sessions.id <> $3
+  AND sessions.expires_at > $4
+  AND sessions.revoked_at IS NULL;
 
 -- name: GetAuditLogByUserID :many
 SELECT id,
        event_type,
-       COALESCE(ip_address::text, '') AS ip_address,
-       COALESCE(user_agent, '') AS user_agent,
-       COALESCE(metadata, '{}'::jsonb) AS metadata,
+       COALESCE(ip_address::text, '')::text AS ip_address,
+       COALESCE(user_agent, '')::text AS user_agent,
+       COALESCE(metadata, '{}'::jsonb)::jsonb AS metadata,
        created_at,
        COUNT(*) OVER() AS total
 FROM audit_log
-WHERE user_id = $1
+WHERE audit_log.user_id = NULLIF(sqlc.arg(user_id)::text, '')::uuid
 ORDER BY created_at DESC
-LIMIT $2 OFFSET $3;
+LIMIT sqlc.arg(page_limit) OFFSET sqlc.arg(page_offset);
 
 -- name: CountAuditLogByUserID :one
 SELECT COUNT(*)
 FROM audit_log
-WHERE user_id = $1;
+WHERE audit_log.user_id = NULLIF(sqlc.arg(user_id)::text, '')::uuid;

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -85,3 +85,31 @@ VALUES (
   $3,
   $4
 );
+
+-- name: InsertTestAuthRequestWithResource :exec
+INSERT INTO auth_requests (
+  id,
+  client_id,
+  redirect_uri,
+  scopes,
+  state,
+  nonce,
+  code_challenge,
+  code_challenge_method,
+  resource,
+  expires_at,
+  created_at
+)
+VALUES (
+  $1,
+  'test-app',
+  'http://localhost/callback',
+  '{openid}',
+  $2,
+  'test-nonce',
+  'E9Melhoa2OwvFrEMT',
+  'S256',
+  $3,
+  $4,
+  $5
+);

--- a/internal/db/storeq/audit_log.sql.go
+++ b/internal/db/storeq/audit_log.sql.go
@@ -33,16 +33,12 @@ type InsertAuditLogParams struct {
 }
 
 func (q *Queries) InsertAuditLog(ctx context.Context, arg InsertAuditLogParams) error {
-	var metadataStr interface{}
-	if len(arg.Metadata) > 0 {
-		metadataStr = string(arg.Metadata)
-	}
 	_, err := q.db.ExecContext(ctx, insertAuditLog,
 		arg.UserID,
 		arg.EventType,
 		arg.IpAddress,
 		arg.UserAgent,
-		metadataStr,
+		arg.Metadata,
 		arg.CreatedAt,
 	)
 	return err

--- a/internal/db/storeq/cleanup.sql.go
+++ b/internal/db/storeq/cleanup.sql.go
@@ -185,3 +185,25 @@ func (q *Queries) MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedBy
 	_, err := q.db.ExecContext(ctx, markUserDeletedByID, arg.DeletedAt, arg.UserID)
 	return err
 }
+
+const tryCleanupAdvisoryLock = `-- name: TryCleanupAdvisoryLock :one
+SELECT pg_try_advisory_lock($1::bigint)
+`
+
+func (q *Queries) TryCleanupAdvisoryLock(ctx context.Context, lockKey int64) (bool, error) {
+	row := q.db.QueryRowContext(ctx, tryCleanupAdvisoryLock, lockKey)
+	var pg_try_advisory_lock bool
+	err := row.Scan(&pg_try_advisory_lock)
+	return pg_try_advisory_lock, err
+}
+
+const unlockCleanupAdvisoryLock = `-- name: UnlockCleanupAdvisoryLock :one
+SELECT pg_advisory_unlock($1::bigint)
+`
+
+func (q *Queries) UnlockCleanupAdvisoryLock(ctx context.Context, lockKey int64) (bool, error) {
+	row := q.db.QueryRowContext(ctx, unlockCleanupAdvisoryLock, lockKey)
+	var pg_advisory_unlock bool
+	err := row.Scan(&pg_advisory_unlock)
+	return pg_advisory_unlock, err
+}

--- a/internal/db/storeq/console.sql.go
+++ b/internal/db/storeq/console.sql.go
@@ -14,24 +14,37 @@ import (
 	"github.com/lib/pq"
 )
 
+const countAuditLogByUserID = `-- name: CountAuditLogByUserID :one
+SELECT COUNT(*)
+FROM audit_log
+WHERE audit_log.user_id = NULLIF($1::text, '')::uuid
+`
+
+func (q *Queries) CountAuditLogByUserID(ctx context.Context, userID string) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countAuditLogByUserID, userID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const getActiveConnectionsByUserID = `-- name: GetActiveConnectionsByUserID :many
 WITH active_tokens AS (
   SELECT DISTINCT ON (client_id)
          client_id,
          scopes
   FROM refresh_tokens
-  WHERE user_id = $1
-    AND revoked_at IS NULL
-    AND expires_at > $2
-  ORDER BY client_id, created_at DESC
+  WHERE refresh_tokens.user_id = $1
+    AND refresh_tokens.revoked_at IS NULL
+    AND refresh_tokens.expires_at > $2
+  ORDER BY refresh_tokens.client_id, refresh_tokens.created_at DESC
 ),
 last_used_tokens AS (
   SELECT client_id,
-         MAX(used_at) AS last_used
+         MAX(used_at)::timestamptz AS last_used
   FROM refresh_tokens
-  WHERE user_id = $1
-    AND used_at IS NOT NULL
-  GROUP BY client_id
+  WHERE refresh_tokens.user_id = $1
+    AND refresh_tokens.used_at IS NOT NULL
+  GROUP BY refresh_tokens.client_id
 )
 SELECT active_tokens.client_id,
        active_tokens.scopes,
@@ -66,34 +79,21 @@ func (q *Queries) GetActiveConnectionsByUserID(ctx context.Context, arg GetActiv
 		}
 		items = append(items, i)
 	}
-	return items, rows.Err()
-}
-
-const revokeActiveRefreshTokensByUserIDAndClientID = `-- name: RevokeActiveRefreshTokensByUserIDAndClientID :exec
-UPDATE refresh_tokens
-SET revoked_at = $1
-WHERE user_id = $2
-  AND client_id = $3
-  AND revoked_at IS NULL
-`
-
-type RevokeActiveRefreshTokensByUserIDAndClientIDParams struct {
-	RevokedAt sql.NullTime
-	UserID    string
-	ClientID  string
-}
-
-func (q *Queries) RevokeActiveRefreshTokensByUserIDAndClientID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDAndClientIDParams) error {
-	_, err := q.db.ExecContext(ctx, revokeActiveRefreshTokensByUserIDAndClientID, arg.RevokedAt, arg.UserID, arg.ClientID)
-	return err
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getActiveSessionsByUserID = `-- name: GetActiveSessionsByUserID :many
 SELECT s.id,
        s.expires_at,
-       COALESCE(login.ip_address::text, '') AS ip_address,
-       COALESCE(login.user_agent, '') AS user_agent,
-       login.created_at
+       COALESCE(login.ip_address::text, '')::text AS ip_address,
+       COALESCE(login.user_agent, '')::text AS user_agent,
+       COALESCE(login.created_at, s.created_at) AS created_at
 FROM sessions s
 LEFT JOIN LATERAL (
   SELECT audit_log.ip_address,
@@ -122,7 +122,7 @@ type GetActiveSessionsByUserIDRow struct {
 	ExpiresAt time.Time
 	IpAddress string
 	UserAgent string
-	CreatedAt sql.NullTime
+	CreatedAt time.Time
 }
 
 func (q *Queries) GetActiveSessionsByUserID(ctx context.Context, arg GetActiveSessionsByUserIDParams) ([]GetActiveSessionsByUserIDRow, error) {
@@ -145,67 +145,33 @@ func (q *Queries) GetActiveSessionsByUserID(ctx context.Context, arg GetActiveSe
 		}
 		items = append(items, i)
 	}
-	return items, rows.Err()
-}
-
-const revokeSessionByUserIDAndID = `-- name: RevokeSessionByUserIDAndID :exec
-UPDATE sessions
-SET revoked_at = $1
-WHERE user_id = $2
-  AND id = $3
-  AND revoked_at IS NULL
-`
-
-type RevokeSessionByUserIDAndIDParams struct {
-	RevokedAt sql.NullTime
-	UserID    string
-	ID        string
-}
-
-func (q *Queries) RevokeSessionByUserIDAndID(ctx context.Context, arg RevokeSessionByUserIDAndIDParams) error {
-	_, err := q.db.ExecContext(ctx, revokeSessionByUserIDAndID, arg.RevokedAt, arg.UserID, arg.ID)
-	return err
-}
-
-const revokeOtherActiveSessionsByUserID = `-- name: RevokeOtherActiveSessionsByUserID :exec
-UPDATE sessions
-SET revoked_at = $1
-WHERE user_id = $2
-  AND id <> $3
-  AND expires_at > $4
-  AND revoked_at IS NULL
-`
-
-type RevokeOtherActiveSessionsByUserIDParams struct {
-	RevokedAt sql.NullTime
-	UserID    string
-	ID        string
-	ExpiresAt time.Time
-}
-
-func (q *Queries) RevokeOtherActiveSessionsByUserID(ctx context.Context, arg RevokeOtherActiveSessionsByUserIDParams) error {
-	_, err := q.db.ExecContext(ctx, revokeOtherActiveSessionsByUserID, arg.RevokedAt, arg.UserID, arg.ID, arg.ExpiresAt)
-	return err
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getAuditLogByUserID = `-- name: GetAuditLogByUserID :many
 SELECT id,
        event_type,
-       COALESCE(ip_address::text, '') AS ip_address,
-       COALESCE(user_agent, '') AS user_agent,
-       COALESCE(metadata, '{}'::jsonb) AS metadata,
+       COALESCE(ip_address::text, '')::text AS ip_address,
+       COALESCE(user_agent, '')::text AS user_agent,
+       COALESCE(metadata, '{}'::jsonb)::jsonb AS metadata,
        created_at,
        COUNT(*) OVER() AS total
 FROM audit_log
-WHERE user_id = $1
+WHERE audit_log.user_id = NULLIF($1::text, '')::uuid
 ORDER BY created_at DESC
-LIMIT $2 OFFSET $3
+LIMIT $3 OFFSET $2
 `
 
 type GetAuditLogByUserIDParams struct {
-	UserID string
-	Limit  int32
-	Offset int32
+	UserID     string
+	PageOffset int32
+	PageLimit  int32
 }
 
 type GetAuditLogByUserIDRow struct {
@@ -219,7 +185,7 @@ type GetAuditLogByUserIDRow struct {
 }
 
 func (q *Queries) GetAuditLogByUserID(ctx context.Context, arg GetAuditLogByUserIDParams) ([]GetAuditLogByUserIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, getAuditLogByUserID, arg.UserID, arg.Limit, arg.Offset)
+	rows, err := q.db.QueryContext(ctx, getAuditLogByUserID, arg.UserID, arg.PageOffset, arg.PageLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -240,18 +206,75 @@ func (q *Queries) GetAuditLogByUserID(ctx context.Context, arg GetAuditLogByUser
 		}
 		items = append(items, i)
 	}
-	return items, rows.Err()
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
-const countAuditLogByUserID = `-- name: CountAuditLogByUserID :one
-SELECT COUNT(*)
-FROM audit_log
-WHERE user_id = $1
+const revokeActiveRefreshTokensByUserIDAndClientID = `-- name: RevokeActiveRefreshTokensByUserIDAndClientID :exec
+UPDATE refresh_tokens
+SET revoked_at = $1
+WHERE refresh_tokens.user_id = $2
+  AND refresh_tokens.client_id = $3
+  AND refresh_tokens.revoked_at IS NULL
 `
 
-func (q *Queries) CountAuditLogByUserID(ctx context.Context, userID string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countAuditLogByUserID, userID)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
+type RevokeActiveRefreshTokensByUserIDAndClientIDParams struct {
+	RevokedAt sql.NullTime
+	UserID    string
+	ClientID  string
+}
+
+func (q *Queries) RevokeActiveRefreshTokensByUserIDAndClientID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDAndClientIDParams) error {
+	_, err := q.db.ExecContext(ctx, revokeActiveRefreshTokensByUserIDAndClientID, arg.RevokedAt, arg.UserID, arg.ClientID)
+	return err
+}
+
+const revokeOtherActiveSessionsByUserID = `-- name: RevokeOtherActiveSessionsByUserID :exec
+UPDATE sessions
+SET revoked_at = $1
+WHERE sessions.user_id = $2
+  AND sessions.id <> $3
+  AND sessions.expires_at > $4
+  AND sessions.revoked_at IS NULL
+`
+
+type RevokeOtherActiveSessionsByUserIDParams struct {
+	RevokedAt sql.NullTime
+	UserID    string
+	ID        string
+	ExpiresAt time.Time
+}
+
+func (q *Queries) RevokeOtherActiveSessionsByUserID(ctx context.Context, arg RevokeOtherActiveSessionsByUserIDParams) error {
+	_, err := q.db.ExecContext(ctx, revokeOtherActiveSessionsByUserID,
+		arg.RevokedAt,
+		arg.UserID,
+		arg.ID,
+		arg.ExpiresAt,
+	)
+	return err
+}
+
+const revokeSessionByUserIDAndID = `-- name: RevokeSessionByUserIDAndID :exec
+UPDATE sessions
+SET revoked_at = $1
+WHERE sessions.user_id = $2
+  AND sessions.id = $3
+  AND sessions.revoked_at IS NULL
+`
+
+type RevokeSessionByUserIDAndIDParams struct {
+	RevokedAt sql.NullTime
+	UserID    string
+	ID        string
+}
+
+func (q *Queries) RevokeSessionByUserIDAndID(ctx context.Context, arg RevokeSessionByUserIDAndIDParams) error {
+	_, err := q.db.ExecContext(ctx, revokeSessionByUserIDAndID, arg.RevokedAt, arg.UserID, arg.ID)
+	return err
 }

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -25,11 +25,11 @@ type Querier interface {
 	DeleteSessionsByUserID(ctx context.Context, userID string) error
 	DeleteUserIdentitiesByUserID(ctx context.Context, userID string) error
 	DenyDeviceCodeByUserCode(ctx context.Context, userCode string) error
-	GetAuthRequestByCode(ctx context.Context, code sql.NullString) (GetAuthRequestByCodeRow, error)
-	GetAuthRequestByID(ctx context.Context, id string) (GetAuthRequestByIDRow, error)
 	GetActiveConnectionsByUserID(ctx context.Context, arg GetActiveConnectionsByUserIDParams) ([]GetActiveConnectionsByUserIDRow, error)
 	GetActiveSessionsByUserID(ctx context.Context, arg GetActiveSessionsByUserIDParams) ([]GetActiveSessionsByUserIDRow, error)
 	GetAuditLogByUserID(ctx context.Context, arg GetAuditLogByUserIDParams) ([]GetAuditLogByUserIDRow, error)
+	GetAuthRequestByCode(ctx context.Context, code sql.NullString) (GetAuthRequestByCodeRow, error)
+	GetAuthRequestByID(ctx context.Context, id string) (GetAuthRequestByIDRow, error)
 	GetDeviceAuthorizationForUpdate(ctx context.Context, arg GetDeviceAuthorizationForUpdateParams) (GetDeviceAuthorizationForUpdateRow, error)
 	GetDeviceCodeByUserCode(ctx context.Context, userCode string) (GetDeviceCodeByUserCodeRow, error)
 	GetRefreshFamilyIDByTokenHash(ctx context.Context, tokenHash string) (string, error)
@@ -47,6 +47,7 @@ type Querier interface {
 	InsertRefreshToken(ctx context.Context, arg InsertRefreshTokenParams) error
 	InsertSession(ctx context.Context, arg InsertSessionParams) error
 	InsertTestAuthRequest(ctx context.Context, arg InsertTestAuthRequestParams) error
+	InsertTestAuthRequestWithResource(ctx context.Context, arg InsertTestAuthRequestWithResourceParams) error
 	InsertUser(ctx context.Context, arg InsertUserParams) error
 	InsertUserIdentity(ctx context.Context, arg InsertUserIdentityParams) error
 	ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff sql.NullTime) ([]string, error)
@@ -63,6 +64,8 @@ type Querier interface {
 	RevokeSessionByUserIDAndID(ctx context.Context, arg RevokeSessionByUserIDAndIDParams) error
 	RevokeSessionsByUserID(ctx context.Context, arg RevokeSessionsByUserIDParams) error
 	SetUserStatusByID(ctx context.Context, arg SetUserStatusByIDParams) error
+	TryCleanupAdvisoryLock(ctx context.Context, lockKey int64) (bool, error)
+	UnlockCleanupAdvisoryLock(ctx context.Context, lockKey int64) (bool, error)
 	UpdateAuthRequestCode(ctx context.Context, arg UpdateAuthRequestCodeParams) error
 	UpdateDeviceCodeStateConsumedByID(ctx context.Context, id string) error
 }

--- a/internal/db/storeq/users.sql.go
+++ b/internal/db/storeq/users.sql.go
@@ -201,6 +201,54 @@ func (q *Queries) InsertTestAuthRequest(ctx context.Context, arg InsertTestAuthR
 	return err
 }
 
+const insertTestAuthRequestWithResource = `-- name: InsertTestAuthRequestWithResource :exec
+INSERT INTO auth_requests (
+  id,
+  client_id,
+  redirect_uri,
+  scopes,
+  state,
+  nonce,
+  code_challenge,
+  code_challenge_method,
+  resource,
+  expires_at,
+  created_at
+)
+VALUES (
+  $1,
+  'test-app',
+  'http://localhost/callback',
+  '{openid}',
+  $2,
+  'test-nonce',
+  'E9Melhoa2OwvFrEMT',
+  'S256',
+  $3,
+  $4,
+  $5
+)
+`
+
+type InsertTestAuthRequestWithResourceParams struct {
+	ID        string
+	State     sql.NullString
+	Resource  sql.NullString
+	ExpiresAt time.Time
+	CreatedAt time.Time
+}
+
+func (q *Queries) InsertTestAuthRequestWithResource(ctx context.Context, arg InsertTestAuthRequestWithResourceParams) error {
+	_, err := q.db.ExecContext(ctx, insertTestAuthRequestWithResource,
+		arg.ID,
+		arg.State,
+		arg.Resource,
+		arg.ExpiresAt,
+		arg.CreatedAt,
+	)
+	return err
+}
+
 const insertUser = `-- name: InsertUser :exec
 INSERT INTO users (id, email, email_verified, name, avatar_url, status, created_at, updated_at)
 VALUES ($1, $2, $3, $4, $5, 'active', $6, $6)

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -101,13 +101,14 @@ func TestAudit002_LoginChannels(t *testing.T) {
 	})
 
 	t.Run("device", func(t *testing.T) {
-		svc, store, _ := setupDeviceExtTest(t, "audit-device-sub")
+		svc, store, clk := setupDeviceExtTest(t, "audit-device-sub")
 		ctx := context.Background()
 
 		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device@test.com", EmailVerified: true, Name: "Device", AvatarURL: "", Provider: "google", ProviderUserID: "audit-device-sub", ProviderEmail: "audit-device@test.com"})
 		if err != nil {
 			t.Fatalf("create user: %v", err)
 		}
+		insertDeviceCode(t, store, "AUDT-DEV", clk)
 
 		result := svc.HandleDeviceCallback(ctx, "fake-code", "AUDT-DEV", "127.0.0.1", "device-agent")
 		if result.Action != DeviceRedirectBack {
@@ -243,8 +244,12 @@ func TestAudit009_InactiveUser(t *testing.T) {
 			if err := store.SetUserStatus(ctx, user.ID, tt.status); err != nil {
 				t.Fatalf("set user status: %v", err)
 			}
+			arID, err := store.CreateTestAuthRequest(ctx, "audit-inactive-"+tt.name)
+			if err != nil {
+				t.Fatalf("create auth request: %v", err)
+			}
 
-			result := svc.HandleCallback(ctx, "fake-code", "audit-inactive", "127.0.0.1", "inactive-agent")
+			result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "inactive-agent")
 			if result.Action != ActionError {
 				t.Fatalf("action = %v, want Error", result.Action)
 			}

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -166,10 +166,11 @@ func TestDeviceCallback_NewUser_SignupRequired(t *testing.T) {
 }
 
 func TestDeviceCallback_ExistingUser_RedirectBack(t *testing.T) {
-	svc, store, _ := setupDeviceService(t)
+	svc, store, clk := setupDeviceService(t)
 	ctx := context.Background()
 
 	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-cb@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "dc@test.com"})
+	insertDeviceCode(t, store, "RDIR-CODE", clk)
 
 	result := svc.HandleDeviceCallback(ctx, "fake-code", "RDIR-CODE", "127.0.0.1", "test")
 	if result.Action != DeviceRedirectBack {
@@ -270,7 +271,7 @@ func TestDeviceApprove_AfterStatusTransition_Rejected(t *testing.T) {
 			svc, store, clk := setupDeviceExtTest(t, "dev-approve-"+tt.status)
 			ctx := context.Background()
 
-			user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-"+tt.status+"@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-approve-"+tt.status, ProviderEmail: "dev-approve-"+tt.status+"@test.com"})
+			user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-" + tt.status + "@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-approve-" + tt.status, ProviderEmail: "dev-approve-" + tt.status + "@test.com"})
 			sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 			insertDeviceCode(t, store, "ASTA-"+tt.status, clk)
 

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -128,20 +128,7 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 		return &CallbackResult{Action: ActionError, Error: "upstream_error", ErrorCode: http.StatusInternalServerError}
 	}
 
-	authReq, err := s.store.GetAuthRequestModel(ctx, authRequestID)
-	if errors.Is(err, storage.ErrNotFound) {
-		return &CallbackResult{Action: ActionError, Error: "auth_request_not_found", ErrorCode: http.StatusBadRequest}
-	}
-	if err != nil {
-		return &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
-	}
-
-	user, signedUp, result := s.findOrCreateBrowserUser(ctx, userInfo, ipAddress, userAgent)
-	if result != nil {
-		return result
-	}
-
-	user, result = s.ensureBrowserAccess(ctx, user, ipAddress, userAgent)
+	user, signedUp, authReq, result := s.prepareBrowserCallbackUser(ctx, userInfo, authRequestID, ipAddress, userAgent)
 	if result != nil {
 		return result
 	}
@@ -164,6 +151,43 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 	return &CallbackResult{Action: ActionAutoApprove, AuthRequestID: authRequestID, SessionID: sessionID}
 }
 
+func (s *LoginService) prepareBrowserCallbackUser(ctx context.Context, userInfo *upstream.UserInfo, authRequestID, ipAddress, userAgent string) (*storage.User, bool, *storage.AuthRequestModel, *CallbackResult) {
+	providerName := s.browserProvider.Name()
+	user, err := s.store.GetUserByProviderIdentity(ctx, providerName, userInfo.Sub)
+	if errors.Is(err, storage.ErrNotFound) {
+		authReq, result := s.getCallbackAuthRequest(ctx, authRequestID)
+		if result != nil {
+			return nil, false, nil, result
+		}
+		user, result := s.signupBrowserUser(ctx, providerName, userInfo, ipAddress, userAgent)
+		return user, true, authReq, result
+	}
+	if err != nil {
+		return nil, false, nil, &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+	}
+
+	user, result := s.ensureBrowserAccess(ctx, user, ipAddress, userAgent)
+	if result != nil {
+		return nil, false, nil, result
+	}
+	authReq, result := s.getCallbackAuthRequest(ctx, authRequestID)
+	if result != nil {
+		return nil, false, nil, result
+	}
+	return user, false, authReq, nil
+}
+
+func (s *LoginService) getCallbackAuthRequest(ctx context.Context, authRequestID string) (*storage.AuthRequestModel, *CallbackResult) {
+	authReq, err := s.store.GetAuthRequestModel(ctx, authRequestID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, &CallbackResult{Action: ActionError, Error: "auth_request_not_found", ErrorCode: http.StatusBadRequest}
+	}
+	if err != nil {
+		return nil, &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+	}
+	return authReq, nil
+}
+
 func (s *LoginService) redirectToProvider(authRequestID string) *LoginResult {
 	return &LoginResult{Action: ActionRedirectToIdP, RedirectURL: s.browserProvider.AuthURL(authRequestID)}
 }
@@ -174,20 +198,6 @@ func (s *LoginService) recoverUser(ctx context.Context, userID, ipAddress, userA
 	}
 	s.store.AuditLog(ctx, &userID, "auth.deletion_cancelled", ipAddress, userAgent, nil)
 	return nil
-}
-
-func (s *LoginService) findOrCreateBrowserUser(ctx context.Context, userInfo *upstream.UserInfo, ipAddress, userAgent string) (*storage.User, bool, *CallbackResult) {
-	providerName := s.browserProvider.Name()
-	user, err := s.store.GetUserByProviderIdentity(ctx, providerName, userInfo.Sub)
-	if errors.Is(err, storage.ErrNotFound) {
-		user, result := s.signupBrowserUser(ctx, providerName, userInfo, ipAddress, userAgent)
-		return user, true, result
-	}
-	if err != nil {
-		return nil, false, &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
-	}
-
-	return user, false, nil
 }
 
 func (s *LoginService) signupBrowserUser(ctx context.Context, providerName string, userInfo *upstream.UserInfo, ipAddress, userAgent string) (*storage.User, *CallbackResult) {

--- a/internal/service/login_test.go
+++ b/internal/service/login_test.go
@@ -141,8 +141,12 @@ func TestHandleCallback_InactiveUser_Error(t *testing.T) {
 	// Create disabled user
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "disabled@example.com", EmailVerified: true, Name: "Disabled", AvatarURL: "", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "disabled@example.com"})
 	store.DisableUser(ctx, user.ID)
+	arID, err := store.CreateTestAuthRequest(ctx, "req-disabled")
+	if err != nil {
+		t.Fatalf("create auth request: %v", err)
+	}
 
-	result := svc.HandleCallback(ctx, "fake-code", "req-disabled", "127.0.0.1", "test-agent")
+	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test-agent")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error", result.Action)

--- a/internal/storage/cleanup_runner.go
+++ b/internal/storage/cleanup_runner.go
@@ -26,9 +26,10 @@ func (r *CleanupRunner) WithExclusiveLock(ctx context.Context, fn func(context.C
 		return false, err
 	}
 	defer conn.Close()
+	qconn := storeq.New(conn)
 
-	var acquired bool
-	if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, cleanupAdvisoryLockKey).Scan(&acquired); err != nil {
+	acquired, err := qconn.TryCleanupAdvisoryLock(ctx, cleanupAdvisoryLockKey)
+	if err != nil {
 		return false, err
 	}
 	if !acquired {
@@ -37,8 +38,7 @@ func (r *CleanupRunner) WithExclusiveLock(ctx context.Context, fn func(context.C
 
 	runErr := fn(ctx)
 
-	var released bool
-	unlockErr := conn.QueryRowContext(ctx, `SELECT pg_advisory_unlock($1)`, cleanupAdvisoryLockKey).Scan(&released)
+	released, unlockErr := qconn.UnlockCleanupAdvisoryLock(ctx, cleanupAdvisoryLockKey)
 
 	if runErr != nil {
 		return true, runErr

--- a/internal/storage/console.go
+++ b/internal/storage/console.go
@@ -124,10 +124,8 @@ func (s *Storage) GetActiveSessions(ctx context.Context, userID string) ([]Sessi
 			IPAddress: row.IpAddress,
 			UserAgent: row.UserAgent,
 		}
-		if row.CreatedAt.Valid {
-			createdAt := row.CreatedAt.Time
-			info.CreatedAt = &createdAt
-		}
+		createdAt := row.CreatedAt
+		info.CreatedAt = &createdAt
 		sessions = append(sessions, info)
 	}
 	return sessions, nil
@@ -154,9 +152,9 @@ func (s *Storage) RevokeOtherSessions(ctx context.Context, userID, currentSessio
 func (s *Storage) GetAuditLog(ctx context.Context, userID string, limit, offset int) (*AuditLogPage, error) {
 	q := storeq.New(s.db)
 	rows, err := q.GetAuditLogByUserID(ctx, storeq.GetAuditLogByUserIDParams{
-		UserID: userID,
-		Limit:  int32(limit),
-		Offset: int32(offset),
+		UserID:     userID,
+		PageLimit:  int32(limit),
+		PageOffset: int32(offset),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -251,14 +251,15 @@ func (s *Storage) CreateTestAuthRequest(ctx context.Context, label string) (stri
 func (s *Storage) CreateTestAuthRequestWithResource(ctx context.Context, label, resource string) (string, error) {
 	id := s.idgen.NewUUID()
 	now := s.clock.Now()
-	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO auth_requests (id, client_id, redirect_uri, scopes, state, nonce, code_challenge, code_challenge_method, resource, expires_at, created_at)`+
-		` VALUES ($1, 'test-app', 'http://localhost/callback', '{openid}', $2, 'test-nonce', 'E9Melhoa2OwvFrEMT', 'S256', $3, $4, $5)`,
-		id, label, resource, now.Add(10*time.Minute), now,
-	)
+	err := storeq.New(s.db).InsertTestAuthRequestWithResource(ctx, storeq.InsertTestAuthRequestWithResourceParams{
+		ID:        id,
+		State:     sql.NullString{String: label, Valid: true},
+		Resource:  sql.NullString{String: resource, Valid: true},
+		ExpiresAt: now.Add(10 * time.Minute),
+		CreatedAt: now,
+	})
 	return id, err
 }
-
 
 // Session management
 


### PR DESCRIPTION
## Summary

- Fix SQLC generation failure by qualifying ambiguous console query columns and preserving sqlc-generated Go contracts.
- Restore the CI sqlc-only storage guard by replacing the unavailable `rg` dependency with `git grep`.
- Move remaining runtime storage direct SQL calls behind sqlc-generated queries so the restored guard passes.
- Reorder browser callback recovery for existing pending-deletion users so recovery persists before auth request completion failure.
- Add missing auth_request/device_code fixtures for integration tests that depended on literal IDs.

## Why

The latest CI failures had two visible roots:

```text
CI
├─ SQLC: console.sql user_id ambiguity
├─ Test: recovery retry left user pending_deletion
└─ Hidden guard issue: rg was not installed, so direct SQL guard never actually ran
```

## Test plan

- [x] `/private/tmp/sqlc-v1.28.0/sqlc generate`
- [x] `/private/tmp/sqlc-v1.28.0/sqlc vet`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage ./internal/service`
- [x] `go test -tags integration ./internal/service -run "TestAudit002_LoginChannels|TestAudit009_InactiveUser|TestDeviceCallback_ExistingUser_RedirectBack|TestHandleCallback_InactiveUser_Error|TestE2E5_RecoveryThenAuthRequestRetry|TestBrowser007_RecoveryRetryIdempotent" -count=1`
- [x] `go test -tags integration ./internal/integration -count=1`
- [x] `go test -tags integration ./internal/... -count=1`

Note: local `go test -coverprofile=... ./internal/...` on darwin hit a local Go toolchain `covdata` issue for no-test packages, so full coverage-profile parity is left to CI Linux.