### PR TITLE
fix(handler): set session cookie SameSite=Strict to block cross-site auto-approve

### DIFF
--- a/internal/handler/session_cookie.go
+++ b/internal/handler/session_cookie.go
@@ -10,7 +10,7 @@ func setSessionCookie(w http.ResponseWriter, sessionID string, devMode bool) {
 		Value:    sessionID,
 		Path:     "/",
 		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
+		SameSite: http.SameSiteStrictMode,
 		Secure:   !devMode,
 	})
 }

--- a/internal/integration/integration_account_test.go
+++ b/internal/integration/integration_account_test.go
@@ -90,7 +90,7 @@ func TestIntegration_DeleteAccount_InactiveUser_Rejected(t *testing.T) {
 	}
 }
 
-// handler-login: session cookie HttpOnly / SameSite=Lax / Secure=false(devMode) 속성 검증
+// handler-login: session cookie HttpOnly / SameSite=Strict / Secure=false(devMode) 속성 검증
 func TestIntegration_DeleteAccount_ResponseShape(t *testing.T) {
 	ts := SetupTestServer(t)
 	ctx := context.Background()

--- a/internal/integration/integration_browser_test.go
+++ b/internal/integration/integration_browser_test.go
@@ -165,8 +165,8 @@ func TestIntegration_SessionCookie_Attributes(t *testing.T) {
 	if !sessionCookie.HttpOnly {
 		t.Error("session cookie: HttpOnly should be true")
 	}
-	if sessionCookie.SameSite != http.SameSiteLaxMode {
-		t.Errorf("session cookie: SameSite = %v, want Lax", sessionCookie.SameSite)
+	if sessionCookie.SameSite != http.SameSiteStrictMode {
+		t.Errorf("session cookie: SameSite = %v, want Strict", sessionCookie.SameSite)
 	}
 	// devMode=true in TestServer → Secure must be false
 	if sessionCookie.Secure {


### PR DESCRIPTION
## Summary

- Switches the `authgate_session` cookie from `SameSite=Lax` to `SameSite=Strict`
- Updates the browser integration assertion (`internal/integration/integration_browser_test.go`) and a stale inline comment in `internal/integration/integration_account_test.go`

## Why

`SameSite=Lax` sends the session cookie on top-level cross-site GET navigations. Combined with the auto-approve path at `/login?authRequestID=...`, an attacker can craft a phishing link that uses the victim's existing session to silently complete an auth_request and harvest the resulting code at the registered redirect_uri.

`Strict` blocks that path. The legitimate OAuth flow is unaffected because:

1. The cross-site entry is `/authorize` (handled by zitadel/oidc op) which does **not** read the session cookie
2. `/authorize` issues a same-site 302 to `/login?authRequestID=...`
3. Browsers treat that same-site redirect as a same-site request — Strict cookies are sent — so the auto-approve UX still works for users arriving via the standard OAuth flow

## Verification

- `go build ./...` clean
- `go test ./internal/handler/... ./internal/service/...` pass
- `go test -tags=integration ./internal/integration/... -timeout=120s` pass (`ok internal/integration 59.4s`)

## Test plan

- [ ] Manual: legitimate "Sign in with authgate" from a third-party app still hits `/authorize → /login` and auto-approves an existing session
- [ ] Manual: a phishing link `https://authgate.example.com/login?authRequestID=<id>` from a different origin no longer carries the session cookie and falls through to the IdP login

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)