### PR TITLE
fix(handler): set session cookie only on ActionAutoApprove path

### DIFF
--- a/internal/handler/login.go
+++ b/internal/handler/login.go
@@ -51,12 +51,11 @@ func (h *LoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 
 	result := h.loginService.HandleCallback(r.Context(), code, authRequestID, info.IP, info.UserAgent)
 
-	if result.SessionID != "" {
-		setSessionCookie(w, result.SessionID, h.devMode)
-	}
-
 	switch result.Action {
 	case service.ActionAutoApprove:
+		if result.SessionID != "" {
+			setSessionCookie(w, result.SessionID, h.devMode)
+		}
 		http.Redirect(w, r, "/authorize/callback?id="+result.AuthRequestID, http.StatusFound)
 
 	case service.ActionError:

--- a/internal/handler/mcp_login.go
+++ b/internal/handler/mcp_login.go
@@ -50,12 +50,11 @@ func (h *MCPLoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request)
 
 	result := h.loginService.HandleCallback(r.Context(), code, authRequestID, info.IP, info.UserAgent)
 
-	if result.SessionID != "" {
-		setSessionCookie(w, result.SessionID, h.devMode)
-	}
-
 	switch result.Action {
 	case service.ActionAutoApprove:
+		if result.SessionID != "" {
+			setSessionCookie(w, result.SessionID, h.devMode)
+		}
 		http.Redirect(w, r, "/authorize/callback?id="+result.AuthRequestID, http.StatusFound)
 	case service.ActionError:
 		h.renderError(w, result.ErrorCode, result.Error)


### PR DESCRIPTION
## Summary
- \`LoginHandler.HandleCallback\` / \`MCPLoginHandler.HandleCallback\`에서 \`setSessionCookie\` 호출을 switch 이전 → \`case ActionAutoApprove:\` 안으로 이동

## Why
- 기존 코드는 service 레이어가 항상 \`AutoApprove\`에서만 SessionID를 채운다는 invariant에 의존
- service가 SessionID를 채우고 후속 검증에서 \`ActionError\`를 반환하는 경로가 추가되는 순간 → 에러 분기에서도 세션 쿠키가 클라이언트에 발급
- 핸들러 레벨에서 invariant를 강제

## Test plan
- [x] \`go build ./...\` PASS
- [x] \`go test ./internal/handler/...\` PASS
- [x] \`go vet ./...\` PASS

## Note
- 현재 service 구현 기준으로는 동작 변화 없음 (정상 흐름 동일)
- 회귀 테스트(서비스가 SessionID + ActionError 반환할 때 cookie 미발급)는 별도 design 필요