### PR TITLE
docs(storage): document clientinfo import as intentional layer exception

### DIFF
--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -11,6 +11,12 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"github.com/zitadel/oidc/v3/pkg/op"
 
+	// clientinfo is imported here as an intentional exception to the usual
+	// handler→service→storage layering. The op.Storage interface methods in
+	// this file (CreateAccessAndRefreshTokens, TerminateSession, RevokeToken,
+	// TokenRequestByRefreshToken) are dictated by zitadel-oidc and cannot
+	// take IP/UA as explicit parameters. The clientinfo middleware is
+	// required to populate the request context before these methods run.
 	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/db/storeq"
 )


### PR DESCRIPTION
## Summary
- \`internal/storage/storage_auth_tokens.go\`의 \`clientinfo\` import 위에 주석 블록 추가
- "왜 storage가 clientinfo를 import하는가" — op.Storage 인터페이스 제약 명시

## Why
- 코드 리뷰(H3)에서 \`storage → clientinfo\` 의존이 계층 역행으로 지적됨
- 그러나 \`*Storage\`가 zitadel-oidc \`op.Storage\` 인터페이스를 구현 중이고, 관련 메서드들(\`CreateAccessAndRefreshTokens\`, \`TerminateSession\`, \`RevokeToken\`, \`TokenRequestByRefreshToken\`)은 시그니처 변경 불가
- ctx에서 추출하는 패턴은 구조적으로 유일한 선택지 → 의도된 예외임을 명시
- 향후 읽는 사람이 잘못된 "리팩터" 시도하지 않도록 가드

## Test plan
- [x] \`go build ./...\` PASS
- [x] \`go vet ./...\` PASS
- 동작 변화 없음 (주석만 추가)

## Note
- 이 결정은 별도 ADR로 정식화하는 것도 고려 가능 (docs/architecture/ 에 컴포넌트 경계 ADR이 있음)
- 본 PR은 코드 인라인 주석으로 즉시 가시화