### PR TITLE
fix(storage): log DB errors from refresh-token revoke helpers

### DIFF
--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -448,10 +449,14 @@ func (s *Storage) validateRefreshTokenRequest(ctx context.Context, tx *sql.Tx, r
 
 func tryRevokeRefreshByHash(ctx context.Context, q *storeq.Queries, tokenOrTokenID string, now time.Time) bool {
 	h := hashToken(tokenOrTokenID)
-	rows, _ := q.RevokeRefreshTokenByHash(ctx, storeq.RevokeRefreshTokenByHashParams{
+	rows, err := q.RevokeRefreshTokenByHash(ctx, storeq.RevokeRefreshTokenByHashParams{
 		RevokedAt: sql.NullTime{Time: now, Valid: true},
 		TokenHash: h,
 	})
+	if err != nil {
+		slog.ErrorContext(ctx, "revoke refresh token by hash", "error", err)
+		return false
+	}
 	return rows > 0
 }
 
@@ -473,7 +478,11 @@ func tryRevokeRefreshByIDReturning(ctx context.Context, q *storeq.Queries, token
 		RevokedAt: sql.NullTime{Time: now, Valid: true},
 		ID:        tokenOrTokenID,
 	})
-	return err == nil
+	if err != nil {
+		slog.ErrorContext(ctx, "revoke refresh token by id", "error", err)
+		return false
+	}
+	return true
 }
 
 // GetAuthRequestModel fetches the auth request by ID and returns the concrete model.


### PR DESCRIPTION
## Summary
- \`tryRevokeRefreshByHash\` / \`tryRevokeRefreshByIDReturning\`가 DB 에러를 \`_\`로 묵살하던 것 수정
- 에러 시 \`slog.ErrorContext\` 기록 후 false 반환

## Why
- caller \`RevokeToken\`은 RFC 7009대로 항상 200 반환
- 결과적으로 **DB 장애가 200 OK로 외부에 보고**되어 운영자가 인지 불가
- HTTP 동작은 그대로 두고, 로그로만 가시화

## Design
- \`audit.go\` 패턴(error만, 토큰값 미포함) 그대로 따름
- 단위 테스트 추가 안 함 — 동작 변화 없음 (slog handler mock은 별도 작업)

## Test plan
- [x] \`go build ./...\` PASS
- [x] \`go test ./internal/storage/...\` PASS
- [x] \`go vet ./...\` PASS

## Note
- \`tryRevokeRefreshByID\` (dead code, L7로 분류된 별도 cleanup 대상)는 이번 PR에서 손대지 않음