### PR TITLE
fix(storage): honor JWT kid header so console accepts both signing keys during rotation

### DIFF
--- a/internal/storage/console.go
+++ b/internal/storage/console.go
@@ -211,8 +211,17 @@ func (s *Storage) ValidateBearerTokenWithClientID(ctx context.Context, authHeade
 		return nil, "", errors.New("invalid token format")
 	}
 
+	// Resolve the verification key from the JWT `kid` header so a 2-slot
+	// rotation (current + previous, exposed via JWKS) is honored on the
+	// console path the same way it is by the zitadel OP. Tokens with no
+	// `kid` are treated as legacy and fall back to the current signing key.
+	verifyKey, err := s.selectVerificationKey(tok)
+	if err != nil {
+		return nil, "", err
+	}
+
 	var claims josejwt.Claims
-	if err := tok.Claims(s.signingKey.Public(), &claims); err != nil {
+	if err := tok.Claims(verifyKey, &claims); err != nil {
 		return nil, "", errors.New("invalid token signature")
 	}
 
@@ -247,4 +256,30 @@ func (s *Storage) ValidateBearerTokenWithClientID(ctx context.Context, authHeade
 		return nil, "", err
 	}
 	return user, clientID, nil
+}
+
+// selectVerificationKey picks the RSA public key used to verify a bearer
+// token's signature based on the JWT's `kid` header.
+//
+// Selection rules:
+//   - kid empty → current signing key (legacy / pre-rotation tokens)
+//   - kid == signingKeyID → current signing key
+//   - kid == previousKeyID and previousKey != nil → previous signing key
+//   - anything else → "invalid token: unknown key"
+//
+// Returning the public key as `any` keeps the existing tok.Claims call site
+// untouched.
+func (s *Storage) selectVerificationKey(tok *josejwt.JSONWebToken) (any, error) {
+	kid := ""
+	if len(tok.Headers) > 0 {
+		kid = tok.Headers[0].KeyID
+	}
+	switch {
+	case kid == "" || kid == s.signingKeyID:
+		return s.signingKey.Public(), nil
+	case s.previousKey != nil && kid == s.previousKeyID:
+		return s.previousKey.Public(), nil
+	default:
+		return nil, errors.New("invalid token: unknown key")
+	}
 }

--- a/internal/storage/console_unit_test.go
+++ b/internal/storage/console_unit_test.go
@@ -17,9 +17,20 @@ import (
 // signTestToken returns a serialized RS256-signed JWT carrying the given claims.
 func signTestToken(t *testing.T, key *rsa.PrivateKey, claims josejwt.Claims) string {
 	t.Helper()
+	return signTestTokenWithKID(t, key, "", claims)
+}
+
+// signTestTokenWithKID returns a serialized RS256-signed JWT with the given
+// `kid` header (empty string omits the header).
+func signTestTokenWithKID(t *testing.T, key *rsa.PrivateKey, kid string, claims josejwt.Claims) string {
+	t.Helper()
+	opts := (&jose.SignerOptions{}).WithType("JWT")
+	if kid != "" {
+		opts = opts.WithHeader("kid", kid)
+	}
 	signer, err := jose.NewSigner(
 		jose.SigningKey{Algorithm: jose.RS256, Key: key},
-		(&jose.SignerOptions{}).WithType("JWT"),
+		opts,
 	)
 	if err != nil {
 		t.Fatalf("signer: %v", err)
@@ -106,5 +117,126 @@ func TestValidateBearerToken_RejectsMissingAudience(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "aud") {
 		t.Fatalf("error = %v, want one mentioning aud", err)
+	}
+}
+
+// #151: a 2-slot rotation (current + previous keys, both exposed via JWKS)
+// must be honored on the console path. Tokens carrying `kid=previousKeyID`
+// are signed with the previous key and must verify against it; tokens with
+// an unknown `kid` must be rejected before signature verification.
+
+func newConsoleTestStoreWithRotation(t *testing.T) (s *Storage, currentKey, previousKey *rsa.PrivateKey) {
+	t.Helper()
+	curr, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa current: %v", err)
+	}
+	prev, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa previous: %v", err)
+	}
+	clk := &clock.FixedClock{T: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)}
+	s = &Storage{
+		clock:         clk,
+		signingKey:    curr,
+		signingKeyID:  "kid-current",
+		previousKey:   prev,
+		previousKeyID: "kid-previous",
+		issuer:        "https://authgate.example.com",
+	}
+	return s, curr, prev
+}
+
+func TestValidateBearerToken_PreviousKeyAcceptedDuringRotation(t *testing.T) {
+	// selectVerificationKey is what implements the kid-based fallback;
+	// exercising it directly avoids the DB roundtrip that follows successful
+	// signature verification.
+	s, _, _ := newConsoleTestStoreWithRotation(t)
+	tok := signedTestJWT(t, s.previousKey, "kid-previous")
+	got, err := s.selectVerificationKey(tok)
+	if err != nil {
+		t.Fatalf("expected previous-key resolution to succeed, got %v", err)
+	}
+	if got != s.previousKey.Public() {
+		t.Fatal("expected resolved key to equal s.previousKey.Public()")
+	}
+}
+
+func TestValidateBearerToken_CurrentKIDResolvesCurrent(t *testing.T) {
+	s, _, _ := newConsoleTestStoreWithRotation(t)
+	tok := signedTestJWT(t, s.signingKey, "kid-current")
+	got, err := s.selectVerificationKey(tok)
+	if err != nil {
+		t.Fatalf("expected current-key resolution to succeed, got %v", err)
+	}
+	if got != s.signingKey.Public() {
+		t.Fatal("expected resolved key to equal s.signingKey.Public()")
+	}
+}
+
+func TestValidateBearerToken_EmptyKIDFallsBackToCurrent(t *testing.T) {
+	s, _, _ := newConsoleTestStoreWithRotation(t)
+	tok := signedTestJWT(t, s.signingKey, "")
+	got, err := s.selectVerificationKey(tok)
+	if err != nil {
+		t.Fatalf("expected empty-kid fallback to succeed, got %v", err)
+	}
+	if got != s.signingKey.Public() {
+		t.Fatal("expected empty-kid fallback to resolve to current key")
+	}
+}
+
+func signedTestJWT(t *testing.T, key *rsa.PrivateKey, kid string) *josejwt.JSONWebToken {
+	t.Helper()
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	raw := signTestTokenWithKID(t, key, kid, josejwt.Claims{
+		Issuer:   "https://authgate.example.com",
+		Subject:  "user-1",
+		Audience: josejwt.Audience{"client-a"},
+		IssuedAt: josejwt.NewNumericDate(now),
+		Expiry:   josejwt.NewNumericDate(now.Add(15 * time.Minute)),
+	})
+	tok, err := josejwt.ParseSigned(raw, []jose.SignatureAlgorithm{jose.RS256})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return tok
+}
+
+func TestValidateBearerToken_UnknownKIDRejected(t *testing.T) {
+	s, curr, _ := newConsoleTestStoreWithRotation(t)
+	now := s.clock.Now()
+	token := signTestTokenWithKID(t, curr, "kid-attacker", josejwt.Claims{
+		Issuer:   "https://authgate.example.com",
+		Subject:  "user-1",
+		Audience: josejwt.Audience{"client-a"},
+		IssuedAt: josejwt.NewNumericDate(now),
+		Expiry:   josejwt.NewNumericDate(now.Add(15 * time.Minute)),
+	})
+
+	_, _, err := s.ValidateBearerTokenWithClientID(context.Background(), "Bearer "+token)
+	if err == nil {
+		t.Fatal("expected rejection of unknown kid")
+	}
+	if !strings.Contains(err.Error(), "unknown key") {
+		t.Fatalf("error = %v, want one mentioning unknown key", err)
+	}
+}
+
+func TestValidateBearerToken_KIDSignedByOtherKeyRejected(t *testing.T) {
+	// Token carries kid=current but is actually signed with the previous key.
+	s, _, prev := newConsoleTestStoreWithRotation(t)
+	now := s.clock.Now()
+	token := signTestTokenWithKID(t, prev, "kid-current", josejwt.Claims{
+		Issuer:   "https://authgate.example.com",
+		Subject:  "user-1",
+		Audience: josejwt.Audience{"client-a"},
+		IssuedAt: josejwt.NewNumericDate(now),
+		Expiry:   josejwt.NewNumericDate(now.Add(15 * time.Minute)),
+	})
+
+	_, _, err := s.ValidateBearerTokenWithClientID(context.Background(), "Bearer "+token)
+	if err == nil || !strings.Contains(err.Error(), "signature") {
+		t.Fatalf("error = %v, want one mentioning signature", err)
 	}
 }


### PR DESCRIPTION
## Summary

Splits the bearer-token verification key lookup into a small helper (`selectVerificationKey`) that picks current vs previous based on the JWT `kid` header:

- `kid` empty → current signing key (legacy fallback)
- `kid == signingKeyID` → current signing key
- `kid == previousKeyID` and `previousKey != nil` → previous signing key
- anything else → `"invalid token: unknown key"`

The single-key `tok.Claims(s.signingKey.Public(), &claims)` call is replaced with `tok.Claims(verifyKey, &claims)` using the helper's result.

Adds 5 table-style tests in `internal/storage/console_unit_test.go`:

- `TestValidateBearerToken_PreviousKeyAcceptedDuringRotation` — kid=previous selects previous public key
- `TestValidateBearerToken_CurrentKIDResolvesCurrent` — kid=current selects current
- `TestValidateBearerToken_EmptyKIDFallsBackToCurrent` — empty kid → current (legacy)
- `TestValidateBearerToken_UnknownKIDRejected` — unknown kid is rejected before signature verification
- `TestValidateBearerToken_KIDSignedByOtherKeyRejected` — kid claims current but signed with previous → "invalid token signature"

The previous tests for issuer / URL audience / missing audience continue to pass.

## Why

`KeySet()` already exposes a 2-slot rotation (current + previous) via JWKS, and the zitadel OP path verifies tokens by kid as part of its standard flow. The console bearer path, however, was hard-pinned to `s.signingKey`. The moment an operator promoted a new key with `SetPreviousKey`, every still-valid access_token signed by the previous key would fail on `/console/me/*` (the JWKS would still list both keys, so external clients verifying tokens directly would not see the same failure). That cliff makes operators reluctant to rotate at all.

Honoring `kid` aligns the console path with JWKS reality and removes the rotation cliff.

## Verification

- `go build ./...` clean
- `go test ./...` pass (full unit suite, including 8 `TestValidateBearerToken_*` cases)
- `go test -tags=integration -count=1 ./internal/storage/... ./internal/integration/... -timeout=180s` pass (storage 14.3s, integration 59.9s)

## Test plan

- [ ] Manual: with `SetSigningKey(newKey, "kid-2")` and `SetPreviousKey(oldKey, "kid-1")`, confirm a console request carrying a token signed by `oldKey` (kid=`kid-1`) succeeds; confirm the same token with kid=`kid-attacker` is rejected with `"invalid token: unknown key"`
- [ ] Reviewer confirms the empty-kid fallback is acceptable for legacy tokens; new tokens issued by zitadel always carry kid (`internal/storage/storage_oidc_device.go` `SigningKey()`)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)