### PR TITLE
fix(adapter): apply 5s floor TTL to CIMD positive cache

### DIFF
--- a/docs/spec/004-mcp-login.md
+++ b/docs/spec/004-mcp-login.md
@@ -339,27 +339,36 @@ YAML 클라이언트(`clients.yaml`)도 입력 크기/개수 검증 원칙은 �
 
 ### CIMD 캐시 정책
 
-IETF draft 권장사항에 맞춰 성공 응답의 HTTP 캐시 헤더를 우선 적용한다.
-error/invalid 문서는 캐시하지 않는다.
+IETF draft 권장사항에 맞춰 성공 응답의 HTTP 캐시 헤더를 적용하되,
+CIMD 메타데이터의 정적 특성과 outbound-amplification 방어를 위해
+최소 floor TTL을 강제한다. 실패 응답도 짧은 부정 캐시 + 실패 쿼터로
+방어한다.
 
 | 항목 | 값 | 이유 |
 |------|-----|------|
-| **성공 캐시 TTL** | `Cache-Control` 우선 (`max-age`, `no-store`, `no-cache`) | 메타데이터 제공자의 캐시 의도 존중 |
+| **성공 캐시 TTL** | `Cache-Control`(`max-age`, `no-store`, `no-cache`) 해석 후 5초 floor 적용 | 짧거나 부재한 캐시 지시로 인한 outbound 증폭 방어 (#158) |
 | **성공 캐시 TTL fallback** | 5분 | 캐시 헤더가 없을 때 기본값 |
-| **실패/invalid 문서 캐시** | 캐시 안 함 | stale error 고착 방지, draft 권장 준수 |
-| **동시 요청 합치기 (singleflight)** | 동일 client_id에 대해 1개만 실행 | cache miss 시 thundering herd 방지 |
-| **캐시 키** | client_id URL 원본 그대로 | URL 정규화 없음 (CIMD 스펙: 정확 일치) |
-| **재시도/백오프** | 없음 | 실패 시 즉시 에러 반환 |
+| **실패 응답 부정 캐시** | 30초 | 동일 client_id 반복 실패 시 outbound HTTP 차단 (#156) |
+| **실패 쿼터** | 5분 윈도우 내 5회 실패 시 후속 요청 즉시 거부 | 부정 캐시 만료 후에도 amplification 방지 (#156) |
+| **동시 요청 합치기 (singleflight)** | 동일 정규형 client_id에 대해 1개만 실행 | cache miss 시 thundering herd 방지 |
+| **캐시 키** | 정규형 client_id (lowercase host, default port 제거, path.Clean, ASCII 한정) | URL alias로 위 방어선을 우회하지 못하도록 비정규형 입력은 게이트에서 거부 (#156) |
+| **캐시 크기 상한** | 4096 엔트리 (bounded LRU) | 고유 client_id URL 폭주로 인한 OOM 방지 (#159) |
+| **재시도/백오프** | 없음 (실패 쿼터로 대체) | 실패 시 즉시 에러 반환 |
 
 ```text
 캐시 동작 흐름:
 
-요청 → cache hit?
-  ├─ 성공 캐시 (TTL 내) → 캐시된 ClientModel 반환
-  └─ cache miss / 만료 → singleflight로 동시 요청 합치기
-       └─ fetch 실행
-            ├─ 성공 → Cache-Control 기준 TTL로 캐시 (헤더 없으면 5분)
-            └─ 실패/invalid → 캐시하지 않고 에러 반환
+요청 → 정규형 client_id 검증
+  ├─ 비정규형 → 즉시 거부 (HTTP 호출 없음)
+  └─ 정규형 → cache hit?
+       ├─ 성공 캐시 (TTL 내) → 캐시된 ClientModel 반환
+       ├─ 부정 캐시 (TTL 내) → 캐시된 에러 즉시 반환 (HTTP 호출 없음)
+       └─ cache miss / 만료
+            → 실패 쿼터 초과? → 즉시 거부 (HTTP 호출 없음)
+            → singleflight로 동시 요청 합치기
+                 └─ fetch 실행
+                      ├─ 성공 → 서버 TTL ∨ 5초 floor 로 정상 캐시
+                      └─ 실패 → 30초 부정 캐시 + 실패 쿼터 카운트
 ```
 
 ### CIMD 조회 시점별 동작

--- a/internal/adapter/mcp/cimd.go
+++ b/internal/adapter/mcp/cimd.go
@@ -62,6 +62,14 @@ const (
 	// until the window passes (see #156).
 	cimdFailureLimit  = 5
 	cimdFailureWindow = 5 * time.Minute
+
+	// cimdFloorTTL is the minimum positive-cache TTL applied to any
+	// successful response. Server-stated max-age values smaller than this
+	// (or `no-store` / `no-cache` / `max-age<=0`, which previously bypassed
+	// the cache entirely) are raised to the floor so back-to-back identical
+	// fetches cannot keep stalling the worker pool when the upstream is
+	// slow (see #158).
+	cimdFloorTTL = 5 * time.Second
 )
 
 // errCIMDRateLimited is returned when a client_id exceeds cimdFailureLimit
@@ -401,6 +409,17 @@ func (f *HTTPCIMDFetcher) fetchAndValidate(ctx context.Context, clientID string)
 }
 
 func cacheTTLFromCacheControl(cacheControl string, fallback time.Duration) time.Duration {
+	ttl := parseCacheControlTTL(cacheControl, fallback)
+	if ttl < cimdFloorTTL {
+		return cimdFloorTTL
+	}
+	return ttl
+}
+
+// parseCacheControlTTL returns the TTL implied by a Cache-Control header
+// without applying the cimdFloorTTL clamp. `no-store`, `no-cache`, and
+// `max-age<=0` map to 0; an unparseable header falls back to `fallback`.
+func parseCacheControlTTL(cacheControl string, fallback time.Duration) time.Duration {
 	if cacheControl == "" {
 		return fallback
 	}

--- a/internal/adapter/mcp/cimd_fetcher_cache_test.go
+++ b/internal/adapter/mcp/cimd_fetcher_cache_test.go
@@ -142,7 +142,11 @@ func TestCIMDFetcher_CacheExpiry(t *testing.T) {
 	}
 }
 
-func TestCIMDFetcher_RespectsCacheControlMaxAge(t *testing.T) {
+// TestCIMDFetcher_RespectsCacheControlMaxAgeAboveFloor checks that a
+// server-supplied max-age larger than cimdFloorTTL is still honored
+// verbatim (the floor only raises short / missing values, never lowers
+// long ones).
+func TestCIMDFetcher_RespectsCacheControlMaxAgeAboveFloor(t *testing.T) {
 	fetchCount := 0
 	var serverURL string
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -154,7 +158,7 @@ func TestCIMDFetcher_RespectsCacheControlMaxAge(t *testing.T) {
 			GrantTypes:   []string{"authorization_code"},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Cache-Control", "max-age=1")
+		w.Header().Set("Cache-Control", "max-age=10")
 		json.NewEncoder(w).Encode(meta)
 	}))
 	defer srv.Close()
@@ -174,7 +178,7 @@ func TestCIMDFetcher_RespectsCacheControlMaxAge(t *testing.T) {
 		t.Fatalf("fetchCount = %d, want 1 (within max-age)", fetchCount)
 	}
 
-	clk.T = clk.T.Add(2 * time.Second)
+	clk.T = clk.T.Add(11 * time.Second)
 	if _, err := fetcher.FetchClient(context.Background(), clientID); err != nil {
 		t.Fatalf("third fetch failed: %v", err)
 	}
@@ -183,7 +187,12 @@ func TestCIMDFetcher_RespectsCacheControlMaxAge(t *testing.T) {
 	}
 }
 
-func TestCIMDFetcher_NoStoreDisablesCache(t *testing.T) {
+// TestCIMDFetcher_FloorTTLOnNoStore covers #158: even responses that
+// declare `Cache-Control: no-store` (or `max-age=0`) get a small floor TTL
+// so back-to-back identical fetches do not each issue a fresh outbound
+// HTTP request. Without the floor a slow upstream stalls every concurrent
+// authorize attempt for the same client_id.
+func TestCIMDFetcher_FloorTTLOnNoStore(t *testing.T) {
 	fetchCount := 0
 	var serverURL string
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -201,7 +210,8 @@ func TestCIMDFetcher_NoStoreDisablesCache(t *testing.T) {
 	defer srv.Close()
 	serverURL = srv.URL
 
-	fetcher := &HTTPCIMDFetcher{client: srv.Client(), clock: clock.RealClock{}, cacheTTL: 5 * time.Minute}
+	clk := &clock.FixedClock{T: time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)}
+	fetcher := &HTTPCIMDFetcher{client: srv.Client(), clock: clk, cacheTTL: 5 * time.Minute}
 	clientID := serverURL + "/client.json"
 
 	if _, err := fetcher.FetchClient(context.Background(), clientID); err != nil {
@@ -210,7 +220,16 @@ func TestCIMDFetcher_NoStoreDisablesCache(t *testing.T) {
 	if _, err := fetcher.FetchClient(context.Background(), clientID); err != nil {
 		t.Fatalf("second fetch failed: %v", err)
 	}
+	if fetchCount != 1 {
+		t.Errorf("fetchCount = %d, want 1 (floor TTL must short-circuit identical no-store calls)", fetchCount)
+	}
+
+	// After the floor TTL elapses the next call should refetch.
+	clk.T = clk.T.Add(cimdFloorTTL + time.Second)
+	if _, err := fetcher.FetchClient(context.Background(), clientID); err != nil {
+		t.Fatalf("third fetch failed: %v", err)
+	}
 	if fetchCount != 2 {
-		t.Fatalf("fetchCount = %d, want 2 (no-store must disable cache)", fetchCount)
+		t.Errorf("fetchCount = %d, want 2 (floor TTL should expire)", fetchCount)
 	}
 }

--- a/internal/adapter/mcp/cimd_floor_ttl_test.go
+++ b/internal/adapter/mcp/cimd_floor_ttl_test.go
@@ -1,0 +1,31 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCacheTTLFromCacheControl_AppliesFloor(t *testing.T) {
+	fallback := 5 * time.Minute
+	cases := []struct {
+		name string
+		hdr  string
+		want time.Duration
+	}{
+		{"no header falls back to fallback", "", fallback},
+		{"no-store is raised to floor", "no-store", cimdFloorTTL},
+		{"no-cache is raised to floor", "no-cache", cimdFloorTTL},
+		{"max-age=0 is raised to floor", "max-age=0", cimdFloorTTL},
+		{"max-age below floor is raised", "max-age=1", cimdFloorTTL},
+		{"max-age equal to floor is kept", "max-age=5", cimdFloorTTL},
+		{"max-age above floor is kept verbatim", "max-age=600", 600 * time.Second},
+		{"unparseable max-age is raised to floor", "max-age=abc", cimdFloorTTL},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cacheTTLFromCacheControl(tc.hdr, fallback); got != tc.want {
+				t.Errorf("cacheTTLFromCacheControl(%q) = %v, want %v", tc.hdr, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #158.

## Summary
The CIMD fetcher honored every short or absent `Cache-Control` value verbatim. A server returning `no-store`, `max-age=0`, or a tiny `max-age` near the 3s per-fetch timeout caused every authorize attempt to issue a fresh outbound HTTPS GET — letting one slow attacker URL stall concurrent `/authorize` lookups for the same `client_id`.

## Change
`cacheTTLFromCacheControl` now clamps every successful-response TTL up to `cimdFloorTTL = 5s`. Server-stated `max-age` values **above** the floor stay verbatim; only short / missing / `no-store` cases are raised.

The header parsing logic itself is unchanged — `parseCacheControlTTL` retains the prior behavior, and the public function now applies the floor on top.

## Tests
- `TestCacheTTLFromCacheControl_AppliesFloor` (table) — covers `no-store`, `no-cache`, `max-age=0`, max-age below / equal to / above floor, and unparseable values.
- `TestCIMDFetcher_FloorTTLOnNoStore` — replaces the prior `TestCIMDFetcher_NoStoreDisablesCache`. Asserts back-to-back `no-store` fetches share one HTTP call, then refetch after the floor expires.
- `TestCIMDFetcher_RespectsCacheControlMaxAgeAboveFloor` — renamed from `TestCIMDFetcher_RespectsCacheControlMaxAge`; now uses `max-age=10` so it meaningfully demonstrates "server's max-age is honored when it exceeds the floor".

## Notes
- Companion to #156 (negative cache + rate limit, merged) — together they close the three CIMD outbound-amplification vectors flagged in the original report.
- The deferred sweeper goroutine from #159 / #156 is still not in this PR; bounded LRU + floor TTL + negative cache make it unnecessary for the documented threat. Can revisit if memory pressure ever becomes the bottleneck.
- No env var, endpoint, or schema change → no doc sync required.

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [ ] CI green
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)