### PR TITLE
fix(config): add OIDC_ISSUER_HOST_ALLOWLIST to gate misconfigured upstream issuer

### DIFF
--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -53,6 +53,7 @@ authgate를 처음 배포할 때 필요한 것:
 | `SESSION_SECRET` | O | — | OIDC 암호화 키 (최소 32자) |
 | `PUBLIC_URL` | O | — | 외부 접근 URL (예: `https://auth.example.com`) |
 | `OIDC_ISSUER_URL` | X | `http://localhost:8082` | OIDC IdP issuer URL (예: `https://accounts.google.com`) |
+| `OIDC_ISSUER_HOST_ALLOWLIST` | X | — | 콤마 구분 host 목록 (예: `accounts.google.com,login.microsoftonline.com`). 비어 있으면 검사 안 함. 설정되면 `OIDC_ISSUER_URL`의 host가 정확히 일치해야 시작. 운영자 misconfig 시 attacker IdP로 phishing redirect 되는 경로를 fail-fast로 차단한다. 운영에서 설정 권장. |
 | `OIDC_INTERNAL_URL` | X | — | 서버 간 OIDC 호출용 내부 URL (Docker/K8s 환경) |
 | `OIDC_HTTP_TIMEOUT_SEC` | X | `10` | Upstream OIDC HTTP 호출 timeout(초) |
 | `OIDC_CLIENT_ID` | X | `authgate` | OIDC Client ID |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -18,6 +20,14 @@ type Config struct {
 	SessionSecret         string
 	PublicURL             string
 	OIDCIssuerURL         string
+	// OIDCIssuerHostAllowlist is an optional comma-separated list of hosts the
+	// OIDC_ISSUER_URL is allowed to point at. When non-empty, the issuer URL's
+	// host must match an entry exactly (host:port if a non-default port is in
+	// the URL). Empty means no allowlist enforcement — the default for backward
+	// compatibility, but operators are encouraged to set this in production to
+	// fail-fast on misconfigured/compromised env vars that would otherwise
+	// redirect every login through an attacker-controlled IdP.
+	OIDCIssuerHostAllowlist []string
 	OIDCInternalURL       string // optional: internal base URL for server-to-server OIDC calls (Docker/K8s)
 	OIDCHTTPTimeout       time.Duration
 	OIDCClientID          string
@@ -56,6 +66,7 @@ func Load() (*Config, error) {
 		SessionSecret:         os.Getenv("SESSION_SECRET"),
 		PublicURL:             os.Getenv("PUBLIC_URL"),
 		OIDCIssuerURL:         envDefault("OIDC_ISSUER_URL", "http://localhost:8082"),
+		OIDCIssuerHostAllowlist: envCommaList("OIDC_ISSUER_HOST_ALLOWLIST"),
 		OIDCInternalURL:       os.Getenv("OIDC_INTERNAL_URL"),
 		OIDCHTTPTimeout:       time.Duration(envInt("OIDC_HTTP_TIMEOUT_SEC", 10)) * time.Second,
 		OIDCClientID:          envDefault("OIDC_CLIENT_ID", "authgate"),
@@ -123,6 +134,16 @@ func Load() (*Config, error) {
 		c.DBMaxIdleConns = c.DBMaxOpenConns
 	}
 
+	if len(c.OIDCIssuerHostAllowlist) > 0 {
+		issuerURL, err := url.Parse(c.OIDCIssuerURL)
+		if err != nil {
+			return nil, fmt.Errorf("OIDC_ISSUER_URL is not a valid URL: %w", err)
+		}
+		if !slices.Contains(c.OIDCIssuerHostAllowlist, issuerURL.Host) {
+			return nil, fmt.Errorf("OIDC_ISSUER_URL host %q is not in OIDC_ISSUER_HOST_ALLOWLIST %v", issuerURL.Host, c.OIDCIssuerHostAllowlist)
+		}
+	}
+
 	// Production guards
 	if !c.DevMode {
 		if len(c.SessionSecret) < 32 {
@@ -171,6 +192,24 @@ func envBool(key string, fallback bool) bool {
 		return fallback
 	}
 	return b
+}
+
+// envCommaList returns the comma-separated values of an environment variable,
+// trimmed of surrounding whitespace, with empty entries dropped. Empty or unset
+// returns nil.
+func envCommaList(key string) []string {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	out := parts[:0]
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func envFloat(key string, fallback float64) float64 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,13 +2,15 @@ package config
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
 func clearEnv() {
 	for _, key := range []string{
 		"PORT", "DATABASE_URL", "SESSION_SECRET", "PUBLIC_URL",
-		"OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET",
+		"OIDC_ISSUER_URL", "OIDC_ISSUER_HOST_ALLOWLIST",
+		"OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET",
 		"OIDC_HTTP_TIMEOUT_SEC",
 		"SESSION_TTL", "ACCESS_TOKEN_TTL", "REFRESH_TOKEN_TTL",
 		"DEV_MODE", "ENABLE_MCP",
@@ -171,6 +173,51 @@ func TestLoad_Defaults(t *testing.T) {
 	}
 	if cfg.DBConnMaxIdleTime.Seconds() != 120 {
 		t.Errorf("DBConnMaxIdleTime = %v, want 120s", cfg.DBConnMaxIdleTime)
+	}
+}
+
+func TestLoad_OIDCIssuerHostAllowlist_Match(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("OIDC_ISSUER_URL", "https://accounts.google.com")
+	os.Setenv("OIDC_ISSUER_HOST_ALLOWLIST", "accounts.google.com,login.microsoftonline.com")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := cfg.OIDCIssuerHostAllowlist; len(got) != 2 || got[0] != "accounts.google.com" || got[1] != "login.microsoftonline.com" {
+		t.Errorf("OIDCIssuerHostAllowlist = %v, want [accounts.google.com login.microsoftonline.com]", got)
+	}
+}
+
+func TestLoad_OIDCIssuerHostAllowlist_Mismatch(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("OIDC_ISSUER_URL", "https://attacker.example.com")
+	os.Setenv("OIDC_ISSUER_HOST_ALLOWLIST", "accounts.google.com")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error: issuer host not in allowlist")
+	}
+	if !strings.Contains(err.Error(), "OIDC_ISSUER_HOST_ALLOWLIST") {
+		t.Errorf("error = %v, want one mentioning OIDC_ISSUER_HOST_ALLOWLIST", err)
+	}
+}
+
+func TestLoad_OIDCIssuerHostAllowlist_EmptyDisablesCheck(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("OIDC_ISSUER_URL", "https://anything.example.com")
+	// OIDC_ISSUER_HOST_ALLOWLIST unset
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("empty allowlist should not enforce: %v", err)
+	}
+	if len(cfg.OIDCIssuerHostAllowlist) != 0 {
+		t.Errorf("OIDCIssuerHostAllowlist = %v, want empty", cfg.OIDCIssuerHostAllowlist)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds an optional `OIDC_ISSUER_HOST_ALLOWLIST` env var (comma-separated). When non-empty, authgate parses `OIDC_ISSUER_URL` at startup and refuses to start if the URL's host is not in the allowlist. Empty/unset means no enforcement (backward-compatible default).

- `internal/config/config.go` — `OIDCIssuerHostAllowlist []string` field, `envCommaList` helper, allowlist check before the existing production guards
- `internal/config/config_test.go` — `TestLoad_OIDCIssuerHostAllowlist_Match`, `_Mismatch`, `_EmptyDisablesCheck`
- `docs/spec/009-operations.md` — env-var table row

## Why

A misconfigured (or attacker-controlled) `OIDC_ISSUER_URL` silently redirects every login attempt through a hostile IdP — there is no signal at startup or runtime that the issuer is wrong. With the allowlist set, the wrong host fails fast at boot before any traffic is served.

## Verification

- `go build ./...` clean
- `go test ./...` pass
- `go test ./internal/config/... -run TestLoad_OIDCIssuerHostAllowlist` — all 3 cases pass

## Test plan

- [ ] Manual: set `OIDC_ISSUER_HOST_ALLOWLIST=accounts.google.com` and `OIDC_ISSUER_URL=https://attacker.example.com` — expect server to refuse to start with a clear error
- [ ] Manual: omit the env var entirely — verify existing deployments are unaffected
- [ ] Reviewer confirms exact-match host comparison is desired (vs. suffix-match) given that the JWKS endpoint and discovery URLs are derived from the issuer URL

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)