### PR TITLE
fix(audit): record auth.other_sessions_revoked on bulk session revoke

### DIFF
--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -269,6 +269,8 @@ func (s *ConsoleService) RevokeOtherSessions(ctx context.Context, sessionID, aut
 	if err := s.store.RevokeOtherSessions(ctx, auth.user.ID, auth.sessionID); err != nil {
 		return &RevokeOtherSessionsResult{ErrorCode: http.StatusInternalServerError}
 	}
+	info := clientinfo.FromContext(ctx)
+	s.store.AuditLog(ctx, &auth.user.ID, "auth.other_sessions_revoked", info.IP, info.UserAgent, map[string]any{"current_session_id": auth.sessionID})
 	return &RevokeOtherSessionsResult{}
 }
 

--- a/internal/service/console_unit_test.go
+++ b/internal/service/console_unit_test.go
@@ -564,6 +564,30 @@ func TestConsole_RevokeOtherSessions_RevokesExceptCurrent(t *testing.T) {
 	}
 }
 
+func TestConsole_RevokeOtherSessions_AuditLogged(t *testing.T) {
+	var gotEventType string
+	var gotMetadata map[string]any
+	store := activeUserStore(nil, nil)
+	store.revokeOtherSessionsFn = func(ctx context.Context, userID, currentSessionID string) error {
+		return nil
+	}
+	store.auditLogFn = func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
+		gotEventType = eventType
+		gotMetadata = metadata
+	}
+	svc := NewConsoleService(store)
+	r := svc.RevokeOtherSessions(context.Background(), "sess-1", "")
+	if r.ErrorCode != 0 {
+		t.Fatalf("want success, got %d", r.ErrorCode)
+	}
+	if gotEventType != "auth.other_sessions_revoked" {
+		t.Fatalf("audit event=%q, want auth.other_sessions_revoked", gotEventType)
+	}
+	if gotMetadata["current_session_id"] != "sess-1" {
+		t.Fatalf("audit metadata current_session_id=%v, want sess-1", gotMetadata["current_session_id"])
+	}
+}
+
 // --- Audit log ---
 
 func TestConsole_GetAuditLog_DefaultsAndFormats(t *testing.T) {


### PR DESCRIPTION
## Summary
- \`ConsoleService.RevokeOtherSessions\`가 audit 호출 누락이던 것 수정
- 신규 단위 테스트 \`TestConsole_RevokeOtherSessions_AuditLogged\` 추가

## Why
- 같은 파일의 \`RevokeSession\`/\`RevokeConnection\`은 이미 audit 정상 기록 중
- 일괄 세션 폐기가 가장 보안상 중요한 console 작업인데 흔적 없이 수행되던 문제
- 최근 #134 PR(\`fix(audit): record IP/UA on token-revoke, logout, console actions\`)이 메운 갭과 동일 클래스

## Design
- 이벤트 이름: \`auth.other_sessions_revoked\` — 기존 convention과 정합
- metadata: \`{"current_session_id": auth.sessionID}\` — 일괄 폐기를 트리거한 세션 추적용

## Test plan
- [x] \`go test ./internal/service/...\` 통과 (61 PASS)
- [ ] integration 테스트 — 리뷰어 환경에서 확인 권장

## Doc sync needed
- \`docs/spec/006-account-lifecycle.md\` 또는 \`004-mcp-login.md\`에 \`auth.other_sessions_revoked\` 이벤트 추가 (별도 PR)