### PR TITLE
fix(storage): reject closed accounts in bearer-token validation

### DIFF
--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -114,18 +114,24 @@ func (s *ConsoleService) resolveAuth(ctx context.Context, sessionID, authHeader 
 		if err == nil {
 			return &consoleAuth{user: user, sessionID: sessionID}, nil
 		}
-		// storage.ErrUserAccountClosed (added in #157) intentionally falls
-		// through to the bearer path. The bearer leg gets its own
-		// status-enforcement gate in #161; once that lands, both legs
-		// reject closed accounts and resolveAuth returns "unauthenticated"
-		// here instead of the prior CheckAccess→403 path.
+		if errors.Is(err, storage.ErrUserAccountClosed) && user != nil {
+			// Storage flagged a closed account (#157). Pass the user
+			// through so the channel-aware CheckAccess in each console
+			// handler returns 403 with the existing semantics.
+			return &consoleAuth{user: user, sessionID: sessionID}, nil
+		}
 	}
 	if authHeader != "" {
 		user, clientID, err := s.store.ValidateBearerTokenWithClientID(ctx, authHeader)
-		if err != nil {
-			return nil, err
+		if err == nil {
+			return &consoleAuth{user: user, clientID: clientID}, nil
 		}
-		return &consoleAuth{user: user, clientID: clientID}, nil
+		if errors.Is(err, storage.ErrUserAccountClosed) && user != nil {
+			// Same shape as the session leg above; #161 adds the bearer-
+			// path enforcement that produces this sentinel.
+			return &consoleAuth{user: user, clientID: clientID}, nil
+		}
+		return nil, err
 	}
 	return nil, errors.New("unauthenticated")
 }

--- a/internal/storage/console.go
+++ b/internal/storage/console.go
@@ -255,6 +255,13 @@ func (s *Storage) ValidateBearerTokenWithClientID(ctx context.Context, authHeade
 	if err != nil {
 		return nil, "", err
 	}
+	if err := requireUsableUser(user); err != nil {
+		// Defense-in-depth for #161: parallels the GetValidSession gate
+		// added in #157. The user is returned alongside the sentinel so
+		// the console handler's CheckAccess still emits the same 403 +
+		// channel-aware response for closed accounts.
+		return user, clientID, err
+	}
 	return user, clientID, nil
 }
 

--- a/internal/storage/storage_integration_test.go
+++ b/internal/storage/storage_integration_test.go
@@ -4,10 +4,14 @@ package storage
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"errors"
 	"sync"
 	"testing"
 	"time"
+
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
 
 	"github.com/kangheeyong/authgate/internal/clock"
 	"github.com/kangheeyong/authgate/internal/idgen"
@@ -225,6 +229,77 @@ func TestSession_StatusFilter(t *testing.T) {
 				t.Fatalf("user = nil, want non-nil so caller can audit")
 			}
 			if got != nil && got.Status != tc.status {
+				t.Errorf("status = %q, want %q", got.Status, tc.status)
+			}
+		})
+	}
+}
+
+// TestValidateBearerTokenWithClientID_StatusFilter covers #161: the bearer
+// validation path must reject `disabled` / `deleted` accounts at the
+// storage layer with ErrUserAccountClosed (and pass through `active` /
+// `pending_deletion` so service.CheckAccess can apply channel-aware
+// policy).
+func TestValidateBearerTokenWithClientID_StatusFilter(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  string
+		wantErr error
+	}{
+		{name: "active passes through", status: "active", wantErr: nil},
+		{name: "pending_deletion passes through", status: "pending_deletion", wantErr: nil},
+		{name: "disabled is rejected", status: "disabled", wantErr: ErrUserAccountClosed},
+		{name: "deleted is rejected", status: "deleted", wantErr: ErrUserAccountClosed},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := testStorage(t)
+			key, err := rsa.GenerateKey(rand.Reader, 2048)
+			if err != nil {
+				t.Fatalf("rsa key: %v", err)
+			}
+			s.SetSigningKey(key, "kid-1")
+			s.SetIssuer("https://test.authgate")
+
+			ctx := context.Background()
+			user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+				Email: tc.name + "@bearer.test", EmailVerified: true, Name: "Bearer", AvatarURL: "",
+				Provider: "google", ProviderUserID: "bearer-" + tc.name, ProviderEmail: tc.name + "@bearer.test",
+			})
+			if err != nil {
+				t.Fatalf("create user: %v", err)
+			}
+			if tc.status != "active" {
+				if err := s.SetUserStatus(ctx, user.ID, tc.status); err != nil {
+					t.Fatalf("set status %q: %v", tc.status, err)
+				}
+			}
+
+			now := s.clock.Now()
+			token := signTestToken(t, key, josejwt.Claims{
+				Issuer:   "https://test.authgate",
+				Subject:  user.ID,
+				Audience: josejwt.Audience{"client-a"},
+				IssuedAt: josejwt.NewNumericDate(now),
+				Expiry:   josejwt.NewNumericDate(now.Add(15 * time.Minute)),
+			})
+
+			got, gotClientID, err := s.ValidateBearerTokenWithClientID(ctx, "Bearer "+token)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("err = %v, want nil", err)
+				}
+			} else if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tc.wantErr)
+			}
+			if got == nil {
+				t.Fatalf("user = nil, want non-nil so caller can audit")
+			}
+			if gotClientID != "client-a" {
+				t.Errorf("client_id = %q, want client-a", gotClientID)
+			}
+			if got.Status != tc.status {
 				t.Errorf("status = %q, want %q", got.Status, tc.status)
 			}
 		})


### PR DESCRIPTION
Closes #161.

## Summary
`ValidateBearerTokenWithClientID` resolved the JWT subject and returned the user record without checking `u.status`. Console handlers still ran `CheckAccess` afterwards so behavior was correct today, but storage offered no defense in depth — a new caller doing the natural `if err != nil { return err }` after bearer validation would silently accept `disabled` / `deleted` users.

## Change
- Reuse `requireUsableUser` from #157 inside `ValidateBearerTokenWithClientID`. Returns `(user, clientID, ErrUserAccountClosed)` for closed accounts so callers can audit before rejecting.
- `service/console.go` `resolveAuth` is tightened in both legs together: when storage returns `ErrUserAccountClosed` from session **or** bearer, the user is wrapped in `consoleAuth` so the handler's `CheckAccess` preserves the existing 403 response. Without this, a closed account with valid cookie + token would regress from 403 to 401.
- The note added in #157 about the deferred bearer-leg work is now removed because the bearer leg is closed.

## Tests
- `TestValidateBearerTokenWithClientID_StatusFilter` (new, storage integration): table over `active`, `pending_deletion`, `disabled`, `deleted`. Uses a freshly minted RS256 JWT against the real DB.
- Existing console unit tests for closed-account 403 (e.g. `TestConsole_ListClients_DisabledUser_Forbidden`) continue to pass via the new `resolveAuth` pass-through path.

## Pairing
This is the second leg of the storage-level status enforcement started in #157. Together they ensure every storage entry point that resolves a session or token to a user enforces the closed-account terminal states.

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -tags=integration -count=0 ./internal/storage/` (compiles)
- [ ] CI green
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)