### PR TITLE
feat(clientinfo): trusted-proxy gate + XFF middleware (#135 PR-A)

### DIFF
--- a/internal/clientinfo/clientinfo.go
+++ b/internal/clientinfo/clientinfo.go
@@ -1,0 +1,143 @@
+// Package clientinfo extracts trusted client IP and User-Agent from an HTTP
+// request and threads the result through the request context. It honors
+// X-Forwarded-For only when the request hop is from a trusted proxy CIDR,
+// preventing arbitrary clients from spoofing audit IP.
+package clientinfo
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+// Info carries client identity derived from a request. IP is normalized to a
+// PostgreSQL inet-compatible form (no port, no brackets); an empty string
+// means the source value was missing or unparseable, and downstream callers
+// should treat it the same as "no IP recorded" (i.e. NULL in audit_log).
+// UserAgent is the raw header value with no truncation; storage callers are
+// responsible for any size limits they enforce.
+type Info struct {
+	IP        string
+	UserAgent string
+}
+
+// Extract returns Info derived from r. X-Forwarded-For is honored only when
+// the immediate hop (r.RemoteAddr) falls within one of the trusted CIDRs;
+// otherwise the header is ignored. Pass nil or empty trusted to disable
+// proxy trust entirely (safe default for self-deployed setups).
+func Extract(r *http.Request, trusted []*net.IPNet) Info {
+	if r == nil {
+		return Info{}
+	}
+	hopIP := normalizeAddr(r.RemoteAddr)
+	ip := hopIP
+	if hopIP != "" && isTrustedHop(hopIP, trusted) {
+		if xff := leftmostXFF(r.Header.Get("X-Forwarded-For")); xff != "" {
+			ip = xff
+		}
+	}
+	return Info{IP: ip, UserAgent: r.Header.Get("User-Agent")}
+}
+
+// ParseTrustedProxies parses a comma-separated list of CIDRs ("10.0.0.0/8,
+// 192.168.0.0/16"). Empty input returns (nil, nil) meaning no proxy is
+// trusted. Whitespace-only entries are skipped. Bare IPs without a /mask are
+// rejected — operators must spell CIDRs explicitly to avoid ambiguity. If
+// any single entry is invalid the entire list is rejected with an error,
+// rather than silently using the valid prefix; this keeps the trust set a
+// fail-closed configuration.
+func ParseTrustedProxies(spec string) ([]*net.IPNet, error) {
+	if strings.TrimSpace(spec) == "" {
+		return nil, nil
+	}
+	var nets []*net.IPNet
+	for _, raw := range strings.Split(spec, ",") {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		if !strings.Contains(entry, "/") {
+			return nil, fmt.Errorf("clientinfo: %q must be a CIDR (e.g. 10.0.0.0/8)", entry)
+		}
+		_, cidr, err := net.ParseCIDR(entry)
+		if err != nil {
+			return nil, fmt.Errorf("clientinfo: invalid CIDR %q: %w", entry, err)
+		}
+		nets = append(nets, cidr)
+	}
+	return nets, nil
+}
+
+func isTrustedHop(ip string, trusted []*net.IPNet) bool {
+	if len(trusted) == 0 {
+		return false
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	for _, cidr := range trusted {
+		if cidr.Contains(parsed) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeAddr accepts forms like "1.2.3.4", "1.2.3.4:5678", "[::1]:1234",
+// "::1", and bracketed bare IPv6 ("[::1]"), and returns a bare IP string. It
+// returns "" when the input is missing or unparseable.
+func normalizeAddr(addr string) string {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return ""
+	}
+	if ip, err := netip.ParseAddr(addr); err == nil {
+		return ip.String()
+	}
+	if strings.HasPrefix(addr, "[") && strings.HasSuffix(addr, "]") {
+		if ip, err := netip.ParseAddr(strings.TrimSuffix(strings.TrimPrefix(addr, "["), "]")); err == nil {
+			return ip.String()
+		}
+	}
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		if ip, err := netip.ParseAddr(host); err == nil {
+			return ip.String()
+		}
+	}
+	return ""
+}
+
+// leftmostXFF returns the leftmost client address from an X-Forwarded-For
+// value, normalized to a bare IP. Empty input or unparseable leftmost
+// returns "".
+func leftmostXFF(value string) string {
+	if value == "" {
+		return ""
+	}
+	first, _, _ := strings.Cut(value, ",")
+	return normalizeAddr(first)
+}
+
+type ctxKey struct{}
+
+// WithContext attaches info to ctx. The returned context is suitable for
+// passing to downstream handlers, services, and storage callers that need
+// the client identity for audit-log writes.
+func WithContext(ctx context.Context, info Info) context.Context {
+	return context.WithValue(ctx, ctxKey{}, info)
+}
+
+// FromContext returns the Info attached to ctx via WithContext, or a zero
+// Info if none was attached. It never panics and never returns nil.
+func FromContext(ctx context.Context) Info {
+	if ctx == nil {
+		return Info{}
+	}
+	info, _ := ctx.Value(ctxKey{}).(Info)
+	return info
+}
+

--- a/internal/clientinfo/clientinfo_test.go
+++ b/internal/clientinfo/clientinfo_test.go
@@ -1,0 +1,266 @@
+package clientinfo
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// mustParseTrusted is a tiny test helper so each test case can declare a
+// trusted-CIDR list inline without repeating ParseTrustedProxies error checks.
+func mustParseTrusted(t *testing.T, spec string) []*net.IPNet {
+	t.Helper()
+	nets, err := ParseTrustedProxies(spec)
+	if err != nil {
+		t.Fatalf("ParseTrustedProxies(%q) error: %v", spec, err)
+	}
+	return nets
+}
+
+func TestExtract_NoTrust_UsesRemoteAddr(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "203.0.113.5:51234"
+	got := Extract(r, nil)
+	if got.IP != "203.0.113.5" {
+		t.Fatalf("IP = %q, want 203.0.113.5", got.IP)
+	}
+}
+
+// Spoof prevention: with no trusted proxies the X-Forwarded-For header must be
+// ignored even if a malicious client sets it.
+func TestExtract_NoTrust_IgnoresXFF(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "203.0.113.5:51234"
+	r.Header.Set("X-Forwarded-For", "1.2.3.4")
+	got := Extract(r, nil)
+	if got.IP != "203.0.113.5" {
+		t.Fatalf("IP = %q, want 203.0.113.5 (XFF ignored without trust)", got.IP)
+	}
+}
+
+func TestExtract_Trust_UsesXFFLeftmost(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.244.2.54:443"
+	r.Header.Set("X-Forwarded-For", "1.2.3.4, 5.6.7.8")
+	got := Extract(r, mustParseTrusted(t, "10.244.0.0/16"))
+	if got.IP != "1.2.3.4" {
+		t.Fatalf("IP = %q, want 1.2.3.4", got.IP)
+	}
+}
+
+func TestExtract_Trust_NoXFF_FallsBackToRemoteAddr(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.244.2.54:443"
+	got := Extract(r, mustParseTrusted(t, "10.244.0.0/16"))
+	if got.IP != "10.244.2.54" {
+		t.Fatalf("IP = %q, want 10.244.2.54", got.IP)
+	}
+}
+
+// Spoof prevention: the trust list is non-empty but the actual hop comes from
+// outside that list — the XFF header must be ignored.
+func TestExtract_Trust_RemoteAddrOutsideCIDR_IgnoresXFF(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "198.51.100.7:51234"
+	r.Header.Set("X-Forwarded-For", "1.2.3.4")
+	got := Extract(r, mustParseTrusted(t, "10.244.0.0/16"))
+	if got.IP != "198.51.100.7" {
+		t.Fatalf("IP = %q, want 198.51.100.7 (untrusted hop must not honor XFF)", got.IP)
+	}
+}
+
+func TestExtract_PortStripped_IPv4(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:5678"
+	got := Extract(r, nil)
+	if got.IP != "1.2.3.4" {
+		t.Fatalf("IP = %q, want 1.2.3.4", got.IP)
+	}
+}
+
+func TestExtract_PortStripped_IPv6(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bracketed-with-port", "[2001:db8::1]:5678", "2001:db8::1"},
+		{"loopback-with-port", "[::1]:1234", "::1"},
+		{"bare", "::1", "::1"},
+		{"bracketed-without-port", "[::1]", "::1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/", nil)
+			r.RemoteAddr = tc.in
+			got := Extract(r, nil)
+			if got.IP != tc.want {
+				t.Fatalf("IP for %q = %q, want %q", tc.in, got.IP, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtract_XFFMultipleHops_TakesLeftmost(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.244.0.5:443"
+	r.Header.Set("X-Forwarded-For", "1.2.3.4, 5.6.7.8, 9.0.1.2")
+	got := Extract(r, mustParseTrusted(t, "10.244.0.0/16"))
+	if got.IP != "1.2.3.4" {
+		t.Fatalf("IP = %q, want leftmost 1.2.3.4", got.IP)
+	}
+}
+
+func TestExtract_XFFWhitespaceTrimmed(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.244.0.5:443"
+	r.Header.Set("X-Forwarded-For", "  1.2.3.4  , 5.6.7.8")
+	got := Extract(r, mustParseTrusted(t, "10.244.0.0/16"))
+	if got.IP != "1.2.3.4" {
+		t.Fatalf("IP = %q, want 1.2.3.4", got.IP)
+	}
+}
+
+func TestExtract_UnparseableIP_EmptyResult(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "garbage"
+	got := Extract(r, nil)
+	if got.IP != "" {
+		t.Fatalf("IP = %q, want empty for unparseable input", got.IP)
+	}
+}
+
+func TestExtract_UserAgentPassedThrough(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:443"
+	r.Header.Set("User-Agent", "Mozilla/5.0 (probe)")
+	got := Extract(r, nil)
+	if got.UserAgent != "Mozilla/5.0 (probe)" {
+		t.Fatalf("UA = %q, want Mozilla/5.0 (probe)", got.UserAgent)
+	}
+}
+
+// Garbage XFF (header present but unparseable) must fall back to the trusted
+// hop. Without this guarantee a malformed proxy could silently zero out the
+// audit IP for trusted requests.
+func TestExtract_Trust_GarbageXFF_FallsBackToRemoteAddr(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.244.0.5:443"
+	r.Header.Set("X-Forwarded-For", "not-an-ip")
+	got := Extract(r, mustParseTrusted(t, "10.244.0.0/16"))
+	if got.IP != "10.244.0.5" {
+		t.Fatalf("IP = %q, want 10.244.0.5 (garbage XFF must fall back to trusted hop)", got.IP)
+	}
+}
+
+// IPv6 leftmost in XFF must round-trip correctly through normalization.
+// strings.Cut on the comma is safe because IPv6 addresses don't contain
+// commas, but we exercise it explicitly to lock the contract.
+func TestExtract_Trust_XFFIPv6Leftmost(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.244.0.5:443"
+	r.Header.Set("X-Forwarded-For", "2001:db8::1, 5.6.7.8")
+	got := Extract(r, mustParseTrusted(t, "10.244.0.0/16"))
+	if got.IP != "2001:db8::1" {
+		t.Fatalf("IP = %q, want 2001:db8::1", got.IP)
+	}
+}
+
+func TestExtract_EmptyXFF_FallsBackToRemoteAddr(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.244.0.5:443"
+	r.Header.Set("X-Forwarded-For", "")
+	got := Extract(r, mustParseTrusted(t, "10.244.0.0/16"))
+	if got.IP != "10.244.0.5" {
+		t.Fatalf("IP = %q, want 10.244.0.5", got.IP)
+	}
+}
+
+func TestParseTrustedProxies_Empty_NilNil(t *testing.T) {
+	got, err := ParseTrustedProxies("")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got != nil {
+		t.Fatalf("got = %v, want nil", got)
+	}
+}
+
+func TestParseTrustedProxies_Multiple(t *testing.T) {
+	got, err := ParseTrustedProxies("10.0.0.0/8, 192.168.0.0/16")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].String() != "10.0.0.0/8" || got[1].String() != "192.168.0.0/16" {
+		t.Fatalf("got = %v", got)
+	}
+}
+
+func TestParseTrustedProxies_WhitespaceOnly_Skipped(t *testing.T) {
+	got, err := ParseTrustedProxies("10.0.0.0/8, , 192.168.0.0/16")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (whitespace-only entry must be skipped)", len(got))
+	}
+}
+
+func TestParseTrustedProxies_Invalid_Error(t *testing.T) {
+	cases := []string{
+		"not-a-cidr",
+		"10.0.0.0",     // bare IP, no /mask — must be rejected
+		"10.0.0.0/40",  // mask out of range
+		"::/-1",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if _, err := ParseTrustedProxies(in); err == nil {
+				t.Fatalf("ParseTrustedProxies(%q) err = nil, want non-nil", in)
+			}
+		})
+	}
+}
+
+func TestMiddleware_AttachesContext(t *testing.T) {
+	trusted := mustParseTrusted(t, "10.244.0.0/16")
+	var got Info
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got = FromContext(r.Context())
+	})
+	h := Middleware(trusted)(inner)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.244.2.54:443"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	req.Header.Set("User-Agent", "probe/1.0")
+
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got.IP != "1.2.3.4" {
+		t.Fatalf("ctx IP = %q, want 1.2.3.4", got.IP)
+	}
+	if got.UserAgent != "probe/1.0" {
+		t.Fatalf("ctx UA = %q, want probe/1.0", got.UserAgent)
+	}
+}
+
+func TestFromContext_Absent_ReturnsZeroInfo(t *testing.T) {
+	if got := FromContext(context.Background()); got != (Info{}) {
+		t.Fatalf("FromContext(empty) = %#v, want zero", got)
+	}
+	// nil ctx must not panic and must return zero.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("FromContext(nil) panicked: %v", r)
+		}
+	}()
+	if got := FromContext(nil); got != (Info{}) {
+		t.Fatalf("FromContext(nil) = %#v, want zero", got)
+	}
+}

--- a/internal/clientinfo/middleware.go
+++ b/internal/clientinfo/middleware.go
@@ -1,0 +1,22 @@
+package clientinfo
+
+import (
+	"net"
+	"net/http"
+)
+
+// Middleware extracts client info on every request and attaches it to the
+// request context for downstream handlers and services. It performs no
+// rejection or rewriting of the request itself. The attached Info is always
+// non-nil (zero value when extraction yields no IP), so callers can rely on
+// FromContext returning a usable value without nil checks. Wire it as the
+// outermost http.Handler so the context propagates through every other
+// middleware.
+func Middleware(trusted []*net.IPNet) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			info := Extract(r, trusted)
+			next.ServeHTTP(w, r.WithContext(WithContext(r.Context(), info)))
+		})
+	}
+}


### PR DESCRIPTION
PR-A for #135. **Infrastructure only** — no existing call sites are migrated. PR-B (separate) will wire `TRUSTED_PROXIES` into `cmd/authgate/main.go`, install the middleware, replace `r.RemoteAddr` reads in handlers with `clientinfo.FromContext`, and consolidate `internal/middleware/ratelimit.go`'s `extractIP` into the same path.

Refs #135.

## Summary

신규 패키지 `internal/clientinfo`:
- `Info{IP, UserAgent}` — request에서 추출한 client identity
- `Extract(r, trusted)` — trusted-proxy 게이트로 X-Forwarded-For 처리
- `WithContext` / `FromContext` — context 주입/추출
- `Middleware(trusted)` — 모든 요청에서 Info 추출 후 context 부착
- `ParseTrustedProxies(spec)` — env config 파싱

## Why this is its own PR

main이 5회 연속 sqlc-red 였던 부채를 막 청산했고, 이슈 #134/#135은 동일 root cause(request metadata 흐름이 fragmented)를 가지지만 fix surface가 큽니다. 모든 변경을 한 PR에 묶으면:
1. spoof-prevention 정책이 분산된 PR diff에 묻혀 리뷰가 어려워짐
2. 나중에 trusted-proxy 정책을 바꿀 때 git history에서 단일 커밋으로 추적이 안 됨

## Policy decisions

| 결정 | 선택 | 근거 |
|---|---|---|
| Default trust | **none** (XFF 무시) | self-deployed setups에서 같은 cluster의 임의 pod가 spoof 가능. operator opt-in 강제 |
| Bare IP (`10.0.0.0`) | **reject** | `/32` 자동 변환은 operator가 모르고 단일 host trust로 끝나는 사고 가능 |
| Mixed valid+invalid | **fail closed** | 부분 수용은 trust set이 어느 정도인지 모호. 명료성 우선 |
| `Extract(nil)` / `FromContext(nil)` | **non-nil zero Info** | 다운스트림 caller가 nil 체크 없이 안전 |
| `r.RemoteAddr` mutation | **안 함** | middleware는 추출만, 거부/재작성 없음. 다른 미들웨어에서 raw addr 필요할 수도 |

## Tests

20+ 케이스. 핵심:
- **Spoof 방지** 3 경로: trust 없음+XFF, trust+외부 hop+XFF, trust+IPv6 leftmost
- **정규화**: IPv4 port-strip, IPv6 bracketed/bare/with-port, junk → empty
- **XFF**: leftmost 추출, whitespace trim, empty/garbage fallback, IPv6 leftmost
- **ParseTrustedProxies**: empty → (nil,nil), multiple, whitespace skip, invalid (4 forms) reject
- **Middleware**: context 부착 검증
- **FromContext**: nil ctx panic-free, absent → zero Info

## Out of scope (PR-B 예정)

- `cmd/authgate/main.go` — `TRUSTED_PROXIES` env wiring + middleware install
- `internal/handler/{login,mcp_login,device,account}.go` — `r.RemoteAddr`/`r.UserAgent()` → `clientinfo.FromContext`
- `internal/middleware/ratelimit.go` — `extractIP` 제거 + 단일 진실 통합
- `internal/storage/storage_auth_tokens.go` (#134 fix) — context 기반 IP/UA로 빈 string 채우기
- `internal/service/console.go` (`auth.connection_revoked`, `auth.session_revoked`) 등 빠진 사이트
- `docs/spec/009-operations.md` 환경변수 표 업데이트

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./internal/clientinfo/` 20+ 케이스 PASS
- [x] `go test -count=1 ./...` 전체 회귀 통과
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)