### PR TITLE
fix(adapter): negative-cache CIMD failures and add per-client failure rate limit

### DIFF
--- a/internal/adapter/mcp/cimd.go
+++ b/internal/adapter/mcp/cimd.go
@@ -141,14 +141,16 @@ func (f *HTTPCIMDFetcher) recordFailure(clientID string, now time.Time) {
 	rec.times = append(pruneOldTimestamps(rec.times, now, cimdFailureWindow), now)
 }
 
-// canonicalCIMDKey returns a normalized form of clientID for cache,
-// rate-limit, and singleflight bookkeeping so trivial URL aliases (host
-// case, redundant default port, path that resolves to the same target) all
-// share one bucket. The fetch and `meta.client_id` validation still use
-// the raw clientID — only internal map keys are normalized.
+// canonicalCIMDKey returns the canonical form of clientID:
+//   - lowercase host
+//   - default `:443` removed
+//   - path.Clean (collapses `//`, resolves `..`)
+//   - any percent-encoding in the path normalized to its decoded form
 //
-// Without this, an attacker can defeat the per-client_id rate limit in
-// #156 by issuing the same logical URL with mutated case or path segments.
+// Used by isCanonicalCIMDClientID to gate non-canonical inputs at the door
+// so that an attacker cannot defeat the per-client_id rate limit (or
+// silently mis-attribute a positive-cache entry to an alias) by mutating
+// trivial parts of the URL.
 func canonicalCIMDKey(clientID string) string {
 	u, err := url.Parse(clientID)
 	if err != nil || u.Scheme == "" || u.Host == "" {
@@ -169,6 +171,23 @@ func canonicalCIMDKey(clientID string) string {
 	u.RawPath = ""
 	u.Fragment = ""
 	return u.String()
+}
+
+// isCanonicalCIMDClientID rejects non-ASCII inputs (closes the IDN/punycode
+// alias class) and inputs that are not already in the canonical form
+// produced by canonicalCIMDKey (closes host-case, default-port,
+// path-segment, and percent-encoding alias classes).
+//
+// Rejecting at the gate means alias variants never enter the cache,
+// rate-limit tracker, or singleflight, so no positive cache entry can be
+// mis-attributed across two raw IDs that share a canonical form.
+func isCanonicalCIMDClientID(clientID string) bool {
+	for _, r := range clientID {
+		if r > 127 {
+			return false
+		}
+	}
+	return canonicalCIMDKey(clientID) == clientID
 }
 
 func pruneOldTimestamps(times []time.Time, now time.Time, window time.Duration) []time.Time {
@@ -223,34 +242,36 @@ func (f *HTTPCIMDFetcher) FetchClient(ctx context.Context, clientID string) (*st
 	if !storage.IsCIMDClientID(clientID) {
 		return nil, fmt.Errorf("cimd: invalid client_id URL")
 	}
+	if !isCanonicalCIMDClientID(clientID) {
+		return nil, fmt.Errorf("cimd: client_id must be in canonical form (lowercase ASCII host, no default port, clean path)")
+	}
 
 	cache := f.ensureCache()
-	key := canonicalCIMDKey(clientID)
 
 	// Check cache (positive or negative entry).
-	if ce, ok := cache.Get(key); ok {
+	if ce, ok := cache.Get(clientID); ok {
 		if f.clock.Now().Before(ce.expiresAt) {
 			if ce.err != nil {
 				return nil, ce.err
 			}
 			return ce.client, nil
 		}
-		cache.Remove(key)
+		cache.Remove(clientID)
 	}
 
 	// Reject without an outbound call when this client_id is currently
 	// rate-limited.
-	if f.isRateLimited(key, f.clock.Now()) {
+	if f.isRateLimited(clientID, f.clock.Now()) {
 		return nil, errCIMDRateLimited
 	}
 
 	// Collapse concurrent cache-miss fetches for the same client_id.
-	v, err, _ := f.sf.Do(key, func() (any, error) {
+	v, err, _ := f.sf.Do(clientID, func() (any, error) {
 		client, ttl, fetchErr := f.fetchAndValidate(ctx, clientID)
 		if fetchErr != nil {
 			now := f.clock.Now()
-			f.recordFailure(key, now)
-			cache.Add(key, &cimdCacheEntry{
+			f.recordFailure(clientID, now)
+			cache.Add(clientID, &cimdCacheEntry{
 				err:       fetchErr,
 				expiresAt: now.Add(cimdNegativeCacheTTL),
 			})
@@ -258,7 +279,7 @@ func (f *HTTPCIMDFetcher) FetchClient(ctx context.Context, clientID string) (*st
 		}
 
 		if ttl > 0 {
-			cache.Add(key, &cimdCacheEntry{
+			cache.Add(clientID, &cimdCacheEntry{
 				client:    client,
 				expiresAt: f.clock.Now().Add(ttl),
 			})

--- a/internal/adapter/mcp/cimd.go
+++ b/internal/adapter/mcp/cimd.go
@@ -48,7 +48,23 @@ const (
 	// cimdCacheMaxEntries caps the in-memory cache so a flood of unique
 	// client_id URLs cannot grow the cache without bound (see #159).
 	cimdCacheMaxEntries = 4096
+
+	// cimdNegativeCacheTTL short-circuits repeat lookups of a failing
+	// client_id so a flood of identical requests cannot keep issuing fresh
+	// outbound HTTP fetches (see #156).
+	cimdNegativeCacheTTL = 30 * time.Second
+
+	// cimdFailureLimit / cimdFailureWindow form a per-client_id failure
+	// quota. Once a single client_id produces this many failures inside the
+	// window, the fetcher rejects further attempts without an outbound call
+	// until the window passes (see #156).
+	cimdFailureLimit  = 5
+	cimdFailureWindow = 5 * time.Minute
 )
+
+// errCIMDRateLimited is returned when a client_id exceeds cimdFailureLimit
+// failures inside cimdFailureWindow.
+var errCIMDRateLimited = fmt.Errorf("cimd: too many recent failures, retry later")
 
 // HTTPCIMDFetcher fetches CIMD metadata via HTTP with SSRF protection and caching.
 type HTTPCIMDFetcher struct {
@@ -59,6 +75,16 @@ type HTTPCIMDFetcher struct {
 	cacheMax  int // overrides cimdCacheMaxEntries when > 0; primarily for tests.
 	cacheOnce sync.Once
 	sf        singleflight.Group
+
+	failuresMu   sync.Mutex
+	failures     *lru.Cache[string, *cimdFailureRecord]
+	failuresOnce sync.Once
+}
+
+// cimdFailureRecord tracks the timestamps of recent failures for a single
+// client_id; entries outside cimdFailureWindow are pruned on access.
+type cimdFailureRecord struct {
+	times []time.Time
 }
 
 func (f *HTTPCIMDFetcher) ensureCache() *lru.Cache[string, *cimdCacheEntry] {
@@ -71,6 +97,57 @@ func (f *HTTPCIMDFetcher) ensureCache() *lru.Cache[string, *cimdCacheEntry] {
 		f.cache = c
 	})
 	return f.cache
+}
+
+func (f *HTTPCIMDFetcher) ensureFailures() *lru.Cache[string, *cimdFailureRecord] {
+	f.failuresOnce.Do(func() {
+		max := f.cacheMax
+		if max <= 0 {
+			max = cimdCacheMaxEntries
+		}
+		c, _ := lru.New[string, *cimdFailureRecord](max)
+		f.failures = c
+	})
+	return f.failures
+}
+
+// isRateLimited reports whether clientID has exceeded cimdFailureLimit
+// failures inside cimdFailureWindow as of now. It also prunes timestamps
+// that have aged out of the window.
+func (f *HTTPCIMDFetcher) isRateLimited(clientID string, now time.Time) bool {
+	f.failuresMu.Lock()
+	defer f.failuresMu.Unlock()
+	rec, ok := f.ensureFailures().Get(clientID)
+	if !ok {
+		return false
+	}
+	rec.times = pruneOldTimestamps(rec.times, now, cimdFailureWindow)
+	return len(rec.times) >= cimdFailureLimit
+}
+
+// recordFailure appends a failure timestamp for clientID, pruning any that
+// have aged out of cimdFailureWindow.
+func (f *HTTPCIMDFetcher) recordFailure(clientID string, now time.Time) {
+	f.failuresMu.Lock()
+	defer f.failuresMu.Unlock()
+	cache := f.ensureFailures()
+	rec, ok := cache.Get(clientID)
+	if !ok {
+		rec = &cimdFailureRecord{}
+		cache.Add(clientID, rec)
+	}
+	rec.times = append(pruneOldTimestamps(rec.times, now, cimdFailureWindow), now)
+}
+
+func pruneOldTimestamps(times []time.Time, now time.Time, window time.Duration) []time.Time {
+	cutoff := now.Add(-window)
+	kept := times[:0]
+	for _, t := range times {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	return kept
 }
 
 // NewHTTPCIMDFetcher creates a CIMD fetcher with SSRF-safe HTTP client.
@@ -117,7 +194,7 @@ func (f *HTTPCIMDFetcher) FetchClient(ctx context.Context, clientID string) (*st
 
 	cache := f.ensureCache()
 
-	// Check cache
+	// Check cache (positive or negative entry).
 	if ce, ok := cache.Get(clientID); ok {
 		if f.clock.Now().Before(ce.expiresAt) {
 			if ce.err != nil {
@@ -128,11 +205,23 @@ func (f *HTTPCIMDFetcher) FetchClient(ctx context.Context, clientID string) (*st
 		cache.Remove(clientID)
 	}
 
+	// Reject without an outbound call when this client_id is currently
+	// rate-limited.
+	if f.isRateLimited(clientID, f.clock.Now()) {
+		return nil, errCIMDRateLimited
+	}
+
 	// Collapse concurrent cache-miss fetches for the same client_id.
 	v, err, _ := f.sf.Do(clientID, func() (any, error) {
-		client, ttl, err := f.fetchAndValidate(ctx, clientID)
-		if err != nil {
-			return nil, err
+		client, ttl, fetchErr := f.fetchAndValidate(ctx, clientID)
+		if fetchErr != nil {
+			now := f.clock.Now()
+			f.recordFailure(clientID, now)
+			cache.Add(clientID, &cimdCacheEntry{
+				err:       fetchErr,
+				expiresAt: now.Add(cimdNegativeCacheTTL),
+			})
+			return nil, fetchErr
 		}
 
 		if ttl > 0 {

--- a/internal/adapter/mcp/cimd.go
+++ b/internal/adapter/mcp/cimd.go
@@ -8,6 +8,8 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -139,6 +141,36 @@ func (f *HTTPCIMDFetcher) recordFailure(clientID string, now time.Time) {
 	rec.times = append(pruneOldTimestamps(rec.times, now, cimdFailureWindow), now)
 }
 
+// canonicalCIMDKey returns a normalized form of clientID for cache,
+// rate-limit, and singleflight bookkeeping so trivial URL aliases (host
+// case, redundant default port, path that resolves to the same target) all
+// share one bucket. The fetch and `meta.client_id` validation still use
+// the raw clientID — only internal map keys are normalized.
+//
+// Without this, an attacker can defeat the per-client_id rate limit in
+// #156 by issuing the same logical URL with mutated case or path segments.
+func canonicalCIMDKey(clientID string) string {
+	u, err := url.Parse(clientID)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return clientID
+	}
+	host := strings.ToLower(u.Hostname())
+	if p := u.Port(); p != "" && p != "443" {
+		host += ":" + p
+	}
+	u.Host = host
+	if u.Path != "" {
+		cleaned := path.Clean(u.Path)
+		if cleaned == "." {
+			cleaned = "/"
+		}
+		u.Path = cleaned
+	}
+	u.RawPath = ""
+	u.Fragment = ""
+	return u.String()
+}
+
 func pruneOldTimestamps(times []time.Time, now time.Time, window time.Duration) []time.Time {
 	cutoff := now.Add(-window)
 	kept := times[:0]
@@ -193,31 +225,32 @@ func (f *HTTPCIMDFetcher) FetchClient(ctx context.Context, clientID string) (*st
 	}
 
 	cache := f.ensureCache()
+	key := canonicalCIMDKey(clientID)
 
 	// Check cache (positive or negative entry).
-	if ce, ok := cache.Get(clientID); ok {
+	if ce, ok := cache.Get(key); ok {
 		if f.clock.Now().Before(ce.expiresAt) {
 			if ce.err != nil {
 				return nil, ce.err
 			}
 			return ce.client, nil
 		}
-		cache.Remove(clientID)
+		cache.Remove(key)
 	}
 
 	// Reject without an outbound call when this client_id is currently
 	// rate-limited.
-	if f.isRateLimited(clientID, f.clock.Now()) {
+	if f.isRateLimited(key, f.clock.Now()) {
 		return nil, errCIMDRateLimited
 	}
 
 	// Collapse concurrent cache-miss fetches for the same client_id.
-	v, err, _ := f.sf.Do(clientID, func() (any, error) {
+	v, err, _ := f.sf.Do(key, func() (any, error) {
 		client, ttl, fetchErr := f.fetchAndValidate(ctx, clientID)
 		if fetchErr != nil {
 			now := f.clock.Now()
-			f.recordFailure(clientID, now)
-			cache.Add(clientID, &cimdCacheEntry{
+			f.recordFailure(key, now)
+			cache.Add(key, &cimdCacheEntry{
 				err:       fetchErr,
 				expiresAt: now.Add(cimdNegativeCacheTTL),
 			})
@@ -225,7 +258,7 @@ func (f *HTTPCIMDFetcher) FetchClient(ctx context.Context, clientID string) (*st
 		}
 
 		if ttl > 0 {
-			cache.Add(clientID, &cimdCacheEntry{
+			cache.Add(key, &cimdCacheEntry{
 				client:    client,
 				expiresAt: f.clock.Now().Add(ttl),
 			})

--- a/internal/adapter/mcp/cimd_canonical_key_test.go
+++ b/internal/adapter/mcp/cimd_canonical_key_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,11 +29,44 @@ func TestCanonicalCIMDKey(t *testing.T) {
 	}
 }
 
-// TestCIMDFetcher_NegativeCacheNormalizesURLAliases verifies the bypass
-// closed in this PR's review: trivial URL aliases must share the negative
-// cache (and rate-limit budget) so they cannot each get a fresh failure
-// quota.
-func TestCIMDFetcher_NegativeCacheNormalizesURLAliases(t *testing.T) {
+func TestIsCanonicalCIMDClientID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		// Already canonical.
+		{"https://example.com/c.json", true},
+		{"https://example.com/path/c.json", true},
+
+		// Host case.
+		{"https://Example.com/c.json", false},
+
+		// Default port.
+		{"https://example.com:443/c.json", false},
+
+		// Path normalization.
+		{"https://example.com//c.json", false},
+		{"https://example.com/x/../c.json", false},
+
+		// Percent-encoding (decodes to a different canonical form).
+		{"https://example.com/a%2Fb/c.json", false},
+
+		// Non-ASCII host (closes IDN/Unicode alias class).
+		{"https://мирзоев.example/c.json", false},
+	}
+	for _, tc := range cases {
+		if got := isCanonicalCIMDClientID(tc.in); got != tc.want {
+			t.Errorf("isCanonicalCIMDClientID(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestCIMDFetcher_RejectsNonCanonicalAtGate verifies the gate fix from the
+// PR review: non-canonical inputs must be rejected before any cache,
+// rate-limit, or HTTP work happens. This closes both the alias rate-limit
+// bypass and the positive-cache mis-attribution between aliases sharing a
+// canonical key.
+func TestCIMDFetcher_RejectsNonCanonicalAtGate(t *testing.T) {
 	fetchCount := 0
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fetchCount++
@@ -43,20 +77,24 @@ func TestCIMDFetcher_NegativeCacheNormalizesURLAliases(t *testing.T) {
 	clk := &clock.FixedClock{T: time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)}
 	fetcher := &HTTPCIMDFetcher{client: srv.Client(), clock: clk, cacheTTL: 5 * time.Minute}
 
-	canonical := srv.URL + "/c.json"
-	aliased := srv.URL + "/x/../c.json"
-
-	if _, err := fetcher.FetchClient(context.Background(), canonical); err == nil {
-		t.Fatal("first fetch should fail")
+	// httptest URL is https://127.0.0.1:<port>/, so :443 stripping and host
+	// case don't apply directly; exercise path-aliasing instead, which is
+	// representative of the alias class.
+	aliases := []string{
+		srv.URL + "//c.json",
+		srv.URL + "/x/../c.json",
+		srv.URL + "/a%2Fb/c.json",
 	}
-	if fetchCount != 1 {
-		t.Fatalf("after first fetch, fetchCount = %d, want 1", fetchCount)
+	for _, alias := range aliases {
+		_, err := fetcher.FetchClient(context.Background(), alias)
+		if err == nil {
+			t.Fatalf("FetchClient(%q) should reject non-canonical input", alias)
+		}
+		if !strings.Contains(err.Error(), "canonical") {
+			t.Errorf("FetchClient(%q) error = %q, want to mention 'canonical'", alias, err.Error())
+		}
 	}
-
-	if _, err := fetcher.FetchClient(context.Background(), aliased); err == nil {
-		t.Fatal("aliased fetch should fail")
-	}
-	if fetchCount != 1 {
-		t.Errorf("aliased fetch issued HTTP, fetchCount = %d, want 1 (negative cache must merge URL aliases)", fetchCount)
+	if fetchCount != 0 {
+		t.Errorf("fetchCount = %d, want 0 (gate must reject before HTTP)", fetchCount)
 	}
 }

--- a/internal/adapter/mcp/cimd_canonical_key_test.go
+++ b/internal/adapter/mcp/cimd_canonical_key_test.go
@@ -53,6 +53,13 @@ func TestIsCanonicalCIMDClientID(t *testing.T) {
 
 		// Non-ASCII host (closes IDN/Unicode alias class).
 		{"https://мирзоев.example/c.json", false},
+
+		// IPv6 literal: intentionally unsupported. The canonical re-
+		// serialization drops the surrounding brackets, so the rebuilt URL
+		// no longer matches the input. If IPv6 CIMD clients are ever
+		// supported, this row will need to flip to true and canonicalCIMDKey
+		// will need bracket-aware host handling.
+		{"https://[::1]/c.json", false},
 	}
 	for _, tc := range cases {
 		if got := isCanonicalCIMDClientID(tc.in); got != tc.want {

--- a/internal/adapter/mcp/cimd_canonical_key_test.go
+++ b/internal/adapter/mcp/cimd_canonical_key_test.go
@@ -1,0 +1,62 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kangheeyong/authgate/internal/clock"
+)
+
+func TestCanonicalCIMDKey(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"https://attacker.example/c.json", "https://attacker.example/c.json"},
+		{"https://Attacker.EXAMPLE/c.json", "https://attacker.example/c.json"},
+		{"https://attacker.example:443/c.json", "https://attacker.example/c.json"},
+		{"https://attacker.example//c.json", "https://attacker.example/c.json"},
+		{"https://attacker.example/x/../c.json", "https://attacker.example/c.json"},
+	}
+	for _, tc := range cases {
+		if got := canonicalCIMDKey(tc.in); got != tc.want {
+			t.Errorf("canonicalCIMDKey(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestCIMDFetcher_NegativeCacheNormalizesURLAliases verifies the bypass
+// closed in this PR's review: trivial URL aliases must share the negative
+// cache (and rate-limit budget) so they cannot each get a fresh failure
+// quota.
+func TestCIMDFetcher_NegativeCacheNormalizesURLAliases(t *testing.T) {
+	fetchCount := 0
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	clk := &clock.FixedClock{T: time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)}
+	fetcher := &HTTPCIMDFetcher{client: srv.Client(), clock: clk, cacheTTL: 5 * time.Minute}
+
+	canonical := srv.URL + "/c.json"
+	aliased := srv.URL + "/x/../c.json"
+
+	if _, err := fetcher.FetchClient(context.Background(), canonical); err == nil {
+		t.Fatal("first fetch should fail")
+	}
+	if fetchCount != 1 {
+		t.Fatalf("after first fetch, fetchCount = %d, want 1", fetchCount)
+	}
+
+	if _, err := fetcher.FetchClient(context.Background(), aliased); err == nil {
+		t.Fatal("aliased fetch should fail")
+	}
+	if fetchCount != 1 {
+		t.Errorf("aliased fetch issued HTTP, fetchCount = %d, want 1 (negative cache must merge URL aliases)", fetchCount)
+	}
+}

--- a/internal/adapter/mcp/cimd_fetcher_cache_test.go
+++ b/internal/adapter/mcp/cimd_fetcher_cache_test.go
@@ -47,7 +47,10 @@ func TestCIMDFetcher_CacheHit(t *testing.T) {
 	}
 }
 
-func TestCIMDFetcher_ErrorResponsesAreNotCached(t *testing.T) {
+// TestCIMDFetcher_NegativeCachesErrors covers #156: failed fetches must be
+// negative-cached for a short TTL so a flood of repeat lookups against a
+// failing client_id cannot keep issuing fresh outbound HTTP requests.
+func TestCIMDFetcher_NegativeCachesErrors(t *testing.T) {
 	fetchCount := 0
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fetchCount++
@@ -66,21 +69,23 @@ func TestCIMDFetcher_ErrorResponsesAreNotCached(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected first fetch to fail, got nil")
 	}
+	// Within the negative-cache TTL the second call must NOT issue HTTP.
 	_, err = fetcher.FetchClient(context.Background(), srv.URL+"/client.json")
 	if err == nil {
 		t.Fatal("expected second fetch to fail, got nil")
 	}
-	if fetchCount != 2 {
-		t.Errorf("fetchCount = %d, want 2 (error response must not be cached)", fetchCount)
+	if fetchCount != 1 {
+		t.Errorf("fetchCount = %d, want 1 (error must be negative-cached)", fetchCount)
 	}
 
+	// Once the negative-cache TTL expires the next call refetches.
 	clk.T = clk.T.Add(31 * time.Second)
 	_, err = fetcher.FetchClient(context.Background(), srv.URL+"/client.json")
 	if err == nil {
 		t.Fatal("expected third fetch to fail, got nil")
 	}
-	if fetchCount != 3 {
-		t.Errorf("fetchCount = %d, want 3", fetchCount)
+	if fetchCount != 2 {
+		t.Errorf("fetchCount = %d, want 2 (negative cache should have expired)", fetchCount)
 	}
 }
 

--- a/internal/adapter/mcp/cimd_fetcher_ratelimit_test.go
+++ b/internal/adapter/mcp/cimd_fetcher_ratelimit_test.go
@@ -1,0 +1,97 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kangheeyong/authgate/internal/clock"
+)
+
+// TestCIMDFetcher_RateLimitsRepeatedFailures covers the per-client failure
+// rate limit from #156: once a single `client_id` produces enough failures
+// inside the failure window, further attempts must be rejected without
+// issuing a new outbound HTTP request — even after the negative-cache TTL
+// expires.
+func TestCIMDFetcher_RateLimitsRepeatedFailures(t *testing.T) {
+	fetchCount := 0
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	clk := &clock.FixedClock{T: time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)}
+	fetcher := &HTTPCIMDFetcher{
+		client:   srv.Client(),
+		clock:    clk,
+		cacheTTL: 5 * time.Minute,
+	}
+	clientID := srv.URL + "/c.json"
+
+	// Trip the limit. We advance past the negative-cache TTL between calls so
+	// each attempt actually reaches fetchAndValidate and registers a failure.
+	for i := 0; i < cimdFailureLimit; i++ {
+		if _, err := fetcher.FetchClient(context.Background(), clientID); err == nil {
+			t.Fatalf("call %d expected error, got nil", i+1)
+		}
+		clk.T = clk.T.Add(cimdNegativeCacheTTL + time.Second)
+	}
+	if fetchCount != cimdFailureLimit {
+		t.Fatalf("fetchCount after limit = %d, want %d", fetchCount, cimdFailureLimit)
+	}
+
+	// Next attempt is still inside the failure window. It must be rejected
+	// without an outbound call.
+	prev := fetchCount
+	_, err := fetcher.FetchClient(context.Background(), clientID)
+	if err == nil {
+		t.Fatal("rate-limited call expected error, got nil")
+	}
+	if fetchCount != prev {
+		t.Errorf("fetchCount after rate-limited call = %d, want %d (must not issue HTTP)", fetchCount, prev)
+	}
+
+	// After the failure window passes the fetcher should accept new attempts.
+	clk.T = clk.T.Add(cimdFailureWindow + time.Second)
+	_, err = fetcher.FetchClient(context.Background(), clientID)
+	if err == nil {
+		t.Fatal("post-window call expected error, got nil")
+	}
+	if fetchCount != prev+1 {
+		t.Errorf("fetchCount after window expiry = %d, want %d (window should reopen)", fetchCount, prev+1)
+	}
+}
+
+// TestCIMDFetcher_RateLimitIsPerClientID confirms a flood against one
+// `client_id` does not block lookups for a different `client_id`.
+func TestCIMDFetcher_RateLimitIsPerClientID(t *testing.T) {
+	failPath := "/bad.json"
+	okPath := "/good.json"
+	var serverURL string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == failPath {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"client_id":"` + serverURL + okPath + `","client_name":"ok","redirect_uris":["http://localhost:3000/callback"]}`))
+	}))
+	defer srv.Close()
+	serverURL = srv.URL
+
+	clk := &clock.FixedClock{T: time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)}
+	fetcher := &HTTPCIMDFetcher{client: srv.Client(), clock: clk, cacheTTL: 5 * time.Minute}
+
+	failID := serverURL + failPath
+	for i := 0; i < cimdFailureLimit+1; i++ {
+		_, _ = fetcher.FetchClient(context.Background(), failID)
+		clk.T = clk.T.Add(cimdNegativeCacheTTL + time.Second)
+	}
+	// Different client_id must succeed even when the failing one is rate-limited.
+	if _, err := fetcher.FetchClient(context.Background(), serverURL+okPath); err != nil {
+		t.Fatalf("unrelated client_id should succeed: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #156.

## Summary
The CIMD fetcher cached only successful fetches, so every authorize attempt against a failing `client_id` issued a fresh outbound HTTPS request — turning authgate into an outbound amplifier when an attacker drove `/authorize` with a URL returning 5xx or `no-store`.

## Changes
- **Negative cache (30s).** Failed fetches are stored in the existing LRU with `err` set so identical repeats short-circuit at the cache layer.
- **Per-client failure rate limit (5 failures / 5 min).** A separate LRU keyed by `client_id` tracks recent failure timestamps. Once a single `client_id` crosses the threshold inside the rolling window, new attempts return `errCIMDRateLimited` without an outbound call until the window passes.
- The failure-tracking LRU is bounded by the same max-entries cap as the metadata cache (`cimdCacheMaxEntries=4096`, see #159), so attacker-generated unique `client_id`s cannot grow failure tracking without bound either.

## Tests
- `TestCIMDFetcher_NegativeCachesErrors` (replaces `TestCIMDFetcher_ErrorResponsesAreNotCached`) — second fetch within 30s does **not** issue HTTP; refetches once the negative TTL elapses.
- `TestCIMDFetcher_RateLimitsRepeatedFailures` — after `cimdFailureLimit` failures spread across the negative-cache TTL, the next call is rejected without HTTP; new attempts unblock once the failure window passes.
- `TestCIMDFetcher_RateLimitIsPerClientID` — a flooded `client_id` does not block lookups for an unrelated `client_id`.

## Notes
- Floor TTL on `no-store` / `max-age<=0` (the third bullet from #156) is intentionally **not** in this PR — it overlaps with #158 and will land there.
- No env var, endpoint, or schema change → no doc sync required.

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [ ] CI green
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)