### PR TITLE
fix(service): validate auth_request before upstream Exchange in /login/callback

### DIFF
--- a/internal/service/e2e_test.go
+++ b/internal/service/e2e_test.go
@@ -212,7 +212,13 @@ func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
 	}
 }
 
-// E2E 5: 복구 후 로그인 완료 실패가 발생해도 다음 재시도에서 정상 완료되어야 한다.
+// E2E 5: pending_deletion 사용자가 정상 authRequest 콜백으로 복구 + 완료에
+// 한 번에 성공해야 한다.
+//
+// #162 이전: 잘못된 authRequestID 콜백에서도 복구가 선행됐다 (Exchange가 먼저
+// 호출됐기 때문). 이는 outbound IdP 트래픽 amplification 표면이라 차단되었다.
+// 새 동작: 잘못된 authRequestID 콜백은 Exchange 전에 거부되며 복구도 일어나지
+// 않는다. 유효한 authRequestID 콜백 한 번으로 복구 + 완료가 모두 성공한다.
 func TestE2E5_RecoveryThenAuthRequestRetry(t *testing.T) {
 	fx := setupE2ETest(t)
 	ctx := context.Background()
@@ -226,23 +232,25 @@ func TestE2E5_RecoveryThenAuthRequestRetry(t *testing.T) {
 		t.Fatalf("deletion request failed: %s", del.Message)
 	}
 
-	// 2) Browser callback 시도하되 존재하지 않는 authRequestID로 완료 단계 실패 유도
+	// 2) 잘못된 authRequestID 콜백은 Exchange 이전에 거부되고 복구도 일어나지 않는다.
 	first := fx.LoginSvc.HandleCallback(ctx, "fake-code", "missing-auth-request", "127.0.0.1", "browser")
 	if first.Action != ActionError {
 		t.Fatalf("first action = %v, want ActionError", first.Action)
 	}
-
-	// 복구는 선행되므로 status는 active여야 한다.
 	var status string
 	fx.DB.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
-	if status != "active" {
-		t.Fatalf("status after failed completion = %q, want active", status)
+	if status != "pending_deletion" {
+		t.Fatalf("status after invalid callback = %q, want pending_deletion (no recovery)", status)
 	}
 
-	// 3) 정상 authRequest로 재시도 시 성공해야 한다.
+	// 3) 유효한 authRequest로 한 번에 복구 + 완료.
 	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e5-retry")
 	second := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "browser")
 	if second.Action != ActionAutoApprove {
 		t.Fatalf("second action = %v, want ActionAutoApprove", second.Action)
+	}
+	fx.DB.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
+	if status != "active" {
+		t.Fatalf("status after valid callback = %q, want active", status)
 	}
 }

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -162,19 +162,27 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 		return &CallbackResult{Action: ActionError, Error: "missing code or state", ErrorCode: http.StatusBadRequest}
 	}
 
-	// Exchange code for user info
+	// Validate the local auth_request — and its channel binding — BEFORE
+	// contacting the upstream IdP. This blocks attacker-controlled callback
+	// spam (random `state` values) from amplifying outbound traffic to the
+	// IdP, and gives a clean fail-fast for callbacks that arrive after the
+	// auth_request has expired.
+	authReq, result := s.getCallbackAuthRequest(ctx, authRequestID)
+	if result != nil {
+		return result
+	}
+	if errMsg, statusCode := verifyAuthRequestChannel(ctx, s.store, authReq, "browser", ipAddress, userAgent, nil); errMsg != "" {
+		return &CallbackResult{Action: ActionError, Error: errMsg, ErrorCode: statusCode}
+	}
+
 	userInfo, err := s.browserProvider.Exchange(ctx, code)
 	if err != nil {
 		return &CallbackResult{Action: ActionError, Error: "upstream_error", ErrorCode: http.StatusInternalServerError}
 	}
 
-	user, signedUp, authReq, result := s.prepareBrowserCallbackUser(ctx, userInfo, authRequestID, ipAddress, userAgent)
+	user, signedUp, _, result := s.prepareBrowserCallbackUser(ctx, userInfo, authRequestID, ipAddress, userAgent)
 	if result != nil {
 		return result
-	}
-
-	if errMsg, code := verifyAuthRequestChannel(ctx, s.store, authReq, "browser", ipAddress, userAgent, &user.ID); errMsg != "" {
-		return &CallbackResult{Action: ActionError, Error: errMsg, ErrorCode: code}
 	}
 
 	sessionID, err := s.store.CreateSession(ctx, user.ID, s.sessionTTL)

--- a/internal/service/login_test.go
+++ b/internal/service/login_test.go
@@ -157,11 +157,15 @@ func TestHandleCallback_InactiveUser_Error(t *testing.T) {
 }
 
 func TestHandleCallback_UpstreamError_Sanitized(t *testing.T) {
-	svc, _ := setupLoginService(t)
+	svc, store := setupLoginService(t)
 	ctx := context.Background()
 	svc.browserProvider = &upstream.FakeProvider{ProviderName: "google"}
 
-	result := svc.HandleCallback(ctx, "fake-code", "req-upstream", "127.0.0.1", "test-agent")
+	// #162: callback now validates the local auth_request before contacting
+	// the upstream IdP. Use a real auth_request so we exercise the
+	// upstream-error sanitization path rather than the local-state guard.
+	arID, _ := store.CreateTestAuthRequest(ctx, "upstream-err")
+	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test-agent")
 
 	if result.Action != ActionError {
 		t.Fatalf("action = %v, want ActionError", result.Action)
@@ -171,7 +175,13 @@ func TestHandleCallback_UpstreamError_Sanitized(t *testing.T) {
 	}
 }
 
-// browser-007 / E2E 6: 복구 후 auth_request 완료 실패 → 재시도 멱등성
+// browser-007 / E2E 6: 복구가 유효한 auth_request 콜백에서 멱등적으로 동작해야 한다.
+//
+// #162 이전에는 잘못된 authRequestID로도 복구가 선행되었다 (Exchange가 먼저
+// 호출됐으므로). 그 동작은 outbound IdP 트래픽 amplification 표면이라
+// 제거되었다. 새 동작: 잘못된 authRequestID 콜백은 Exchange 전에 거부되며
+// 복구도 일어나지 않는다. 유효한 authRequestID 콜백에서만 복구가 일어나고,
+// 두 번 이상 호출돼도 멱등이다.
 func TestBrowser007_RecoveryRetryIdempotent(t *testing.T) {
 	fx := setupGapTest(t)
 	ctx := context.Background()
@@ -180,24 +190,33 @@ func TestBrowser007_RecoveryRetryIdempotent(t *testing.T) {
 	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "retry@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "r@test.com"})
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
-	// First attempt: recovery succeeds, but use an invalid authRequestID so CompleteAuthRequest fails
+	// First attempt: callback with bogus authRequestID is rejected before
+	// Exchange. Recovery does NOT happen.
 	result1 := fx.LoginSvc.HandleCallback(ctx, "fake-code", "invalid-ar-id", "127.0.0.1", "browser")
-	// Recovery happened (user is now active), but auth_request completion may fail
-	// The important thing: user is recovered
-
-	// Verify user is active (recovery persisted even if auth_request failed)
+	if result1.Action != ActionError {
+		t.Fatalf("invalid authRequestID should be rejected, got %v", result1.Action)
+	}
 	var status string
 	fx.Store.DB().QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
-	if status != "active" {
-		t.Fatalf("user should be active after recovery, got %q", status)
+	if status != "pending_deletion" {
+		t.Fatalf("user must remain pending_deletion when auth_request invalid, got %q", status)
 	}
 
-	// Second attempt: retry login → should succeed normally (idempotent)
+	// Second attempt: valid authRequestID — recovery + completion in one shot.
 	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "retry")
 	result2 := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "browser")
 	if result2.Action != ActionAutoApprove {
-		t.Errorf("retry action = %v, want AutoApprove (recovery already done)", result2.Action)
+		t.Errorf("retry action = %v, want AutoApprove", result2.Action)
+	}
+	fx.Store.DB().QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status)
+	if status != "active" {
+		t.Fatalf("after valid callback, user should be active, got %q", status)
 	}
 
-	_ = result1 // first result may be error, that's OK
+	// Third attempt: idempotent retry on a fresh authRequestID also succeeds.
+	arID2, _ := fx.Store.CreateTestAuthRequest(ctx, "retry-2")
+	result3 := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID2, "127.0.0.1", "browser")
+	if result3.Action != ActionAutoApprove {
+		t.Errorf("idempotent retry action = %v, want AutoApprove", result3.Action)
+	}
 }


### PR DESCRIPTION
## Summary

Reorders `handleCallback` (`internal/service/login.go`) so that the local `auth_request` is fetched and its channel binding verified **before** `browserProvider.Exchange(ctx, code)` is called. The post-Exchange channel check is removed (the pre-check already covers it).

Updates three integration tests that codified the old behavior:

- `TestHandleCallback_UpstreamError_Sanitized` — now seeds a real `auth_request` so the upstream-error path is reached
- `TestE2E5_RecoveryThenAuthRequestRetry` — asserts that an invalid `authRequestID` does **not** recover; recovery + completion happen in a single valid callback
- `TestBrowser007_RecoveryRetryIdempotent` — same, plus an extra call to verify idempotency on a fresh `authRequestID`

`MCPLoginService.HandleCallback` already validated the auth_request (and its resource binding) before Exchange per Spec 004, so no change on the MCP path.

## Why

The browser callback previously called `Exchange` on every hit, including ones with a bogus or attacker-supplied `state`, generating an outbound IdP token-endpoint request per call. Two problems:

1. **Outbound amplification**: a public endpoint (`/login/callback`) becomes a generator for traffic to the operator's IdP, burning quota and making rate limits easier to evade
2. **Side-effect recovery**: `prepareBrowserCallbackUser` performed `pending_deletion → active` recovery before the auth_request lookup, so a successful upstream Exchange + a bogus state was enough to mutate account state

## Behavior change (documented in the test bodies)

- Callbacks with an invalid/expired `authRequestID` are now rejected **before** the upstream Exchange. No outbound traffic.
- `pending_deletion` recovery requires a valid `auth_request`. The previous "best-effort recovery on failed completion" path is gone — recovery now happens only when the legitimate flow can complete.

## Verification

- `go build ./...` clean
- `go test ./...` pass
- `go test -tags=integration -count=1 ./internal/service/... -timeout=180s` pass (67.6s)

## Test plan

- [ ] Manual: hit `/login/callback?code=anything&state=<bogus>` — expect `auth_request_not_found` (400) and no upstream IdP request in IdP logs
- [ ] Manual: simulate a `pending_deletion` user with a valid `auth_request` and a real upstream code — verify recovery + completion in a single callback

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)