### PR TITLE
fix(service): only return user's connected clients from /console/clients

### DIFF
--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -144,9 +144,25 @@ func (s *ConsoleService) ListClients(ctx context.Context, sessionID, authHeader 
 	if CheckAccess(user.Status, "browser") != AccessAllow {
 		return &ClientsResult{ErrorCode: http.StatusForbidden}
 	}
-	clients := s.store.ListAllClients()
-	if clients == nil {
-		clients = []storage.ClientView{}
+
+	// #155: only return clients the requesting user is actually connected
+	// to. Returning the full registered-client roster leaks redirect_uris,
+	// allowed_scopes, and login_channel to any authenticated user, which
+	// is reconnaissance fuel for redirect/scope attacks.
+	connections, err := s.store.GetActiveConnections(ctx, user.ID)
+	if err != nil {
+		return &ClientsResult{ErrorCode: http.StatusInternalServerError}
+	}
+	connected := make(map[string]struct{}, len(connections))
+	for _, c := range connections {
+		connected[c.ClientID] = struct{}{}
+	}
+	all := s.store.ListAllClients()
+	clients := make([]storage.ClientView, 0, len(connected))
+	for _, c := range all {
+		if _, ok := connected[c.ClientID]; ok {
+			clients = append(clients, c)
+		}
 	}
 	return &ClientsResult{Clients: clients}
 }

--- a/internal/service/console_unit_test.go
+++ b/internal/service/console_unit_test.go
@@ -361,6 +361,46 @@ func TestConsole_ListClients_BearerValid_ReturnsClients(t *testing.T) {
 	}
 }
 
+// TestConsole_ListClients_BearerPath_AppliesIntersection ensures the #155
+// filter is applied identically on the bearer-auth path: 2 registered, 1
+// connection, exactly 1 client in the response.
+func TestConsole_ListClients_BearerPath_AppliesIntersection(t *testing.T) {
+	store := bearerStore(&storage.User{ID: "u1", Status: "active"}, nil)
+	store.listAllClientsFn = func() []storage.ClientView {
+		return []storage.ClientView{
+			{ClientID: "app-a", Name: "App A"},
+			{ClientID: "app-b", Name: "App B"},
+		}
+	}
+	store.getActiveConnFn = func(context.Context, string) ([]storage.ConnectionTokenInfo, error) {
+		return []storage.ConnectionTokenInfo{{ClientID: "app-b"}}, nil
+	}
+	svc := NewConsoleService(store)
+	r := svc.ListClients(context.Background(), "", "Bearer valid-token")
+	if r.ErrorCode != 0 {
+		t.Fatalf("want success, got %d", r.ErrorCode)
+	}
+	if len(r.Clients) != 1 || r.Clients[0].ClientID != "app-b" {
+		t.Fatalf("want only app-b, got %+v", r.Clients)
+	}
+}
+
+// TestConsole_ListClients_ConnectionsError_ReturnsInternalError ensures
+// failures from GetActiveConnections surface as 500, not as a silent
+// "no clients" response that could be misread as "user has no
+// connections".
+func TestConsole_ListClients_ConnectionsError_ReturnsInternalError(t *testing.T) {
+	store := activeUserStore([]storage.ClientView{{ClientID: "app-a"}}, nil)
+	store.getActiveConnFn = func(context.Context, string) ([]storage.ConnectionTokenInfo, error) {
+		return nil, errors.New("db down")
+	}
+	svc := NewConsoleService(store)
+	r := svc.ListClients(context.Background(), "sess-1", "")
+	if r.ErrorCode != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", r.ErrorCode)
+	}
+}
+
 func TestConsole_ListClients_BearerInvalid_Unauthorized(t *testing.T) {
 	svc := NewConsoleService(bearerStore(nil, errors.New("invalid token")))
 	r := svc.ListClients(context.Background(), "", "Bearer bad-token")

--- a/internal/service/console_unit_test.go
+++ b/internal/service/console_unit_test.go
@@ -150,29 +150,63 @@ func TestConsole_ListClients_PendingDeletion_Forbidden(t *testing.T) {
 	}
 }
 
-func TestConsole_ListClients_ActiveUser_ReturnsClients(t *testing.T) {
-	clients := []storage.ClientView{
+// TestConsole_ListClients_OnlyReturnsConnectedClients covers #155: the
+// endpoint must NOT return the full registered-client roster to every
+// authenticated user. It must return only the clients the requesting user
+// has an active connection with.
+func TestConsole_ListClients_OnlyReturnsConnectedClients(t *testing.T) {
+	registered := []storage.ClientView{
 		{ClientID: "app-a", Name: "App A"},
 		{ClientID: "app-b", Name: "App B"},
+		{ClientID: "app-c", Name: "App C"},
 	}
-	svc := NewConsoleService(activeUserStore(clients, nil))
+	// User has connected to app-a only.
+	svc := NewConsoleService(activeUserStore(registered, []string{"app-a"}))
 	r := svc.ListClients(context.Background(), "sess-1", "")
 	if r.ErrorCode != 0 {
 		t.Fatalf("want success, got error %d", r.ErrorCode)
 	}
-	if len(r.Clients) != 2 {
-		t.Fatalf("want 2 clients, got %d", len(r.Clients))
+	if len(r.Clients) != 1 {
+		t.Fatalf("want 1 client (app-a), got %d", len(r.Clients))
+	}
+	if r.Clients[0].ClientID != "app-a" {
+		t.Errorf("client_id = %q, want app-a", r.Clients[0].ClientID)
 	}
 }
 
-func TestConsole_ListClients_NilClients_ReturnsEmptySlice(t *testing.T) {
-	svc := NewConsoleService(activeUserStore(nil, nil))
+// TestConsole_ListClients_NoConnections_ReturnsEmpty covers #155: users who
+// have not connected to any registered client must NOT see the registry.
+func TestConsole_ListClients_NoConnections_ReturnsEmpty(t *testing.T) {
+	registered := []storage.ClientView{
+		{ClientID: "app-a", Name: "App A"},
+		{ClientID: "app-b", Name: "App B"},
+	}
+	svc := NewConsoleService(activeUserStore(registered, nil))
 	r := svc.ListClients(context.Background(), "sess-1", "")
 	if r.ErrorCode != 0 {
-		t.Fatalf("want success, got %d", r.ErrorCode)
+		t.Fatalf("want success, got error %d", r.ErrorCode)
+	}
+	if len(r.Clients) != 0 {
+		t.Fatalf("want 0 clients (no connections), got %d", len(r.Clients))
 	}
 	if r.Clients == nil {
 		t.Fatal("want empty slice, got nil")
+	}
+}
+
+// TestConsole_ListClients_DropsRevokedAndUnregistered guards against a
+// connection record whose client_id is no longer in the registered set
+// (admin removed it, or the connection points at a CIMD URL not held in
+// the in-memory map). Such entries must not appear in /console/clients.
+func TestConsole_ListClients_DropsRevokedAndUnregistered(t *testing.T) {
+	registered := []storage.ClientView{{ClientID: "app-a", Name: "App A"}}
+	svc := NewConsoleService(activeUserStore(registered, []string{"app-a", "ghost-client"}))
+	r := svc.ListClients(context.Background(), "sess-1", "")
+	if r.ErrorCode != 0 {
+		t.Fatalf("want success, got error %d", r.ErrorCode)
+	}
+	if len(r.Clients) != 1 || r.Clients[0].ClientID != "app-a" {
+		t.Fatalf("want only app-a, got %+v", r.Clients)
 	}
 }
 
@@ -312,6 +346,10 @@ func TestConsole_ListClients_BearerValid_ReturnsClients(t *testing.T) {
 	store := bearerStore(&storage.User{ID: "u1", Status: "active"}, nil)
 	store.listAllClientsFn = func() []storage.ClientView {
 		return []storage.ClientView{{ClientID: "app-a", Name: "App A"}}
+	}
+	// Bearer-authenticated user has connected to app-a.
+	store.getActiveConnFn = func(context.Context, string) ([]storage.ConnectionTokenInfo, error) {
+		return []storage.ConnectionTokenInfo{{ClientID: "app-a"}}, nil
 	}
 	svc := NewConsoleService(store)
 	r := svc.ListClients(context.Background(), "", "Bearer valid-token")


### PR DESCRIPTION
Closes #155.

## Summary
`ListClients` returned every registered OAuth client — `id`, `login_channel`, `redirect_uris`, `allowed_scopes` — to any user with a valid console session or bearer token. One authenticated account was enough to enumerate the full registry, which is reconnaissance fuel for redirect-uri/scope abuse and channel-targeted attacks.

## Change
`ListClients` now intersects `GetActiveConnections(user.ID)` with `ListAllClients()` and returns only the entries whose `client_id` appears in the user's active connections. Connection records pointing at unregistered or revoked client_ids are dropped.

Trade-off acknowledged: a CIMD client (URL-form `client_id`) won't appear in `/console/clients` because `ListAllClients` only walks the in-memory registry, not CIMD-fetched clients. CIMD connections continue to surface via `/console/me/connections` (a separate endpoint), which is the authoritative view of "what am I connected to". `/console/clients` is purely the registry-management UI surface.

## Tests
The prior `TestConsole_ListClients_BearerValid_ReturnsClients` was wired to assert the leaky behavior (no connections, full registry returned). It's updated to wire a matching connection so it remains a meaningful "bearer-auth round trip" test.

The old `_ActiveUser_ReturnsClients` and `_NilClients_ReturnsEmptySlice` are replaced by three more specific cases:

- `TestConsole_ListClients_OnlyReturnsConnectedClients` — 3 registered, user connected to 1, result has 1.
- `TestConsole_ListClients_NoConnections_ReturnsEmpty` — registered clients exist, user has no connections, result is empty (this is the regression that exists pre-#155).
- `TestConsole_ListClients_DropsRevokedAndUnregistered` — connection records referencing unregistered client_ids are filtered out.

## Notes
- No env var, endpoint contract, schema, or migration change → no doc sync needed.
- A separate admin-only "all clients" endpoint can be added later behind a role gate if operators need that view; out of scope for #155.

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [ ] CI green
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)