### PR TITLE
fix(config): require PUBLIC_URL to use https:// when DEV_MODE=false

### DIFF
--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -82,6 +82,7 @@ authgate를 처음 배포할 때 필요한 것:
 
 `DEV_MODE=false` (기본값)일 때 다음이 강제됨:
 - `SESSION_SECRET`이 비어있거나 32자 미만이면 **서버 시작 거부**
+- `PUBLIC_URL`이 `https://`로 시작하지 않으면 **서버 시작 거부** (issuer/authorization/token endpoint가 평문으로 광고되는 것을 방지)
 - `OIDC_ISSUER_URL`이 `https://`로 시작하지 않으면 **서버 시작 거부**
 - `OIDC_CLIENT_ID` 또는 `OIDC_CLIENT_SECRET`이 비어있으면 **서버 시작 거부**
 - 쿠키 `Secure=true`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,6 +128,9 @@ func Load() (*Config, error) {
 		if len(c.SessionSecret) < 32 {
 			return nil, fmt.Errorf("DEV_MODE=false requires SESSION_SECRET of at least 32 characters")
 		}
+		if !strings.HasPrefix(c.PublicURL, "https://") {
+			return nil, fmt.Errorf("DEV_MODE=false requires PUBLIC_URL with https:// (got %q)", c.PublicURL)
+		}
 		if !strings.HasPrefix(c.OIDCIssuerURL, "https://") {
 			return nil, fmt.Errorf("DEV_MODE=false requires OIDC_ISSUER_URL with https:// (got %q)", c.OIDCIssuerURL)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,11 +65,27 @@ func TestLoad_MissingPublicURL(t *testing.T) {
 	}
 }
 
+func TestLoad_DevModeFalseRequiresPublicURLHTTPS(t *testing.T) {
+	clearEnv()
+	os.Setenv("DATABASE_URL", "postgres://localhost/test")
+	os.Setenv("SESSION_SECRET", "test-secret-32-chars-long-enough!")
+	os.Setenv("PUBLIC_URL", "http://authgate.example.com")
+	os.Setenv("DEV_MODE", "false")
+	os.Setenv("OIDC_ISSUER_URL", "https://accounts.google.com")
+	os.Setenv("OIDC_CLIENT_ID", "id")
+	os.Setenv("OIDC_CLIENT_SECRET", "secret")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error: DEV_MODE=false requires https:// PUBLIC_URL")
+	}
+}
+
 func TestLoad_DevModeFalseRequiresHTTPS(t *testing.T) {
 	clearEnv()
 	os.Setenv("DATABASE_URL", "postgres://localhost/test")
 	os.Setenv("SESSION_SECRET", "test-secret-32-chars-long-enough!")
-	os.Setenv("PUBLIC_URL", "http://localhost")
+	os.Setenv("PUBLIC_URL", "https://authgate.example.com")
 	os.Setenv("DEV_MODE", "false")
 	os.Setenv("OIDC_ISSUER_URL", "http://localhost:8082")
 	os.Setenv("OIDC_CLIENT_ID", "id")
@@ -85,7 +101,7 @@ func TestLoad_DevModeFalseRequiresOIDCCredentials(t *testing.T) {
 	clearEnv()
 	os.Setenv("DATABASE_URL", "postgres://localhost/test")
 	os.Setenv("SESSION_SECRET", "test-secret-32-chars-long-enough!")
-	os.Setenv("PUBLIC_URL", "http://localhost")
+	os.Setenv("PUBLIC_URL", "https://authgate.example.com")
 	os.Setenv("DEV_MODE", "false")
 	os.Setenv("OIDC_ISSUER_URL", "https://accounts.google.com")
 	// Missing OIDC_CLIENT_SECRET
@@ -162,7 +178,7 @@ func TestLoad_DevModeFalseShortSessionSecret(t *testing.T) {
 	clearEnv()
 	os.Setenv("DATABASE_URL", "postgres://localhost/test")
 	os.Setenv("SESSION_SECRET", "short") // < 32 chars
-	os.Setenv("PUBLIC_URL", "http://localhost")
+	os.Setenv("PUBLIC_URL", "https://authgate.example.com")
 	os.Setenv("DEV_MODE", "false")
 	os.Setenv("OIDC_ISSUER_URL", "https://accounts.google.com")
 	os.Setenv("OIDC_CLIENT_ID", "id")


### PR DESCRIPTION
## Summary

- Adds a `PUBLIC_URL` https-prefix check inside the existing `DEV_MODE=false` production guard block in `internal/config/config.go`
- Adds `TestLoad_DevModeFalseRequiresPublicURLHTTPS`, updates the existing DEV_MODE=false tests to use `https://authgate.example.com` so each one actually exercises its named guard
- Documents the new requirement in `docs/spec/009-operations.md` (production-required section)

## Why

`OIDC_ISSUER_URL` was already required to be `https://` when `DEV_MODE=false`, but `PUBLIC_URL` was not. `PUBLIC_URL` is what authgate advertises in `/.well-known/openid-configuration` for `issuer`, `authorization_endpoint`, `token_endpoint`, and `jwks_uri`. A misconfigured deployment with `PUBLIC_URL=http://...` would put authorization codes and access tokens on plaintext paths.

This is symmetric to the existing OIDC_ISSUER_URL guard.

## Verification

- `go build ./...` clean
- `go test ./internal/config/... -run TestLoad_DevMode` — all 5 DevMode tests pass

## Test plan

- [ ] Reviewer confirms the existing OIDC_ISSUER_URL guard message remains useful (the test now sets `PUBLIC_URL=https://...` so the OIDC_ISSUER_URL check is what actually fails)

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)