### PR TITLE
fix(audit): record IP/UA on token-revoke, logout, console actions (#134)

### DIFF
--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/storage"
 )
 
@@ -230,7 +231,8 @@ func (s *ConsoleService) RevokeConnection(ctx context.Context, sessionID, authHe
 	if err := s.store.RevokeConnection(ctx, auth.user.ID, clientID); err != nil {
 		return &RevokeConnectionResult{ErrorCode: http.StatusInternalServerError}
 	}
-	s.store.AuditLog(ctx, &auth.user.ID, "auth.connection_revoked", "", "", map[string]any{"client_id": clientID})
+	info := clientinfo.FromContext(ctx)
+	s.store.AuditLog(ctx, &auth.user.ID, "auth.connection_revoked", info.IP, info.UserAgent, map[string]any{"client_id": clientID})
 	return &RevokeConnectionResult{}
 }
 
@@ -248,7 +250,8 @@ func (s *ConsoleService) RevokeSession(ctx context.Context, sessionID, authHeade
 	if err := s.store.RevokeSession(ctx, auth.user.ID, revokeSessionID); err != nil {
 		return &RevokeSessionResult{ErrorCode: http.StatusInternalServerError}
 	}
-	s.store.AuditLog(ctx, &auth.user.ID, "auth.session_revoked", "", "", map[string]any{"session_id": revokeSessionID})
+	info := clientinfo.FromContext(ctx)
+	s.store.AuditLog(ctx, &auth.user.ID, "auth.session_revoked", info.IP, info.UserAgent, map[string]any{"session_id": revokeSessionID})
 	return &RevokeSessionResult{}
 }
 

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/clock"
 	"github.com/kangheeyong/authgate/internal/storage"
 	"github.com/kangheeyong/authgate/internal/upstream"
@@ -189,7 +190,8 @@ func (s *DeviceService) ensureDeviceSessionAccess(ctx context.Context, user *sto
 		return nil
 	}
 
-	s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", "", "", map[string]any{"status": user.Status, "channel": "device"})
+	info := clientinfo.FromContext(ctx)
+	s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", info.IP, info.UserAgent, map[string]any{"status": user.Status, "channel": "device"})
 	return &DevicePageResult{Action: DeviceError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
 }
 

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -10,6 +10,7 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"github.com/zitadel/oidc/v3/pkg/op"
 
+	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/db/storeq"
 )
 
@@ -176,7 +177,8 @@ func (s *Storage) CreateAccessAndRefreshTokens(ctx context.Context, request op.T
 
 	// Audit token.refresh only when this is a refresh-token grant (not the initial code exchange).
 	if currentRefreshToken != "" {
-		s.AuditLog(ctx, &derived.userID, EventTokenRefresh, "", "", map[string]any{
+		info := clientinfo.FromContext(ctx)
+		s.AuditLog(ctx, &derived.userID, EventTokenRefresh, info.IP, info.UserAgent, map[string]any{
 			"client_id": derived.clientID,
 			"family_id": derived.familyID,
 		})
@@ -243,21 +245,23 @@ func (s *Storage) TerminateSession(ctx context.Context, userID string, clientID 
 	if err != nil {
 		return err
 	}
-	s.AuditLog(ctx, &userID, EventAuthLogout, "", "", nil)
+	info := clientinfo.FromContext(ctx)
+	s.AuditLog(ctx, &userID, EventAuthLogout, info.IP, info.UserAgent, nil)
 	return nil
 }
 
 func (s *Storage) RevokeToken(ctx context.Context, tokenOrTokenID string, userID string, clientID string) *oidc.Error {
 	now := s.clock.Now()
 	q := storeq.New(s.db)
+	info := clientinfo.FromContext(ctx)
 
 	if tryRevokeRefreshByHash(ctx, q, tokenOrTokenID, now) {
-		s.AuditLog(ctx, &userID, EventAuthTokenRevoked, "", "", map[string]any{"client_id": clientID})
+		s.AuditLog(ctx, &userID, EventAuthTokenRevoked, info.IP, info.UserAgent, map[string]any{"client_id": clientID})
 		return nil
 	}
 
 	if tryRevokeRefreshByIDReturning(ctx, q, tokenOrTokenID, now) {
-		s.AuditLog(ctx, &userID, EventAuthTokenRevoked, "", "", map[string]any{"client_id": clientID})
+		s.AuditLog(ctx, &userID, EventAuthTokenRevoked, info.IP, info.UserAgent, map[string]any{"client_id": clientID})
 	}
 
 	// RFC 7009: always return 200 regardless of whether anything was revoked
@@ -411,8 +415,9 @@ func revokeRefreshFamilyOnReuse(ctx context.Context, qtx *storeq.Queries, family
 }
 
 func (s *Storage) auditRefreshReuseDetection(ctx context.Context, userID, familyID string) {
-	s.AuditLog(ctx, &userID, "auth.refresh_reuse_detected", "", "", map[string]any{"family_id": familyID})
-	s.AuditLog(ctx, &userID, "auth.refresh_family_revoked", "", "", map[string]any{"family_id": familyID})
+	info := clientinfo.FromContext(ctx)
+	s.AuditLog(ctx, &userID, "auth.refresh_reuse_detected", info.IP, info.UserAgent, map[string]any{"family_id": familyID})
+	s.AuditLog(ctx, &userID, "auth.refresh_family_revoked", info.IP, info.UserAgent, map[string]any{"family_id": familyID})
 }
 
 func (s *Storage) validateRefreshTokenRequest(ctx context.Context, tx *sql.Tx, rt *RefreshTokenModel, now time.Time) error {


### PR DESCRIPTION
Closes #134.

## Summary

PR #137이 모든 요청에 `clientinfo.FromContext`로 client IP/UA를 ctx에 박았으니, 아직 빈 string을 넘기던 storage / console-service / device-service 호출처들이 ctx에서 읽도록 정리합니다. audit_log이 token-revoke / logout / console actions에서 NULL이 아닌 실제 값을 기록.

## What changed

| 파일 | 이벤트 |
|---|---|
| `internal/storage/storage_auth_tokens.go` | `auth.logout`, `auth.token_revoked` (2곳), `token.refresh`, `auth.refresh_reuse_detected`, `auth.refresh_family_revoked` |
| `internal/service/console.go` | `auth.connection_revoked`, `auth.session_revoked` |
| `internal/service/device.go` | `auth.inactive_user` (device-page 세션 재사용 경로) |

## Why context-based, not signature change

`Storage.TerminateSession`, `Storage.RevokeToken`은 zitadel `op.Storage` 인터페이스 메서드라 시그니처 추가 불가. 다행히 OIDC framework이 이미 `context.Context`를 통과시키므로, `clientinfo.FromContext(ctx)`로 동일한 IP/UA를 끌어올 수 있음. PR #137에서 `clientinfo.Middleware`가 mux 외곽에 install되어 모든 OIDC 요청 ctx에도 자동 부착됨.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./...` 전체 회귀 통과
- [ ] CI 전체 통과 (특히 통합 테스트 — audit_log row의 ip_address/user_agent 검증 회귀 없음 확인)

## Out of scope

- `cleanup_runner.go`의 `auth.deletion_completed` 빈 IP/UA — cleanup 잡은 사용자 ctx 없음. background job 컨텍스트라 의도된 NULL.
- audit_log 보존 정책 / 인덱스 / 이벤트 카탈로그 통합은 별도 P2 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)