### PR TITLE
fix(storage): validate issuer and reject resource-URL audience on bearer tokens

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -151,6 +151,7 @@ func newStateChecker() func(*storage.User) error {
 
 func mustBuildStore(cfg *config.Config, db *sql.DB, clk clock.Clock, gen idgen.CryptoGenerator) *storage.Storage {
 	store := storage.New(db, clk, gen, newStateChecker(), cfg.AccessTokenTTL, cfg.RefreshTokenTTL)
+	store.SetIssuer(cfg.PublicURL)
 	mustConfigureSigningKey(store)
 	configureMCPPoliciesIfEnabled(cfg, store)
 	return store

--- a/internal/storage/console.go
+++ b/internal/storage/console.go
@@ -216,9 +216,13 @@ func (s *Storage) ValidateBearerTokenWithClientID(ctx context.Context, authHeade
 		return nil, "", errors.New("invalid token signature")
 	}
 
-	if err := claims.ValidateWithLeeway(josejwt.Expected{
+	expected := josejwt.Expected{
 		Time: s.clock.Now(),
-	}, time.Second*5); err != nil {
+	}
+	if s.issuer != "" {
+		expected.Issuer = s.issuer
+	}
+	if err := claims.ValidateWithLeeway(expected, time.Second*5); err != nil {
 		return nil, "", errors.New("token validation failed: " + err.Error())
 	}
 
@@ -226,10 +230,16 @@ func (s *Storage) ValidateBearerTokenWithClientID(ctx context.Context, authHeade
 		return nil, "", errors.New("missing sub claim")
 	}
 
-	// client_id is carried in the aud claim for browser/device flows
-	clientID := ""
-	if len(claims.Audience) > 0 {
-		clientID = string(claims.Audience[0])
+	if len(claims.Audience) == 0 {
+		return nil, "", errors.New("missing aud claim")
+	}
+	// client_id is carried in the aud claim for browser/device flows. MCP
+	// resource-bound tokens (RFC 8707) carry a resource URL in `aud` instead;
+	// those must never be accepted on console APIs even though they share the
+	// same signing key. Reject anything that parses as an http(s) URL.
+	clientID := string(claims.Audience[0])
+	if strings.HasPrefix(clientID, "http://") || strings.HasPrefix(clientID, "https://") {
+		return nil, "", errors.New("resource-bound token not accepted on console")
 	}
 
 	user, err := s.GetUserByID(ctx, claims.Subject)

--- a/internal/storage/console_unit_test.go
+++ b/internal/storage/console_unit_test.go
@@ -1,0 +1,110 @@
+package storage
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"strings"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+
+	"github.com/kangheeyong/authgate/internal/clock"
+)
+
+// signTestToken returns a serialized RS256-signed JWT carrying the given claims.
+func signTestToken(t *testing.T, key *rsa.PrivateKey, claims josejwt.Claims) string {
+	t.Helper()
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: key},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	tok, err := josejwt.Signed(signer).Claims(claims).Serialize()
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return tok
+}
+
+func newConsoleTestStore(t *testing.T) (*Storage, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa key: %v", err)
+	}
+	clk := &clock.FixedClock{T: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)}
+	s := &Storage{
+		clock:        clk,
+		signingKey:   key,
+		signingKeyID: "kid-1",
+		issuer:       "https://authgate.example.com",
+	}
+	return s, key
+}
+
+// #150: tokens whose `aud` is a resource URL (RFC 8707, used by MCP flows)
+// must not be accepted on console APIs even though they share the same
+// signing key as legitimate console tokens.
+func TestValidateBearerToken_RejectsURLAudience(t *testing.T) {
+	s, key := newConsoleTestStore(t)
+	now := s.clock.Now()
+	token := signTestToken(t, key, josejwt.Claims{
+		Issuer:   "https://authgate.example.com",
+		Subject:  "user-1",
+		Audience: josejwt.Audience{"https://other-app.example.com/mcp"},
+		IssuedAt: josejwt.NewNumericDate(now),
+		Expiry:   josejwt.NewNumericDate(now.Add(15 * time.Minute)),
+	})
+
+	_, _, err := s.ValidateBearerTokenWithClientID(context.Background(), "Bearer "+token)
+	if err == nil {
+		t.Fatal("expected rejection of resource-URL audience")
+	}
+	if !strings.Contains(err.Error(), "resource-bound") {
+		t.Fatalf("error = %v, want one mentioning resource-bound", err)
+	}
+}
+
+// #150: a token signed with the same key but issued by a different authgate
+// instance (or one whose issuer claim is otherwise wrong) must be rejected.
+func TestValidateBearerToken_RejectsWrongIssuer(t *testing.T) {
+	s, key := newConsoleTestStore(t)
+	now := s.clock.Now()
+	token := signTestToken(t, key, josejwt.Claims{
+		Issuer:   "https://other-authgate.example.com",
+		Subject:  "user-1",
+		Audience: josejwt.Audience{"client-a"},
+		IssuedAt: josejwt.NewNumericDate(now),
+		Expiry:   josejwt.NewNumericDate(now.Add(15 * time.Minute)),
+	})
+
+	_, _, err := s.ValidateBearerTokenWithClientID(context.Background(), "Bearer "+token)
+	if err == nil {
+		t.Fatal("expected rejection of wrong issuer")
+	}
+}
+
+// Tokens with no audience cannot be mapped to a client and must be rejected.
+func TestValidateBearerToken_RejectsMissingAudience(t *testing.T) {
+	s, key := newConsoleTestStore(t)
+	now := s.clock.Now()
+	token := signTestToken(t, key, josejwt.Claims{
+		Issuer:   "https://authgate.example.com",
+		Subject:  "user-1",
+		IssuedAt: josejwt.NewNumericDate(now),
+		Expiry:   josejwt.NewNumericDate(now.Add(15 * time.Minute)),
+	})
+
+	_, _, err := s.ValidateBearerTokenWithClientID(context.Background(), "Bearer "+token)
+	if err == nil {
+		t.Fatal("expected rejection of missing aud")
+	}
+	if !strings.Contains(err.Error(), "aud") {
+		t.Fatalf("error = %v, want one mentioning aud", err)
+	}
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -51,6 +51,11 @@ type Storage struct {
 	clients         sync.Map // map[string]*ClientModel (client_id → client)
 	clientPolicy    ClientResolutionPolicy
 	resourcePolicy  ResourceBindingPolicy
+	// issuer is the expected `iss` claim for bearer-token validation on
+	// console APIs. Wired from cfg.PublicURL via SetIssuer at startup; empty
+	// string falls back to clock-only validation for backward compatibility
+	// with tests that construct Storage without explicit issuer plumbing.
+	issuer string
 }
 
 func New(db *sql.DB, clk clock.Clock, gen idgen.IDGenerator, checker StateChecker, accessTTL, refreshTTL time.Duration) *Storage {
@@ -78,6 +83,14 @@ func (s *Storage) SetSigningKey(key *rsa.PrivateKey, keyID string) {
 func (s *Storage) SetPreviousKey(key *rsa.PrivateKey, keyID string) {
 	s.previousKey = key
 	s.previousKeyID = keyID
+}
+
+// SetIssuer pins the expected `iss` claim used during bearer-token
+// validation. Should be called once at startup with cfg.PublicURL. Empty
+// string disables the check (only useful in tests that construct Storage
+// without going through main.go).
+func (s *Storage) SetIssuer(issuer string) {
+	s.issuer = issuer
 }
 
 // DB returns the underlying *sql.DB. For testing only.


### PR DESCRIPTION
## Summary

Tightens `ValidateBearerTokenWithClientID` (`internal/storage/console.go:200-240`) so that:

- The JWT `iss` claim is matched against the operator-configured public URL (when wired via `SetIssuer`).
- Tokens with no `aud` claim are rejected.
- Tokens whose `aud[0]` is an `http://` or `https://` URL are rejected with `"resource-bound token not accepted on console"`.

`Storage` gains an `issuer` field + `SetIssuer(string)` setter; `cmd/authgate/main.go` wires this from `cfg.PublicURL` right after `storage.New`.

## Why

Bearer tokens issued for MCP flows carry a resource URL in the `aud` claim (per `internal/storage/models.go` — `AuthRequestModel.GetAudience` returns `[Resource]` when set). The previous console validator read `claims.Audience[0]` straight into `clientID` and accepted the token regardless. An attacker who legitimately obtained an MCP resource-bound token could forward it to `/console/me/*` and the existing code would treat the resource URL as a client_id, leaking session/connection/audit data for the token's subject.

The new URL-prefix check closes this without requiring full client-resolution per request, and the issuer check guards against tokens minted by a different authgate instance whose signing key happens to overlap.

This is a defense-in-depth measure; a follow-up issue should introduce a dedicated `aud=authgate-console` (or scope-based) discriminator so that even non-URL audiences from non-console clients are rejected on the console path.

## Verification

- `go build ./...` clean
- `go test ./...` pass (full unit suite)
- `go test ./internal/storage/... -run TestValidateBearerToken -v` — 3 new cases pass (URL audience, wrong issuer, missing audience)
- `go test -tags=integration -count=1 ./internal/storage/... ./internal/integration/... -timeout=180s` — both green (storage 14.5s, integration 62.7s)

## Test plan

- [ ] Reviewer confirms the empty-issuer compatibility branch is acceptable (kept so unit tests that build `Storage` by hand are not forced to set an issuer). In production `SetIssuer` is always called via `mustBuildStore`
- [ ] Manual: take a real MCP `access_token` (with `resource=https://...`) and call `/console/me/sessions` — expect 401 with `resource-bound token not accepted on console`

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)