### PR TITLE
fix(handler): reject DELETE /account when Origin header is absent

### DIFF
--- a/internal/handler/account.go
+++ b/internal/handler/account.go
@@ -24,13 +24,14 @@ func (h *AccountHandler) HandleDeleteAccount(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Origin validation for destructive action
-	if origin := r.Header.Get("Origin"); origin != "" {
-		if origin != h.publicURL {
-			w.WriteHeader(http.StatusForbidden)
-			json.NewEncoder(w).Encode(map[string]string{"error": "origin mismatch"})
-			return
-		}
+	// Origin validation for destructive action.
+	// Require Origin to be present and match publicURL — protects against
+	// non-browser clients (curl, etc.) bypassing CSRF protection.
+	origin := r.Header.Get("Origin")
+	if origin == "" || origin != h.publicURL {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"error": "origin mismatch"})
+		return
 	}
 
 	sessionID := getSessionCookie(r)

--- a/internal/handler/account_test.go
+++ b/internal/handler/account_test.go
@@ -51,6 +51,24 @@ func TestDeleteAccount_OriginMismatch_Forbidden(t *testing.T) {
 	}
 }
 
+func TestDeleteAccount_OriginAbsent_Forbidden(t *testing.T) {
+	h := newTestAccountHandler()
+	req := httptest.NewRequest(http.MethodDelete, "/account", nil)
+	// Origin header intentionally not set
+	w := httptest.NewRecorder()
+	h.HandleDeleteAccount(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for absent origin", w.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+	if body["error"] == "" {
+		t.Error("response JSON should contain non-empty error field")
+	}
+}
+
 // Origin이 publicURL과 정확히 일치하면 origin 체크를 통과해야 한다.
 // (이후 service 호출까지 진행 — nil service이므로 panic; recover로 확인)
 func TestDeleteAccount_OriginMatch_PassesOriginCheck(t *testing.T) {
@@ -82,6 +100,7 @@ func TestDeleteAccount_NoSession_Unauthorized(t *testing.T) {
 	h := NewAccountHandler(svc, "http://authgate.example.com")
 
 	req := httptest.NewRequest(http.MethodDelete, "/account", nil)
+	req.Header.Set("Origin", "http://authgate.example.com")
 	w := httptest.NewRecorder()
 	h.HandleDeleteAccount(w, req)
 


### PR DESCRIPTION
## Summary
- `HandleDeleteAccount`이 Origin 헤더 부재 시 통과하던 분기를 막음
- 신규 테스트 `TestDeleteAccount_OriginAbsent_Forbidden` 추가
- 기존 `TestDeleteAccount_NoSession_Unauthorized`에 matching Origin 추가 (의도 보존)

## Why
- DELETE /account는 비가역 destructive op
- Origin 없는 non-browser 클라이언트(curl, 스크립트, 일부 프록시)가 세션 쿠키만으로 호출 가능했음
- SameSite=Lax + Origin-only 검증으로는 CSRF 모델로 부족 → Origin **필수화**

## Test plan
- [x] \`go test ./internal/handler/...\` 통과 (NoSession 401, OriginAbsent 403, OriginMismatch 403, OriginMatch passes)
- [ ] integration 테스트 (\`go test -tags=integration ./...\`) — 리뷰어 환경에서 확인 권장

## Note
- 이 변경으로 Origin 헤더를 보내지 않는 모든 클라이언트는 403을 받음
- 운영 중 정상 사용 케이스(브라우저 BFF)는 Origin 항상 송신하므로 영향 없음