### PR TITLE
fix(handler): use constant-time compare for device CSRF token

### DIFF
--- a/internal/handler/device.go
+++ b/internal/handler/device.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"net/http"
 
@@ -113,7 +114,7 @@ func (h *DeviceHandler) HandleDeviceApprove(w http.ResponseWriter, r *http.Reque
 	if c, err := r.Cookie("csrf_token"); err == nil {
 		cookieToken = c.Value
 	}
-	if formToken == "" || formToken != cookieToken {
+	if formToken == "" || subtle.ConstantTimeCompare([]byte(formToken), []byte(cookieToken)) != 1 {
 		w.WriteHeader(http.StatusForbidden)
 		pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: 403, Message: "CSRF validation failed"})
 		return


### PR DESCRIPTION
## Summary

Replaces `formToken != cookieToken` in the `/device/approve` CSRF check with `subtle.ConstantTimeCompare`. The leading empty-form-token guard remains so a zero-length submission cannot match a zero-length cookie.

## Why

`!=` on Go strings short-circuits at the first differing byte, exposing the comparison to a timing oracle. The token is 16 bytes (128 bits) of entropy from `crypto/rand` — sufficient — but the comparison itself must not leak position-of-first-mismatch information.

## Verification

- `go build ./...` clean
- `go test ./internal/handler/...` passes (`ok  internal/handler 0.467s`)

## Test plan

- [ ] Confirm `/device/approve` still rejects mismatched tokens (returns 403)
- [ ] Confirm valid cookie+form pairs still pass

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)