### PR TITLE
fix(adapter): bound CIMD cache size to prevent OOM via unique client_id URLs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kX
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/internal/adapter/mcp/cimd.go
+++ b/internal/adapter/mcp/cimd.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/kangheeyong/authgate/internal/clock"
 	"github.com/kangheeyong/authgate/internal/storage"
 	"golang.org/x/sync/singleflight"
@@ -43,15 +44,33 @@ const (
 	maxCIMDRedirectURILength = 2048
 	maxCIMDGrantTypeCount    = 2
 	maxCIMDResponseTypeCount = 1
+
+	// cimdCacheMaxEntries caps the in-memory cache so a flood of unique
+	// client_id URLs cannot grow the cache without bound (see #159).
+	cimdCacheMaxEntries = 4096
 )
 
 // HTTPCIMDFetcher fetches CIMD metadata via HTTP with SSRF protection and caching.
 type HTTPCIMDFetcher struct {
-	client   *http.Client
-	clock    clock.Clock
-	cache    sync.Map // map[string]*cimdCacheEntry
-	cacheTTL time.Duration
-	sf       singleflight.Group
+	client    *http.Client
+	clock     clock.Clock
+	cache     *lru.Cache[string, *cimdCacheEntry]
+	cacheTTL  time.Duration
+	cacheMax  int // overrides cimdCacheMaxEntries when > 0; primarily for tests.
+	cacheOnce sync.Once
+	sf        singleflight.Group
+}
+
+func (f *HTTPCIMDFetcher) ensureCache() *lru.Cache[string, *cimdCacheEntry] {
+	f.cacheOnce.Do(func() {
+		max := f.cacheMax
+		if max <= 0 {
+			max = cimdCacheMaxEntries
+		}
+		c, _ := lru.New[string, *cimdCacheEntry](max)
+		f.cache = c
+	})
+	return f.cache
 }
 
 // NewHTTPCIMDFetcher creates a CIMD fetcher with SSRF-safe HTTP client.
@@ -96,16 +115,17 @@ func (f *HTTPCIMDFetcher) FetchClient(ctx context.Context, clientID string) (*st
 		return nil, fmt.Errorf("cimd: invalid client_id URL")
 	}
 
+	cache := f.ensureCache()
+
 	// Check cache
-	if entry, ok := f.cache.Load(clientID); ok {
-		ce := entry.(*cimdCacheEntry)
+	if ce, ok := cache.Get(clientID); ok {
 		if f.clock.Now().Before(ce.expiresAt) {
 			if ce.err != nil {
 				return nil, ce.err
 			}
 			return ce.client, nil
 		}
-		f.cache.Delete(clientID)
+		cache.Remove(clientID)
 	}
 
 	// Collapse concurrent cache-miss fetches for the same client_id.
@@ -116,7 +136,7 @@ func (f *HTTPCIMDFetcher) FetchClient(ctx context.Context, clientID string) (*st
 		}
 
 		if ttl > 0 {
-			f.cache.Store(clientID, &cimdCacheEntry{
+			cache.Add(clientID, &cimdCacheEntry{
 				client:    client,
 				expiresAt: f.clock.Now().Add(ttl),
 			})

--- a/internal/adapter/mcp/cimd_fetcher_lru_test.go
+++ b/internal/adapter/mcp/cimd_fetcher_lru_test.go
@@ -1,0 +1,77 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kangheeyong/authgate/internal/clock"
+)
+
+// TestCIMDFetcher_LRUEvictsOldest exercises the unbounded-cache OOM defense
+// from #159: when the cache reaches its max-entries cap, the least-recently-
+// used entry must be evicted instead of growing without bound.
+func TestCIMDFetcher_LRUEvictsOldest(t *testing.T) {
+	var fetchCount atomic.Int32
+	var serverURL string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount.Add(1)
+		meta := CIMDMetadata{
+			ClientID:     serverURL + r.URL.Path,
+			ClientName:   "x",
+			RedirectURIs: []string{"http://localhost:3000/callback"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(meta)
+	}))
+	defer srv.Close()
+	serverURL = srv.URL
+
+	const cap = 4
+	fetcher := &HTTPCIMDFetcher{
+		client:   srv.Client(),
+		clock:    clock.RealClock{},
+		cacheTTL: 5 * time.Minute,
+		cacheMax: cap,
+	}
+
+	// Fill the cache to exactly cap+1 distinct entries; the first inserted
+	// must be evicted.
+	ids := make([]string, cap+1)
+	for i := 0; i < cap+1; i++ {
+		ids[i] = fmt.Sprintf("%s/c%d.json", serverURL, i)
+	}
+	for _, id := range ids {
+		if _, err := fetcher.FetchClient(context.Background(), id); err != nil {
+			t.Fatalf("fetch %s: %v", id, err)
+		}
+	}
+	if got := fetchCount.Load(); got != int32(cap+1) {
+		t.Fatalf("fetchCount after fill = %d, want %d", got, cap+1)
+	}
+
+	// The most-recent cap entries should still be cache hits.
+	prev := fetchCount.Load()
+	for i := 1; i <= cap; i++ {
+		if _, err := fetcher.FetchClient(context.Background(), ids[i]); err != nil {
+			t.Fatalf("recent re-fetch %s: %v", ids[i], err)
+		}
+	}
+	if got := fetchCount.Load(); got != prev {
+		t.Errorf("fetchCount after recent re-fetch = %d, want %d (recent should be cached)", got, prev)
+	}
+
+	// The oldest (ids[0]) must have been evicted; refetching triggers a new HTTP call.
+	prev = fetchCount.Load()
+	if _, err := fetcher.FetchClient(context.Background(), ids[0]); err != nil {
+		t.Fatalf("oldest re-fetch: %v", err)
+	}
+	if got := fetchCount.Load(); got != prev+1 {
+		t.Errorf("fetchCount after oldest re-fetch = %d, want %d (oldest must have been evicted)", got, prev+1)
+	}
+}


### PR DESCRIPTION
Closes #159.

## Summary
- The CIMD fetcher backed its cache with an unbounded `sync.Map`, so a flood of unique `client_id` URLs (e.g. `https://attacker.example/cimd?n=<rand>`) accumulated for the entire TTL window with no eviction pressure — eventually exhausting memory.
- Replace with `hashicorp/golang-lru/v2`, capped at 4096 entries by default. Test fetchers can lower the cap via the new unexported `cacheMax` field.

## Threat reproduced
The added test `TestCIMDFetcher_LRUEvictsOldest` proves the regression by:
1. Building a fetcher with `cacheMax=4`.
2. Fetching 5 distinct `client_id` URLs.
3. Asserting the most-recent 4 are still cached (no new HTTP) and the oldest was evicted (re-fetch issues a new HTTP call).

Before the fix the test would fail at step 3 because every entry would persist.

## Notes
- Periodic sweeper for TTL-expired entries is intentionally **not** added in this PR — bounded LRU alone resolves the OOM threat described in the issue. Stale entries still self-clear on lookup; sweeping can be revisited together with #156's negative-cache work since the two share storage.
- No env var or endpoint surface change → no doc sync needed.

## Test plan
- [x] `go test ./internal/adapter/mcp/`
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)