### PR TITLE
fix(build): exclude signing_key.pem and secrets from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Secrets — must never enter the Docker build context.
+# signing_key.pem in particular: it is the RSA private key used to sign
+# every access_token/id_token. If it lands in a builder layer that gets
+# pushed as a cache image, the entire fleet's tokens become forgeable.
+signing_key.pem
+*.pem
+*.key
+.env
+.env.*
+
+# Pre-built binaries and test artifacts (must be rebuilt inside the image).
+authgate
+*.test
+*.out
+coverage*
+
+# VCS and local tooling.
+.git
+.gitignore
+.gitmodules
+.github
+.vscode
+.idea
+.claude
+.omc
+.gobin
+.gocache
+.playwright-mcp
+.repos
+
+# Documentation and local screenshots.
+*.png
+docs
+
+# Build outputs and OS files.
+.DS_Store
+node_modules

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -112,6 +112,8 @@ chmod 600 signing_key.pem
 # 교체: 아래 "키 로테이션" 참조
 ```
 
+**Docker 빌드 컨텍스트에 포함 금지.** 리포 루트의 `signing_key.pem`이 `COPY . .`로 builder 레이어에 진입하면 GHCR에 푸시되는 빌더 캐시(예: `cache-to=type=registry`)나 멀티스테이지 캐시 공유를 통해 RSA private key가 노출될 수 있다. `.dockerignore`가 `signing_key.pem`, `*.pem`, `*.key`, `.env*`를 차단하고 있으니 변경 시 항상 유지하라. 운영에서는 키 파일을 빌드 컨텍스트에 두지 말고 Kubernetes Secret / Vault 등 런타임 시크릿으로 컨테이너에 주입하라.
+
 ### client_secret (각 앱별)
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds `.dockerignore` so `signing_key.pem`, `*.pem`, `*.key`, `.env*`, pre-built binaries (`authgate`, `*.test`), coverage outputs, and local tooling caches never enter the Docker build context
- Adds a security note to `docs/spec/009-operations.md` (the existing `signing_key.pem` section) explaining the constraint and pointing operators to runtime secret injection

## Why

`Dockerfile:8` runs `COPY . .` inside the builder stage. Without `.dockerignore`, the local `signing_key.pem` enters the builder layer at every release. The release workflow pushes the final image to GHCR (`.github/workflows/release.yml:52-60`), and any builder-layer cache push (or accidental layer leak) would expose the production RSA private key — token forgery → universal account takeover.

## Verification

- `docker build --target builder -t authgate-test-builder .` succeeded
- Inside the builder: `find /app -name "signing_key.pem" -o -name "*.key" -o -name ".env"` → empty
- `find /app -name "*.test"` → empty
- `/app/authgate` (pre-built binary) → not present, as expected
- Required build inputs (`go.mod`, `go.sum`, `cmd/`, `internal/`, `migrations/`, `VERSION`) are not in `.dockerignore`

## Test plan

- [ ] Reviewer confirms `.dockerignore` does not exclude any path the Dockerfile relies on
- [ ] CI build (release workflow) succeeds on this branch's image build path
- [ ] Audit any GHCR images already pushed: confirm none contain `signing_key.pem` (separate operational follow-up — not in scope of this PR)

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)