### PR TITLE
fix(handler): return error from generateCSRFToken instead of panic

### DIFF
--- a/internal/handler/device.go
+++ b/internal/handler/device.go
@@ -41,7 +41,13 @@ func (h *DeviceHandler) HandleDevicePage(w http.ResponseWriter, r *http.Request)
 		})
 
 	case service.DeviceShowApprove:
-		csrfToken := generateCSRFToken()
+		csrfToken, err := generateCSRFToken()
+		if err != nil {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusInternalServerError)
+			pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: http.StatusInternalServerError, Message: "internal error"})
+			return
+		}
 		http.SetCookie(w, &http.Cookie{
 			Name:     "csrf_token",
 			Value:    csrfToken,
@@ -131,10 +137,10 @@ func (h *DeviceHandler) HandleDeviceApprove(w http.ResponseWriter, r *http.Reque
 	})
 }
 
-func generateCSRFToken() string {
+func generateCSRFToken() (string, error) {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
-		panic("crypto/rand failed: " + err.Error())
+		return "", err
 	}
-	return hex.EncodeToString(b)
+	return hex.EncodeToString(b), nil
 }


### PR DESCRIPTION
## Summary
- \`generateCSRFToken\` 시그니처를 \`() string\` → \`() (string, error)\`로 변경
- \`HandleDevicePage\`의 \`DeviceShowApprove\` 분기에서 에러 시 500 페이지 렌더

## Why
- crypto/rand 실패 시 panic은 net/http가 캐치하지만 stack trace 노출 위험 + 패턴이 다른 핸들러로 전파될 수 있음
- crypto/rand 실패는 운영상 의미 있는 알람 — programmer error가 아닌 operational error로 다뤄야 함

## Test plan
- [x] \`go build ./...\` PASS
- [x] \`go test ./internal/handler/...\` PASS
- [x] \`go vet ./...\` PASS

## Note
- crypto/rand 실패 mocking 단위 테스트는 별도 작업 (현재는 정상 흐름만 검증)