### PR TITLE
fix(storage): drop stray tx.Commit in validateRefreshTokenRequest

### DIFF
--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -422,24 +422,20 @@ func (s *Storage) auditRefreshReuseDetection(ctx context.Context, userID, family
 
 func (s *Storage) validateRefreshTokenRequest(ctx context.Context, tx *sql.Tx, rt *RefreshTokenModel, now time.Time) error {
 	if now.After(rt.ExpiresAt) {
-		_ = tx.Commit()
 		return op.ErrInvalidRefreshToken
 	}
 
 	requestResource := ResourceFromContext(ctx)
 	if err := s.resourcePolicy.ValidateTokenRequest(ctx, rt.ClientID, rt.Resource, requestResource); err != nil {
-		_ = tx.Commit()
 		return err
 	}
 
 	if s.stateChecker != nil {
 		user, err := s.getUserByID(ctx, tx, rt.UserID)
 		if err != nil {
-			_ = tx.Commit()
 			return op.ErrInvalidRefreshToken
 		}
 		if err := s.stateChecker(user); err != nil {
-			_ = tx.Commit()
 			return &oidc.Error{ErrorType: "invalid_grant", Description: err.Error()}
 		}
 	}


### PR DESCRIPTION
## Summary
- `validateRefreshTokenRequest` 내 `_ = tx.Commit()` 4회 호출 제거
- 호출자(`TokenRequestByRefreshToken`)는 이미 `defer tx.Rollback()` 보유 → deferred rollback이 cleanup 담당

## Why
- 검증 실패 분기에서 tx.Commit 후 error 반환 → caller의 deferred rollback이 `sql.ErrTxDone`을 묵살
- 현재는 read-only 트랜잭션이라 무해하지만, 이 path에 mutation이 추가되는 순간 **부분 커밋** 위험
- 의미적으로도 "검증 실패한 요청에서 빈 트랜잭션을 일부러 commit"하는 형태라 어색

## Test plan
- [x] `go build ./...` 통과
- [x] `go test ./internal/storage/...` 통과
- [ ] integration 테스트 (`go test -tags=integration ./...`) — 리뷰어 환경에서 확인 권장