### PR TITLE
fix(service): bind auth_request to client login_channel on /login and /mcp paths

### DIFF
--- a/docs/spec/002-browser-login.md
+++ b/docs/spec/002-browser-login.md
@@ -170,6 +170,7 @@ sequenceDiagram
 | auth code 발급 후 상태 변경 (`pending_deletion`, `disabled`, `deleted`) | `invalid_grant` | 400 | `/oauth/token` 시점에 subject → user 재조회 후 최종 상태 재검사 |
 | PKCE code_verifier 불일치 | `invalid_grant` | 400 | zitadel이 처리 |
 | client_secret 불일치 | `invalid_client` | 401 | confidential 클라이언트만 |
+| 채널 불일치 (`login_channel: mcp` 클라이언트의 auth_request를 브라우저 경로로 완료 시도) | `channel_mismatch` | 400 | `auth.channel_mismatch` audit 후 거부. `/login`, `/login/callback` 둘 다에서 강제 |
 
 ## pending_deletion 복구
 

--- a/docs/spec/004-mcp-login.md
+++ b/docs/spec/004-mcp-login.md
@@ -427,6 +427,18 @@ user.Status = pending_deletion / disabled / deleted
 MCP는 Device와 같은 "후속 로그인 채널"이다.
 가입과 `pending_deletion` 복구는 Browser 채널에서만 처리한다.
 
+### 채널 바인딩 (cross-channel completion 차단)
+
+`/login`, `/login/callback`, `/mcp/login`, `/mcp/callback` 모두 진입 시점에
+`auth_request.client_id`로 클라이언트의 `login_channel`을 조회하고, 현재 경로와
+기대 채널이 다르면 거부한다 (`channel_mismatch`, HTTP 400). 거부 시
+`auth.channel_mismatch` audit 이벤트가 기록되며 `metadata.expected_channel`,
+`metadata.actual_channel`, `metadata.client_id` 필드를 포함한다.
+
+이는 공격자가 MCP 클라이언트의 `auth_request`를 브라우저 `/login` 자동승인
+경로로 흘려서 MCP 전용 정책 (기존 계정 요구, `pending_deletion` 거부, MCP
+callback resource 검증) 을 우회하는 것을 막는다.
+
 ## Resource Parameter
 
 MCP에서 `resource`는 부가 옵션이 아니라, "이 토큰을 어느 MCP 서버에서 쓸 것인가"를 나타내는 식별자다.

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -102,7 +102,7 @@ INSERT INTO auth_requests (
 )
 VALUES (
   $1,
-  'test-app',
+  'test-mcp-app',
   'http://localhost/callback',
   '{openid}',
   $2,

--- a/internal/db/storeq/users.sql.go
+++ b/internal/db/storeq/users.sql.go
@@ -217,7 +217,7 @@ INSERT INTO auth_requests (
 )
 VALUES (
   $1,
-  'test-app',
+  'test-mcp-app',
   'http://localhost/callback',
   '{openid}',
   $2,

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -27,6 +27,28 @@ type LoginStore interface {
 	GetUserByID(ctx context.Context, userID string) (*storage.User, error)
 	CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error)
 	GetAuthRequestModel(ctx context.Context, id string) (*storage.AuthRequestModel, error)
+	GetClientLoginChannel(ctx context.Context, clientID string) (string, error)
+}
+
+// verifyAuthRequestChannel ensures the auth_request's client uses the expected
+// login_channel. On mismatch it audits an auth.channel_mismatch event and
+// returns an error message + HTTP status suitable for a *LoginResult or
+// *CallbackResult. Lookup errors return ("internal_error", 500); a clean match
+// returns ("", 0).
+func verifyAuthRequestChannel(ctx context.Context, store LoginStore, authReq *storage.AuthRequestModel, expected, ipAddress, userAgent string, userID *string) (string, int) {
+	channel, err := store.GetClientLoginChannel(ctx, authReq.ClientID)
+	if err != nil {
+		return "internal_error", http.StatusInternalServerError
+	}
+	if channel != expected {
+		store.AuditLog(ctx, userID, storage.EventAuthChannelMismatch, ipAddress, userAgent, map[string]any{
+			"expected_channel": expected,
+			"actual_channel":   channel,
+			"client_id":        authReq.ClientID,
+		})
+		return "channel_mismatch", http.StatusBadRequest
+	}
+	return "", 0
 }
 
 func NewLoginService(store LoginStore, browserProvider upstream.Provider, sessionTTL time.Duration) *LoginService {
@@ -104,6 +126,10 @@ func (s *LoginService) handleExistingSession(ctx context.Context, user *storage.
 		return &LoginResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
 	}
 
+	if errMsg, code := verifyAuthRequestChannel(ctx, s.store, authReq, "browser", ipAddress, userAgent, &user.ID); errMsg != "" {
+		return &LoginResult{Action: ActionError, Error: errMsg, ErrorCode: code}
+	}
+
 	if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
 		return &LoginResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
 	}
@@ -145,6 +171,10 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 	user, signedUp, authReq, result := s.prepareBrowserCallbackUser(ctx, userInfo, authRequestID, ipAddress, userAgent)
 	if result != nil {
 		return result
+	}
+
+	if errMsg, code := verifyAuthRequestChannel(ctx, s.store, authReq, "browser", ipAddress, userAgent, &user.ID); errMsg != "" {
+		return &CallbackResult{Action: ActionError, Error: errMsg, ErrorCode: code}
 	}
 
 	sessionID, err := s.store.CreateSession(ctx, user.ID, s.sessionTTL)

--- a/internal/service/login_unit_test.go
+++ b/internal/service/login_unit_test.go
@@ -20,6 +20,7 @@ type fakeLoginStore struct {
 	getUserByIDFn             func(ctx context.Context, userID string) (*storage.User, error)
 	createSessionFn           func(ctx context.Context, userID string, ttl time.Duration) (string, error)
 	getAuthRequestModelFn     func(ctx context.Context, id string) (*storage.AuthRequestModel, error)
+	getClientLoginChannelFn   func(ctx context.Context, clientID string) (string, error)
 }
 
 func (f *fakeLoginStore) GetValidSession(ctx context.Context, sessionID string) (*storage.User, error) {
@@ -55,6 +56,15 @@ func (f *fakeLoginStore) GetUserByID(ctx context.Context, userID string) (*stora
 
 func (f *fakeLoginStore) CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error) {
 	return f.createSessionFn(ctx, userID, ttl)
+}
+
+func (f *fakeLoginStore) GetClientLoginChannel(ctx context.Context, clientID string) (string, error) {
+	if f.getClientLoginChannelFn == nil {
+		// Default: callers that don't care about channel binding get "browser",
+		// matching the historical behavior before #149.
+		return "browser", nil
+	}
+	return f.getClientLoginChannelFn(ctx, clientID)
 }
 
 func TestLogin_HandleLogin_RecoversPendingDeletionSession(t *testing.T) {
@@ -212,12 +222,64 @@ func TestLogin_HandleCallback_SignupAuditLogIncludesChannel(t *testing.T) {
 	}
 }
 
+// #149: completing an mcp-channel auth_request via the browser /login flow
+// must be rejected and audited as auth.channel_mismatch.
+func TestLogin_HandleLogin_RejectsCrossChannelAuthRequest(t *testing.T) {
+	type evt struct {
+		eventType string
+		metadata  map[string]any
+	}
+	var events []evt
+	store := &fakeLoginStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return &storage.User{ID: "u1", Status: "active"}, nil
+		},
+		getAuthRequestModelFn: func(context.Context, string) (*storage.AuthRequestModel, error) {
+			return &storage.AuthRequestModel{ID: "ar-1", ClientID: "mcp-client"}, nil
+		},
+		getClientLoginChannelFn: func(context.Context, string) (string, error) {
+			return "mcp", nil
+		},
+		completeAuthRequestFn: func(context.Context, string, string) error {
+			t.Fatal("CompleteAuthRequest must not be called on channel mismatch")
+			return nil
+		},
+		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
+			events = append(events, evt{eventType: eventType, metadata: metadata})
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "s1"}}
+	svc := NewLoginService(store, provider, 24*time.Hour)
+
+	result := svc.HandleLogin(context.Background(), "ar-1", "sess-1", "127.0.0.1", "ua")
+
+	if result.Action != ActionError || result.Error != "channel_mismatch" {
+		t.Fatalf("action=%v error=%q, want channel_mismatch error", result.Action, result.Error)
+	}
+	var found *evt
+	for i := range events {
+		if events[i].eventType == storage.EventAuthChannelMismatch {
+			found = &events[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("auth.channel_mismatch not audited; events=%v", events)
+	}
+	if found.metadata["expected_channel"] != "browser" || found.metadata["actual_channel"] != "mcp" {
+		t.Fatalf("audit metadata=%#v", found.metadata)
+	}
+}
+
 func TestMCPLogin_HandleCallback_AuditLogIncludesSessionAndClient(t *testing.T) {
 	var gotEventType string
 	var gotMetadata map[string]any
 	store := &fakeLoginStore{
 		getAuthRequestModelFn: func(context.Context, string) (*storage.AuthRequestModel, error) {
 			return &storage.AuthRequestModel{ID: "ar-1", ClientID: "mcp-client", Resource: "http://localhost/mcp"}, nil
+		},
+		getClientLoginChannelFn: func(context.Context, string) (string, error) {
+			return "mcp", nil
 		},
 		getUserByProviderIdentity: func(context.Context, string, string) (*storage.User, error) {
 			return &storage.User{ID: "u1", Status: "active"}, nil

--- a/internal/service/mcp_login.go
+++ b/internal/service/mcp_login.go
@@ -38,6 +38,16 @@ func (s *MCPLoginService) HandleLogin(ctx context.Context, authRequestID, sessio
 				s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "mcp"})
 				return &LoginResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
 			}
+			authReq, err := s.store.GetAuthRequestModel(ctx, authRequestID)
+			if errors.Is(err, storage.ErrNotFound) {
+				return &LoginResult{Action: ActionError, Error: "auth_request_not_found", ErrorCode: http.StatusBadRequest}
+			}
+			if err != nil {
+				return &LoginResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+			}
+			if errMsg, code := verifyAuthRequestChannel(ctx, s.store, authReq, "mcp", ipAddress, userAgent, &user.ID); errMsg != "" {
+				return &LoginResult{Action: ActionError, Error: errMsg, ErrorCode: code}
+			}
 			if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
 				return &LoginResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
 			}
@@ -70,6 +80,10 @@ func (s *MCPLoginService) HandleCallback(ctx context.Context, code, authRequestI
 			"ipAddress", ipAddress,
 		)
 		return &CallbackResult{Action: ActionError, Error: "invalid_target", ErrorCode: http.StatusBadRequest}
+	}
+
+	if errMsg, statusCode := verifyAuthRequestChannel(ctx, s.store, authReq, "mcp", ipAddress, userAgent, nil); errMsg != "" {
+		return &CallbackResult{Action: ActionError, Error: errMsg, ErrorCode: statusCode}
 	}
 
 	userInfo, err := s.mcpProvider.Exchange(ctx, code)

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -18,6 +18,7 @@ const (
 	EventAuthDeletionCompleted    = "auth.deletion_completed"
 	EventAuthLogout               = "auth.logout"
 	EventAuthTokenRevoked         = "auth.token_revoked"
+	EventAuthChannelMismatch      = "auth.channel_mismatch"
 
 	EventTokenRefresh   = "token.refresh"
 	EventTokenRevoked   = "token.revoked"

--- a/internal/storage/clients.go
+++ b/internal/storage/clients.go
@@ -170,3 +170,15 @@ func (s *Storage) resolveClient(ctx context.Context, clientID string) (*ClientMo
 	}
 	return s.clientPolicy.ResolveClient(ctx, clientID)
 }
+
+// GetClientLoginChannel returns the login_channel ("browser" or "mcp") for the
+// given client. Used by service-layer channel-binding checks so that an
+// auth_request issued for one channel cannot be completed via the other
+// channel's login flow.
+func (s *Storage) GetClientLoginChannel(ctx context.Context, clientID string) (string, error) {
+	cm, err := s.resolveClient(ctx, clientID)
+	if err != nil {
+		return "", err
+	}
+	return cm.LoginChannel, nil
+}

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -235,7 +235,11 @@ func (s *Storage) setUserStatus(ctx context.Context, userID, status string) erro
 
 // CreateTestAuthRequest creates a minimal auth request for testing purposes.
 // Returns the UUID id assigned to the auth request.
+//
+// The auth_request is bound to client_id "test-app" (registered with
+// login_channel="browser" so the channel-binding guard accepts it).
 func (s *Storage) CreateTestAuthRequest(ctx context.Context, label string) (string, error) {
+	s.LoadClients([]ClientConfigEntry{{ClientID: "test-app", LoginChannel: "browser"}})
 	id := s.idgen.NewUUID()
 	err := storeq.New(s.db).InsertTestAuthRequest(ctx, storeq.InsertTestAuthRequestParams{
 		ID:        id,
@@ -248,7 +252,11 @@ func (s *Storage) CreateTestAuthRequest(ctx context.Context, label string) (stri
 
 // CreateTestAuthRequestWithResource creates a minimal auth request with a resource field set,
 // for testing MCP flows that require resource binding validation.
+//
+// The auth_request is bound to client_id "test-mcp-app" (registered with
+// login_channel="mcp" so the channel-binding guard accepts it).
 func (s *Storage) CreateTestAuthRequestWithResource(ctx context.Context, label, resource string) (string, error) {
+	s.LoadClients([]ClientConfigEntry{{ClientID: "test-mcp-app", LoginChannel: "mcp"}})
 	id := s.idgen.NewUUID()
 	now := s.clock.Now()
 	err := storeq.New(s.db).InsertTestAuthRequestWithResource(ctx, storeq.InsertTestAuthRequestWithResourceParams{


### PR DESCRIPTION
## Summary

Adds a channel-binding guard at all four authgate login entry points so an auth_request issued for an MCP client cannot be completed via the browser `/login` flow (and vice-versa).

- `internal/storage/clients.go` — new `GetClientLoginChannel(ctx, clientID) (string, error)`
- `internal/storage/audit.go` — new `EventAuthChannelMismatch = "auth.channel_mismatch"`
- `internal/service/login.go` — new `verifyAuthRequestChannel` helper used in `handleExistingSession` and `handleCallback`
- `internal/service/mcp_login.go` — same check applied to `HandleLogin` (after `GetValidSession`) and `HandleCallback` (after the resource-binding check)
- `internal/service/login_unit_test.go` — `fakeLoginStore.GetClientLoginChannel` slot + `TestLogin_HandleLogin_RejectsCrossChannelAuthRequest`
- `internal/db/queries/users.sql` + `internal/db/storeq/users.sql.go` — `InsertTestAuthRequestWithResource` now uses `client_id = 'test-mcp-app'` so the two test helpers register non-clashing clients
- `internal/storage/users.go` — `CreateTestAuthRequest*` helpers now `LoadClients` for `test-app` / `test-mcp-app` so the channel guard sees a registered client during integration tests
- `docs/spec/002-browser-login.md` — error-case row for `channel_mismatch`
- `docs/spec/004-mcp-login.md` — new "채널 바인딩 (cross-channel completion 차단)" subsection

## Why

The browser `LoginService` previously did not check that the `auth_request` was issued for a client whose `login_channel` is `browser`. As a result an attacker could craft an MCP-channel `auth_request` (e.g. via a malicious MCP `client_id`) and steer a victim to `/login?authRequestID=<mcp-id>` to silently complete it through the browser auto-approve path, sidestepping every MCP-specific policy.

This is most acutely paired with the `SameSite=Lax` session cookie removed in #154 / #166: a cross-site GET previously carried the victim's session cookie into the auto-approve path. With both fixes in place, both the cookie-attachment vector AND the channel-completion vector are closed.

## Audit shape

```json
{
  "event_type": "auth.channel_mismatch",
  "metadata": {
    "expected_channel": "browser",
    "actual_channel": "mcp",
    "client_id": "<offending-client-id>"
  }
}
```

The user_id is included when the request had a session (browser auto-approve path); MCP callback rejections audit with a nil user_id since the user has not been resolved yet.

## Verification

- `go build ./...` clean
- `go test ./...` pass
- `go test -tags=integration ./internal/storage/... ./internal/service/... ./internal/integration/... -timeout=180s` pass
  - `internal/service` 69.1s, `internal/storage` 13.6s, `internal/integration` 60.5s — all green

## Test plan

- [ ] Manual: register an MCP client (`login_channel: mcp`) and a browser client. Initiate `/authorize?client_id=<mcp-client>...`, then directly hit `/login?authRequestID=<mcp-id>` with a valid browser session — expect `channel_mismatch` 400 and `auth.channel_mismatch` row in `audit_log`
- [ ] Manual: confirm the inverse — feeding a browser `authRequestID` to `/mcp/login` is also rejected
- [ ] Reviewer confirms `verifyAuthRequestChannel` is unreachable when the auth_request lookup already failed (so the new code does not perturb existing 400/500 mappings for missing/expired auth_requests)

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)