### PR TITLE
fix(storage): reject closed-account sessions at the storage layer

### DIFF
--- a/internal/service/account.go
+++ b/internal/service/account.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/kangheeyong/authgate/internal/storage"
@@ -34,6 +35,10 @@ func (s *AccountService) RequestDeletion(ctx context.Context, sessionID, ipAddre
 	}
 
 	user, err := s.store.GetValidSession(ctx, sessionID)
+	if errors.Is(err, storage.ErrUserAccountClosed) {
+		s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "browser"})
+		return &AccountResult{Success: false, Message: "account_inactive", ErrorCode: http.StatusForbidden}
+	}
 	if err != nil {
 		return &AccountResult{Success: false, Message: "invalid session", ErrorCode: http.StatusUnauthorized}
 	}

--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -114,6 +114,11 @@ func (s *ConsoleService) resolveAuth(ctx context.Context, sessionID, authHeader 
 		if err == nil {
 			return &consoleAuth{user: user, sessionID: sessionID}, nil
 		}
+		// storage.ErrUserAccountClosed (added in #157) intentionally falls
+		// through to the bearer path. The bearer leg gets its own
+		// status-enforcement gate in #161; once that lands, both legs
+		// reject closed accounts and resolveAuth returns "unauthenticated"
+		// here instead of the prior CheckAccess→403 path.
 	}
 	if authHeader != "" {
 		user, clientID, err := s.store.ValidateBearerTokenWithClientID(ctx, authHeader)

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -78,6 +78,11 @@ func (s *DeviceService) HandleDevicePage(ctx context.Context, userCode, sessionI
 	if errors.Is(err, storage.ErrNotFound) {
 		return s.redirectDeviceToProvider(userCode)
 	}
+	if errors.Is(err, storage.ErrUserAccountClosed) {
+		// Storage flagged a terminal status; ensureDeviceSessionAccess
+		// performs the audit + 403 response.
+		return s.ensureDeviceSessionAccess(ctx, user)
+	}
 	if err != nil {
 		return &DevicePageResult{Action: DeviceError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
 	}
@@ -145,6 +150,10 @@ func (s *DeviceService) HandleDeviceApprove(ctx context.Context, userCode, actio
 	}
 
 	user, err := s.store.GetValidSession(ctx, sessionID)
+	if errors.Is(err, storage.ErrUserAccountClosed) {
+		s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "device"})
+		return &DeviceApproveResult{Success: false, Message: "account_inactive", ErrorCode: http.StatusForbidden}
+	}
 	if err != nil {
 		return &DeviceApproveResult{Success: false, Message: "invalid session", ErrorCode: http.StatusUnauthorized}
 	}

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -99,6 +99,10 @@ func (s *LoginService) handleSessionLogin(ctx context.Context, authRequestID, se
 	}
 
 	user, err := s.store.GetValidSession(ctx, sessionID)
+	if errors.Is(err, storage.ErrUserAccountClosed) {
+		s.auditInactiveUser(ctx, user.ID, user.Status, ipAddress, userAgent)
+		return &LoginResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
+	}
 	if err != nil {
 		return nil
 	}

--- a/internal/service/mcp_login.go
+++ b/internal/service/mcp_login.go
@@ -33,6 +33,10 @@ func (s *MCPLoginService) HandleLogin(ctx context.Context, authRequestID, sessio
 
 	if sessionID != "" {
 		user, err := s.store.GetValidSession(ctx, sessionID)
+		if errors.Is(err, storage.ErrUserAccountClosed) {
+			s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "mcp"})
+			return &LoginResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
+		}
 		if err == nil {
 			if CheckAccess(user.Status, "mcp") != AccessAllow {
 				s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "mcp"})

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -17,6 +17,19 @@ import (
 var (
 	ErrNotFound      = errors.New("not found")
 	ErrEmailConflict = errors.New("email_conflict")
+
+	// ErrUserAccountClosed is returned when a user lookup succeeds but the
+	// account is in a terminal state (`disabled` or `deleted`). The user is
+	// returned alongside the error so callers can emit the right audit
+	// metadata (channel, IP, UA) before rejecting. `pending_deletion` is
+	// passed through without an error because the channel × status policy
+	// in service.CheckAccess permits browser-channel recovery.
+	//
+	// Defense-in-depth for #157: any new caller that does
+	// `if err != nil { return err }` after a session/bearer lookup will
+	// correctly reject closed accounts without needing to remember the
+	// status check itself.
+	ErrUserAccountClosed = errors.New("user account is closed")
 )
 
 // StateChecker validates that a user is still eligible for token issuance.

--- a/internal/storage/storage_integration_test.go
+++ b/internal/storage/storage_integration_test.go
@@ -4,6 +4,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -170,3 +171,62 @@ func TestSession_CreateAndValidate(t *testing.T) {
 }
 
 func ptrStr(s string) *string { return &s }
+
+// TestSession_StatusFilter covers #157: GetValidSession must reject sessions
+// belonging to users in terminal states (`disabled`, `deleted`) at the
+// storage layer with ErrUserAccountClosed, while still passing through
+// `active` and `pending_deletion` so the channel × status policy in
+// service.CheckAccess can handle browser-channel recovery.
+func TestSession_StatusFilter(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   string
+		wantErr  error
+		wantUser bool
+	}{
+		{name: "active user passes through", status: "active", wantErr: nil, wantUser: true},
+		{name: "pending_deletion passes through", status: "pending_deletion", wantErr: nil, wantUser: true},
+		{name: "disabled user is rejected", status: "disabled", wantErr: ErrUserAccountClosed, wantUser: true},
+		{name: "deleted user is rejected", status: "deleted", wantErr: ErrUserAccountClosed, wantUser: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := testStorage(t)
+			ctx := context.Background()
+
+			user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+				Email: tc.name + "@test.com", EmailVerified: true, Name: "Test", AvatarURL: "",
+				Provider: "google", ProviderUserID: "filter-" + tc.name, ProviderEmail: tc.name + "@test.com",
+			})
+			if err != nil {
+				t.Fatalf("create user: %v", err)
+			}
+			if tc.status != "active" {
+				if err := s.SetUserStatus(ctx, user.ID, tc.status); err != nil {
+					t.Fatalf("set status %q: %v", tc.status, err)
+				}
+			}
+
+			sessionID, err := s.CreateSession(ctx, user.ID, 24*time.Hour)
+			if err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+
+			got, err := s.GetValidSession(ctx, sessionID)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("err = %v, want nil", err)
+				}
+			} else if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tc.wantErr)
+			}
+			if tc.wantUser && got == nil {
+				t.Fatalf("user = nil, want non-nil so caller can audit")
+			}
+			if got != nil && got.Status != tc.status {
+				t.Errorf("status = %q, want %q", got.Status, tc.status)
+			}
+		})
+	}
+}

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -295,7 +295,27 @@ func (s *Storage) GetValidSession(ctx context.Context, sessionID string) (*User,
 	if err != nil {
 		return nil, err
 	}
-	return buildFullUser(row.ID, row.Email, row.EmailVerified, row.Name, row.AvatarUrl, row.Status, row.CreatedAt, row.UpdatedAt), nil
+	user := buildFullUser(row.ID, row.Email, row.EmailVerified, row.Name, row.AvatarUrl, row.Status, row.CreatedAt, row.UpdatedAt)
+	if err := requireUsableUser(user); err != nil {
+		return user, err
+	}
+	return user, nil
+}
+
+// requireUsableUser rejects users in terminal states (`disabled`, `deleted`).
+// `active` and `pending_deletion` pass through because the channel × status
+// matrix in service.CheckAccess still has nuanced handling for the latter
+// (browser-channel recovery). The returned user is non-nil so the caller
+// can emit channel-aware audit metadata before propagating the rejection.
+func requireUsableUser(u *User) error {
+	if u == nil {
+		return errors.New("nil user")
+	}
+	switch u.Status {
+	case "disabled", "deleted":
+		return ErrUserAccountClosed
+	}
+	return nil
 }
 
 func buildCoreUser(id, email string, emailVerified bool, name sql.NullString, status string) *User {


### PR DESCRIPTION
Closes #157.

## Summary
`GetValidSession` previously fetched `u.status` via the SQL join but did not enforce it. Today every service-layer caller (`login`, `device`, `mcp`, `console`, `account`) runs `CheckAccess` against the channel × status matrix, so behavior is correct — but the storage layer offered no defense in depth, and any new caller that wrote the natural `if err != nil { return err }` would silently accept `disabled` / `deleted` users.

## Change
- New sentinel `storage.ErrUserAccountClosed` plus the `requireUsableUser` helper. Reject `disabled` / `deleted` only — `pending_deletion` and `active` pass through because the matrix still permits browser-channel recovery for the former.
- `GetValidSession` returns `(user, ErrUserAccountClosed)` so callers can still emit channel-aware audit metadata (`auth.inactive_user`, status, channel) before rejecting.
- Service callers updated to handle the new error path:
  - `service/login.go` (browser session login → audit + 403)
  - `service/mcp_login.go` (mcp session login → audit + 403)
  - `service/device.go` (device page + approve → audit + 403)
  - `service/account.go` (delete request → audit + 403)
- `service/console.go` intentionally **not** changed: its existing fall-through-to-bearer pattern stays — the bearer path will pick up the same defense in #161.

## Tests
- `TestSession_StatusFilter` (new, storage integration): table covering `active`, `pending_deletion`, `disabled`, `deleted`. Asserts the storage-level contract: closed accounts → `ErrUserAccountClosed` with the user still returned for audit; the other two pass through with no error.
- Existing `TestMCPLogin_DeletedSession_Rejected` and `TestMCPLogin_PendingDeletionSession_Rejected` cover the service-layer audit + 403 path through the new code.

## Notes
- No SQL change. The `WHERE u.status = 'active'` option from the issue body would break browser-channel recovery for `pending_deletion`; chose the sentinel approach the issue offers as the alternative.
- Pairs with #161 — once that lands, `ValidateBearerTokenWithClientID` will reuse `requireUsableUser`, so the console fall-through in this PR no longer leaves a gap.

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -tags=integration ./internal/storage/ -run TestSession_StatusFilter -count=0` (compiles)
- [ ] CI green
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)