### PR TITLE
fix(audit): record auth.login when login reuses an existing session

### DIFF
--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -143,6 +143,44 @@ func TestAudit002_LoginChannels(t *testing.T) {
 	})
 }
 
+// Issue #131: auth.login was missing when login reused an existing session and
+// skipped the upstream IdP round-trip. The audit row must be written in the
+// skip-IdP path with reused_session=true to keep audit history symmetric with
+// the auth.token_revoked rows that follow.
+func TestAudit_ReusedSession_AuthLoginRecorded(t *testing.T) {
+	svc, store := setupBrowserExtTest(t)
+	ctx := context.Background()
+
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-reuse@test.com", EmailVerified: true, Name: "Reuse", AvatarURL: "", Provider: "google", ProviderUserID: "browser-ext-sub", ProviderEmail: "audit-reuse@test.com"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	sessionID, err := store.CreateSession(ctx, user.ID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	arID, err := store.CreateTestAuthRequest(ctx, "audit-reuse")
+	if err != nil {
+		t.Fatalf("create auth request: %v", err)
+	}
+
+	result := svc.HandleLogin(ctx, arID, sessionID, "127.0.0.1", "reuse-agent")
+	if result.Action != ActionAutoApprove {
+		t.Fatalf("action = %v, want AutoApprove", result.Action)
+	}
+
+	event := requireSingleAuditEvent(t, store.DB(), user.ID, "auth.login")
+	if event.Metadata["channel"] != "browser" {
+		t.Fatalf("channel = %v, want browser", event.Metadata["channel"])
+	}
+	if event.Metadata["reused_session"] != true {
+		t.Fatalf("reused_session = %v, want true", event.Metadata["reused_session"])
+	}
+	if event.Metadata["session_id"] != sessionID {
+		t.Fatalf("session_id = %v, want %s", event.Metadata["session_id"], sessionID)
+	}
+}
+
 func TestAudit004_DeviceApproved(t *testing.T) {
 	svc, store, clk := setupDeviceService(t)
 	ctx := context.Background()

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -81,10 +81,10 @@ func (s *LoginService) handleSessionLogin(ctx context.Context, authRequestID, se
 		return nil
 	}
 
-	return s.handleExistingSession(ctx, user, authRequestID, ipAddress, userAgent)
+	return s.handleExistingSession(ctx, user, authRequestID, sessionID, ipAddress, userAgent)
 }
 
-func (s *LoginService) handleExistingSession(ctx context.Context, user *storage.User, authRequestID, ipAddress, userAgent string) *LoginResult {
+func (s *LoginService) handleExistingSession(ctx context.Context, user *storage.User, authRequestID, sessionID, ipAddress, userAgent string) *LoginResult {
 	switch CheckAccess(user.Status, "browser") {
 	case AccessDeny:
 		s.auditInactiveUser(ctx, user.ID, user.Status, ipAddress, userAgent)
@@ -96,9 +96,23 @@ func (s *LoginService) handleExistingSession(ctx context.Context, user *storage.
 		}
 	}
 
+	authReq, err := s.store.GetAuthRequestModel(ctx, authRequestID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return &LoginResult{Action: ActionError, Error: "auth_request_not_found", ErrorCode: http.StatusBadRequest}
+	}
+	if err != nil {
+		return &LoginResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+	}
+
 	if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
 		return &LoginResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
 	}
+	s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{
+		"channel":        "browser",
+		"session_id":     sessionID,
+		"client_id":      authReq.ClientID,
+		"reused_session": true,
+	})
 	return &LoginResult{Action: ActionAutoApprove, AuthRequestID: authRequestID}
 }
 

--- a/internal/service/login_unit_test.go
+++ b/internal/service/login_unit_test.go
@@ -69,6 +69,9 @@ func TestLogin_HandleLogin_RecoversPendingDeletionSession(t *testing.T) {
 			calledRecover = true
 			return nil
 		},
+		getAuthRequestModelFn: func(context.Context, string) (*storage.AuthRequestModel, error) {
+			return &storage.AuthRequestModel{ID: "ar-1", ClientID: "client-a"}, nil
+		},
 		completeAuthRequestFn: func(context.Context, string, string) error {
 			calledComplete = true
 			return nil


### PR DESCRIPTION
Closes #131.

## Summary

`handleExistingSession` (skip-IdP path)에서 `auth.login` audit row가 누락되어 audit log가 비대칭이었던 버그를 수정합니다. cold-IdP 경로(`handleCallback`)는 이미 기록 중이라, 두 경로 모두 동일한 metadata 모양으로 기록되도록 정리합니다.

## Why

`internal/service/login.go`:
- `handleCallback` → `auth.login` 기록 ✓
- `handleExistingSession` → 기록 누락 ❌

기존 zitadel 세션이 살아있는 상태에서 OIDC `/authorize`가 들어오면 skip-IdP 경로를 타고 `CompleteAuthRequest` → `ActionAutoApprove`만 반환되고 audit가 빠집니다. 그 결과 `auth.token_revoked`만 보이고 그것을 발생시킨 로그인은 보이지 않습니다 — 즉 같은 사용자가 하루에 여러 번 재인증해도 audit 상으로는 침묵.

## What changed

- `handleSessionLogin` → `handleExistingSession`에 `sessionID` plumb (metadata.session_id parity)
- `handleExistingSession`에서 `GetAuthRequestModel` fetch 후 (recovery 직후, `CompleteAuthRequest` 직전) `auth.login` 기록
- metadata에 `reused_session: true` 추가 — cold-IdP 경로와 구분
- `internal/service/audit_test.go`에 `TestAudit_ReusedSession_AuthLoginRecorded` 통합 테스트 추가

## Why metadata `reused_session` instead of channel rename

기존 cold-IdP 경로의 metadata `channel: "browser"`를 깨면 콘솔/대시보드 호환성 영향. `reused_session` boolean을 추가해 cold 경로는 그대로 두고 새 경로만 분류 가능하게 함.

## Test plan

- [x] `go build ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test -tags=integration -run TestAudit_ReusedSession_AuthLoginRecorded -count=1 ./internal/service/` PASS (Docker testcontainers)
- [x] 관련 회귀 suite (`TestAudit*`, `TestHandleCallback*`, `TestHandleLogin*`, `TestBrowser*`) 전체 PASS — cold-IdP 경로 영향 없음 확인
- [ ] CI 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)