### PR TITLE
fix(handler): consume client IP/UA from clientinfo context (#135)

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/time/rate"
 
 	mcpadapter "github.com/kangheeyong/authgate/internal/adapter/mcp"
+	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/clock"
 	"github.com/kangheeyong/authgate/internal/config"
 	"github.com/kangheeyong/authgate/internal/db/migrator"
@@ -88,8 +89,16 @@ func main() {
 	httpMetrics := observability.NewHTTPMetrics()
 	registerRoutes(mux, cfg, db, store, provider, loginHandler, deviceHandler, accountHandler, mcpLoginHandler, consoleHandler, httpMetrics, &isShuttingDown)
 
-	// Wrap the mux with CORS middleware so all endpoints benefit.
-	corsHandler := middleware.NewCORSMiddleware(allowedOrigins)(mux)
+	trustedProxies, err := clientinfo.ParseTrustedProxies(cfg.TrustedProxies)
+	if err != nil {
+		log.Fatalf("config: TRUSTED_PROXIES: %v", err)
+	}
+
+	// clientinfo wraps the mux so every handler/middleware downstream reads
+	// IP/UA from request context instead of r.RemoteAddr/r.UserAgent() directly.
+	clientInfoHandler := clientinfo.Middleware(trustedProxies)(mux)
+	// CORS sits outside clientinfo because it inspects only the Origin header.
+	corsHandler := middleware.NewCORSMiddleware(allowedOrigins)(clientInfoHandler)
 	// RequestIDMiddleware runs first so every handler has a request ID in context.
 	requestIDHandler := middleware.RequestIDMiddleware(corsHandler)
 

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -74,6 +74,7 @@ authgate를 처음 배포할 때 필요한 것:
 | `RATE_LIMIT_TOKEN_BURST` | X | `60` | 토큰 엔드포인트 버스트 허용 요청 수 (최솟값: 1) |
 | `RATE_LIMIT_AUTH_RPS` | X | `10` | 인증 엔드포인트 (`/authorize`, `/login`) 초당 허용 요청 수 |
 | `RATE_LIMIT_AUTH_BURST` | X | `20` | 인증 엔드포인트 버스트 허용 요청 수 (최솟값: 1) |
+| `TRUSTED_PROXIES` | X | — | `X-Forwarded-For`를 신뢰할 프록시 CIDR (콤마 구분). 비워두면 헤더 무시 (안전한 기본값). 예: `10.244.0.0/16,127.0.0.1/32`. ingress-nginx 등 reverse proxy 뒤에서 운영할 때만 설정. |
 
 `ENABLE_MCP=false`인 경우 `clients.yaml`에 `login_channel: mcp` 항목이 있으면 서버 시작을 거부한다.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,10 @@ type Config struct {
 	RateLimitTokenBurst   int
 	RateLimitAuthRPS      float64
 	RateLimitAuthBurst    int
+	// TrustedProxies is a comma-separated list of CIDRs whose source addresses
+	// are allowed to set X-Forwarded-For. Empty means no proxy is trusted —
+	// the safe default for a deployment without an explicitly configured edge.
+	TrustedProxies        string
 }
 
 func Load() (*Config, error) {
@@ -73,6 +77,7 @@ func Load() (*Config, error) {
 		RateLimitTokenBurst:   envInt("RATE_LIMIT_TOKEN_BURST", 60),
 		RateLimitAuthRPS:      envFloat("RATE_LIMIT_AUTH_RPS", 10),
 		RateLimitAuthBurst:    envInt("RATE_LIMIT_AUTH_BURST", 20),
+		TrustedProxies:        os.Getenv("TRUSTED_PROXIES"),
 	}
 
 	if c.DatabaseURL == "" {

--- a/internal/handler/account.go
+++ b/internal/handler/account.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/service"
 )
 
@@ -33,8 +34,9 @@ func (h *AccountHandler) HandleDeleteAccount(w http.ResponseWriter, r *http.Requ
 	}
 
 	sessionID := getSessionCookie(r)
+	info := clientinfo.FromContext(r.Context())
 
-	result := h.accountService.RequestDeletion(r.Context(), sessionID, r.RemoteAddr, r.UserAgent())
+	result := h.accountService.RequestDeletion(r.Context(), sessionID, info.IP, info.UserAgent)
 
 	w.Header().Set("Content-Type", "application/json")
 	if result.Success {

--- a/internal/handler/device.go
+++ b/internal/handler/device.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"net/http"
 
+	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/pages"
 	"github.com/kangheeyong/authgate/internal/service"
 )
@@ -70,8 +71,9 @@ func (h *DeviceHandler) HandleDevicePage(w http.ResponseWriter, r *http.Request)
 func (h *DeviceHandler) HandleDeviceCallback(w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 	userCode := r.URL.Query().Get("state")
+	info := clientinfo.FromContext(r.Context())
 
-	result := h.deviceService.HandleDeviceCallback(r.Context(), code, userCode, r.RemoteAddr, r.UserAgent())
+	result := h.deviceService.HandleDeviceCallback(r.Context(), code, userCode, info.IP, info.UserAgent)
 
 	switch result.Action {
 	case service.DeviceRedirectBack:
@@ -114,8 +116,9 @@ func (h *DeviceHandler) HandleDeviceApprove(w http.ResponseWriter, r *http.Reque
 	userCode := r.FormValue("user_code")
 	action := r.FormValue("action")
 	sessionID := getSessionCookie(r)
+	info := clientinfo.FromContext(r.Context())
 
-	result := h.deviceService.HandleDeviceApprove(r.Context(), userCode, action, sessionID, r.RemoteAddr, r.UserAgent())
+	result := h.deviceService.HandleDeviceApprove(r.Context(), userCode, action, sessionID, info.IP, info.UserAgent)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if !result.Success && result.ErrorCode != 0 {

--- a/internal/handler/login.go
+++ b/internal/handler/login.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 
+	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/pages"
 	"github.com/kangheeyong/authgate/internal/service"
 )
@@ -25,8 +26,9 @@ func NewLoginHandler(loginService *service.LoginService, devMode bool, brandName
 func (h *LoginHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	authRequestID := r.URL.Query().Get("authRequestID")
 	sessionID := getSessionCookie(r)
+	info := clientinfo.FromContext(r.Context())
 
-	result := h.loginService.HandleLogin(r.Context(), authRequestID, sessionID, r.RemoteAddr, r.UserAgent())
+	result := h.loginService.HandleLogin(r.Context(), authRequestID, sessionID, info.IP, info.UserAgent)
 
 	switch result.Action {
 	case service.ActionRedirectToIdP:
@@ -45,10 +47,9 @@ func (h *LoginHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 func (h *LoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 	authRequestID := r.URL.Query().Get("state")
-	ipAddress := r.RemoteAddr
-	userAgent := r.UserAgent()
+	info := clientinfo.FromContext(r.Context())
 
-	result := h.loginService.HandleCallback(r.Context(), code, authRequestID, ipAddress, userAgent)
+	result := h.loginService.HandleCallback(r.Context(), code, authRequestID, info.IP, info.UserAgent)
 
 	if result.SessionID != "" {
 		setSessionCookie(w, result.SessionID, h.devMode)

--- a/internal/handler/mcp_login.go
+++ b/internal/handler/mcp_login.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 
+	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/pages"
 	"github.com/kangheeyong/authgate/internal/service"
 )
@@ -25,8 +26,9 @@ func NewMCPLoginHandler(loginService *service.MCPLoginService, devMode bool, bra
 func (h *MCPLoginHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	authRequestID := r.URL.Query().Get("authRequestID")
 	sessionID := getSessionCookie(r)
+	info := clientinfo.FromContext(r.Context())
 
-	result := h.loginService.HandleLogin(r.Context(), authRequestID, sessionID, r.RemoteAddr, r.UserAgent())
+	result := h.loginService.HandleLogin(r.Context(), authRequestID, sessionID, info.IP, info.UserAgent)
 
 	switch result.Action {
 	case service.ActionRedirectToIdP:
@@ -44,8 +46,9 @@ func (h *MCPLoginHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 func (h *MCPLoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 	authRequestID := r.URL.Query().Get("state")
+	info := clientinfo.FromContext(r.Context())
 
-	result := h.loginService.HandleCallback(r.Context(), code, authRequestID, r.RemoteAddr, r.UserAgent())
+	result := h.loginService.HandleCallback(r.Context(), code, authRequestID, info.IP, info.UserAgent)
 
 	if result.SessionID != "" {
 		setSessionCookie(w, result.SessionID, h.devMode)

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -2,12 +2,13 @@ package middleware
 
 import (
 	"encoding/json"
-	"net"
 	"net/http"
 	"sync"
 	"time"
 
 	"golang.org/x/time/rate"
+
+	"github.com/kangheeyong/authgate/internal/clientinfo"
 )
 
 type ipLimiter struct {
@@ -39,7 +40,16 @@ func NewRateLimiter(r rate.Limit, b int) func(http.Handler) http.Handler {
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			ip := extractIP(req)
+			ip := clientinfo.FromContext(req.Context()).IP
+			if ip == "" {
+				// Fall back to a fresh extraction (no trusted proxies) when the
+				// clientinfo middleware was not installed — test harnesses and
+				// partially-configured deployments. This preserves limit
+				// behavior and applies the same port/IPv6 normalization the
+				// middleware would, so a single client cannot multiply its
+				// limiter keys by varying source ports.
+				ip = clientinfo.Extract(req, nil).IP
+			}
 			if !rl.allow(ip) {
 				w.Header().Set("Content-Type", "application/json")
 				w.Header().Set("Retry-After", "1")
@@ -90,38 +100,3 @@ func (rl *RateLimiter) evict(maxAge time.Duration) {
 	}
 }
 
-// extractIP returns the client IP, preferring X-Forwarded-For over RemoteAddr.
-func extractIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// Take first (leftmost) address which is the original client.
-		if idx := len(xff); idx > 0 {
-			first := xff
-			for i, c := range xff {
-				if c == ',' {
-					first = xff[:i]
-					break
-				}
-			}
-			ip := net.ParseIP(trimSpace(first))
-			if ip != nil {
-				return ip.String()
-			}
-		}
-	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
-}
-
-func trimSpace(s string) string {
-	start, end := 0, len(s)
-	for start < end && (s[start] == ' ' || s[start] == '\t') {
-		start++
-	}
-	for end > start && (s[end-1] == ' ' || s[end-1] == '\t') {
-		end--
-	}
-	return s[start:end]
-}


### PR DESCRIPTION
Closes #135.

## Summary

PR #136이 머지한 `internal/clientinfo` 패키지를 실제로 install + 모든 handler가 소비하게 마이그레이션. ingress-nginx 뒤 운영 시 audit_log이 진짜 클라이언트 IP를 기록하도록 만듭니다.

PR-B2(별도, **closes #134**) 에서 storage/service의 빈 IP/UA 사이트(`storage_auth_tokens.go:179/246/255/260/414/415`, `service/console.go:233/251`, `service/device.go:192`)를 ctx에서 읽도록 처리할 예정.

## Changes

| 영역 | 파일 | 변경 |
|---|---|---|
| Config | `internal/config/config.go` | `TrustedProxies string` 필드 + `TRUSTED_PROXIES` env. 빈 값 = no proxy trusted (안전 default) |
| Wiring | `cmd/authgate/main.go` | `clientinfo.ParseTrustedProxies` (invalid 시 fatal) + `Middleware` install |
| Handlers | `internal/handler/{login,mcp_login,device,account}.go` | `r.RemoteAddr`/`r.UserAgent()` → `clientinfo.FromContext(r.Context())` |
| Rate limit | `internal/middleware/ratelimit.go` | in-package `extractIP`/`trimSpace` 제거 → `clientinfo.FromContext`로 통합. fallback 포함 |
| Docs | `docs/spec/009-operations.md` | `TRUSTED_PROXIES` 환경변수 표 항목 추가 |

## Middleware order

```
request → RequestID → CORS → ClientInfo → mux → ratelimit → handler
```

- **RequestID 가장 외곽**: 모든 요청이 ID를 가짐 (downstream 어디서 fail해도 추적 가능)
- **CORS는 ClientInfo 외부**: Origin 헤더만 검사하므로 client IP 불필요
- **ClientInfo는 mux 직전**: 모든 path별 미들웨어(ratelimit 등)가 자동으로 ctx에서 IP 읽음

## 보안 변경 — rate limit bypass 차단

기존 `extractIP`는 X-Forwarded-For를 **무조건** 신뢰했습니다. 즉 공격자가 임의 IP를 헤더로 박으면 rate limit 회피 가능. 이번 변경 후 ratelimit이 `clientinfo.FromContext`를 사용하므로:
- `TRUSTED_PROXIES` 미설정 (안전 default): XFF 무시 → 실제 hop IP로 limit
- `TRUSTED_PROXIES` 설정: trusted hop에서 온 요청만 XFF 신뢰

→ **trusted proxy 뒤에선 진짜 client IP로 limit**, **untrusted origin은 spoof 못 함**.

## Out of scope (PR-B2 예정)

- `internal/storage/storage_auth_tokens.go` (#134): `TerminateSession`/`RevokeToken`/refresh 경로의 빈 IP/UA. zitadel `op.Storage` 시그니처 변경 불가라 ctx 기반 plumbing 필요
- `internal/service/console.go:233/251`: `auth.connection_revoked`/`auth.session_revoked` IP/UA
- `internal/service/device.go:192`: 세션 재사용 device page IP/UA
- `storage_auth_tokens.go:414/415`: refresh reuse 한 쌍

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./...` 전체 회귀 통과
- [x] `r.RemoteAddr` 잔존 grep 검증 — handler/middleware/cmd에 의도된 잔존(ratelimit fallback + 주석) 외 없음
- [ ] CI 전체 통과
- [ ] `go test -tags=integration ./...` (CI에서 실행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)