### PR TITLE
fix(audit): include client_name alongside client_id in audit metadata

### DIFF
--- a/docs/tests/004-audit-events.md
+++ b/docs/tests/004-audit-events.md
@@ -27,14 +27,15 @@
 | `audit-008` | pending_deletion/disabled/deleted 로그인 시도 | `auth.inactive_user` | `metadata.status` 포함 |
 | `audit-009` | refresh token 재사용 탐지 | `auth.refresh_reuse_detected` | `metadata.family_id` 기록 |
 | `audit-010` | family 전체 revoke | `auth.refresh_family_revoked` | `metadata.family_id` 기록 |
+| `audit-011` | client 컨텍스트가 있는 모든 이벤트 | (해당 이벤트) | `metadata.client_id` + `metadata.client_name`이 함께 기록 (#147) |
 
 ## 채널별 auth.login 검증
 
 | ID | 채널 | 입력 | 기대 metadata |
 |----|------|------|---------------|
-| `audit-login-001` | browser | Browser 로그인 성공 | `{channel: "browser"}` |
-| `audit-login-002` | device | Device 로그인 성공 | `{channel: "device"}` |
-| `audit-login-003` | mcp | MCP 로그인 성공 | `{channel: "mcp"}` |
+| `audit-login-001` | browser | Browser 로그인 성공 | `{channel: "browser", client_id, client_name}` |
+| `audit-login-002` | device | Device 로그인 성공 | `{channel: "device", client_id, client_name}` |
+| `audit-login-003` | mcp | MCP 로그인 성공 | `{channel: "mcp", client_id, client_name}` |
 
 ## 보안 이벤트 검증
 

--- a/internal/service/audit_helper.go
+++ b/internal/service/audit_helper.go
@@ -20,6 +20,11 @@ type clientResolver interface {
 // call sites to embed `client_name` alongside `client_id` so audit rows
 // remain renderable after the connection is revoked or the client_id is
 // retired (#147).
+//
+// The empty-string return is intentional rather than "omit the field": the
+// downstream console renders metadata as a flat object and treats absent
+// keys identically to empty strings; keeping the field always present
+// makes the JSON shape stable for log indexers.
 func resolveClientName(ctx context.Context, store clientResolver, clientID string) string {
 	if clientID == "" {
 		return ""

--- a/internal/service/audit_helper.go
+++ b/internal/service/audit_helper.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"context"
+
+	"github.com/kangheeyong/authgate/internal/storage"
+)
+
+// clientResolver is the minimal slice of the storage interface needed to
+// look up a client's display name for audit metadata. Each service's store
+// interface includes ResolveClient so this helper accepts the full store
+// without ceremony.
+type clientResolver interface {
+	ResolveClient(ctx context.Context, clientID string) (*storage.ClientModel, error)
+}
+
+// resolveClientName returns the human-readable name for clientID, or an
+// empty string when the client cannot be resolved (CIMD URL whose document
+// is no longer cached, removed registry entry, lookup error). Used by audit
+// call sites to embed `client_name` alongside `client_id` so audit rows
+// remain renderable after the connection is revoked or the client_id is
+// retired (#147).
+func resolveClientName(ctx context.Context, store clientResolver, clientID string) string {
+	if clientID == "" {
+		return ""
+	}
+	c, err := store.ResolveClient(ctx, clientID)
+	if err != nil || c == nil {
+		return ""
+	}
+	return c.Name
+}

--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -26,6 +26,7 @@ type ConsoleStore interface {
 	RevokeOtherSessions(ctx context.Context, userID, currentSessionID string) error
 	GetAuditLog(ctx context.Context, userID string, limit, offset int) (*storage.AuditLogPage, error)
 	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any)
+	ResolveClient(ctx context.Context, clientID string) (*storage.ClientModel, error)
 }
 
 func NewConsoleService(store ConsoleStore) *ConsoleService {
@@ -259,7 +260,10 @@ func (s *ConsoleService) RevokeConnection(ctx context.Context, sessionID, authHe
 		return &RevokeConnectionResult{ErrorCode: http.StatusInternalServerError}
 	}
 	info := clientinfo.FromContext(ctx)
-	s.store.AuditLog(ctx, &auth.user.ID, "auth.connection_revoked", info.IP, info.UserAgent, map[string]any{"client_id": clientID})
+	s.store.AuditLog(ctx, &auth.user.ID, "auth.connection_revoked", info.IP, info.UserAgent, map[string]any{
+		"client_id":   clientID,
+		"client_name": resolveClientName(ctx, s.store, clientID),
+	})
 	return &RevokeConnectionResult{}
 }
 

--- a/internal/service/console_unit_test.go
+++ b/internal/service/console_unit_test.go
@@ -23,6 +23,7 @@ type fakeConsoleStore struct {
 	revokeOtherSessionsFn      func(ctx context.Context, userID, currentSessionID string) error
 	getAuditLogFn              func(ctx context.Context, userID string, limit, offset int) (*storage.AuditLogPage, error)
 	auditLogFn                 func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any)
+	resolveClientFn            func(ctx context.Context, clientID string) (*storage.ClientModel, error)
 }
 
 func (f *fakeConsoleStore) GetValidSession(ctx context.Context, sessionID string) (*storage.User, error) {
@@ -67,6 +68,13 @@ func (f *fakeConsoleStore) AuditLog(ctx context.Context, userID *string, eventTy
 		return
 	}
 	f.auditLogFn(ctx, userID, eventType, ipAddress, userAgent, metadata)
+}
+
+func (f *fakeConsoleStore) ResolveClient(ctx context.Context, clientID string) (*storage.ClientModel, error) {
+	if f.resolveClientFn != nil {
+		return f.resolveClientFn(ctx, clientID)
+	}
+	return nil, storage.ErrNotFound
 }
 
 func activeUserStore(clients []storage.ClientView, connIDs []string) *fakeConsoleStore {
@@ -484,6 +492,14 @@ func TestConsole_RevokeConnection_ValidAuth_AuditLogsConnectionRevoked(t *testin
 	var gotUserID, gotEventType string
 	var gotMetadata map[string]any
 	store := activeUserStore(nil, nil)
+	// #147: ResolveClient must be wired so audit metadata carries
+	// client_name alongside client_id.
+	store.resolveClientFn = func(_ context.Context, clientID string) (*storage.ClientModel, error) {
+		if clientID == "app-a" {
+			return &storage.ClientModel{ID: "app-a", Name: "App A"}, nil
+		}
+		return nil, storage.ErrNotFound
+	}
 	store.auditLogFn = func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 		if userID != nil {
 			gotUserID = *userID
@@ -503,6 +519,9 @@ func TestConsole_RevokeConnection_ValidAuth_AuditLogsConnectionRevoked(t *testin
 	}
 	if gotMetadata["client_id"] != "app-a" {
 		t.Fatalf("metadata client_id=%v, want app-a", gotMetadata["client_id"])
+	}
+	if gotMetadata["client_name"] != "App A" {
+		t.Fatalf("metadata client_name=%v, want 'App A' (#147)", gotMetadata["client_name"])
 	}
 }
 

--- a/internal/service/console_unit_test.go
+++ b/internal/service/console_unit_test.go
@@ -525,6 +525,35 @@ func TestConsole_RevokeConnection_ValidAuth_AuditLogsConnectionRevoked(t *testin
 	}
 }
 
+// TestConsole_RevokeConnection_UnresolvedClient_NameIsEmpty pins the
+// fallback contract for #147: an audit event whose client_id cannot be
+// resolved (CIMD URL out of cache, removed registry entry, lookup error)
+// must still emit client_name="" rather than crash or omit other metadata.
+func TestConsole_RevokeConnection_UnresolvedClient_NameIsEmpty(t *testing.T) {
+	var gotMetadata map[string]any
+	store := activeUserStore(nil, nil)
+	// Default resolveClientFn is unset → returns ErrNotFound.
+	store.auditLogFn = func(_ context.Context, _ *string, _, _, _ string, metadata map[string]any) {
+		gotMetadata = metadata
+	}
+	svc := NewConsoleService(store)
+
+	r := svc.RevokeConnection(context.Background(), "sess-1", "", "ghost-client")
+	if r.ErrorCode != 0 {
+		t.Fatalf("want success, got %d", r.ErrorCode)
+	}
+	if gotMetadata["client_id"] != "ghost-client" {
+		t.Fatalf("client_id=%v, want ghost-client", gotMetadata["client_id"])
+	}
+	got, ok := gotMetadata["client_name"]
+	if !ok {
+		t.Fatal("client_name missing; expected key with empty-string value")
+	}
+	if got != "" {
+		t.Fatalf("client_name=%q, want \"\" for unresolved client_id", got)
+	}
+}
+
 func TestConsole_RevokeConnection_OwnClient_BadRequest(t *testing.T) {
 	store := bearerStore(&storage.User{ID: "u1", Status: "active"}, nil)
 	store.validateBearerWithClientFn = func(context.Context, string) (*storage.User, string, error) {

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -28,6 +28,7 @@ type DeviceStore interface {
 	CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error)
 	DenyDeviceCode(ctx context.Context, userCode string) error
 	ApproveDeviceCode(ctx context.Context, userCode, subject string) error
+	ResolveClient(ctx context.Context, clientID string) (*storage.ClientModel, error)
 }
 
 func NewDeviceService(store DeviceStore, provider upstream.Provider, publicURL string, sessionTTL time.Duration, clk clock.Clock) *DeviceService {
@@ -128,9 +129,10 @@ func (s *DeviceService) HandleDeviceCallback(ctx context.Context, code, userCode
 	}
 
 	s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{
-		"channel":    "device",
-		"session_id": sessionID,
-		"client_id":  deviceCode.ClientID,
+		"channel":     "device",
+		"session_id":  sessionID,
+		"client_id":   deviceCode.ClientID,
+		"client_name": resolveClientName(ctx, s.store, deviceCode.ClientID),
 	})
 
 	return &DevicePageResult{Action: DeviceRedirectBack, UserCode: userCode, SessionID: sessionID}

--- a/internal/service/device_unit_test.go
+++ b/internal/service/device_unit_test.go
@@ -19,6 +19,7 @@ type fakeDeviceStore struct {
 	createSessionFn           func(ctx context.Context, userID string, ttl time.Duration) (string, error)
 	denyDeviceCodeFn          func(ctx context.Context, userCode string) error
 	approveDeviceCodeFn       func(ctx context.Context, userCode, subject string) error
+	resolveClientFn           func(ctx context.Context, clientID string) (*storage.ClientModel, error)
 }
 
 func (f *fakeDeviceStore) GetDeviceCodeByUserCode(ctx context.Context, userCode string) (*storage.DeviceCodeModel, error) {
@@ -50,6 +51,13 @@ func (f *fakeDeviceStore) DenyDeviceCode(ctx context.Context, userCode string) e
 
 func (f *fakeDeviceStore) ApproveDeviceCode(ctx context.Context, userCode, subject string) error {
 	return f.approveDeviceCodeFn(ctx, userCode, subject)
+}
+
+func (f *fakeDeviceStore) ResolveClient(ctx context.Context, clientID string) (*storage.ClientModel, error) {
+	if f.resolveClientFn != nil {
+		return f.resolveClientFn(ctx, clientID)
+	}
+	return nil, storage.ErrNotFound
 }
 
 func TestDevice_HandleDevicePage_NoSession_Redirects(t *testing.T) {

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -28,6 +28,7 @@ type LoginStore interface {
 	CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error)
 	GetAuthRequestModel(ctx context.Context, id string) (*storage.AuthRequestModel, error)
 	GetClientLoginChannel(ctx context.Context, clientID string) (string, error)
+	ResolveClient(ctx context.Context, clientID string) (*storage.ClientModel, error)
 }
 
 // verifyAuthRequestChannel ensures the auth_request's client uses the expected
@@ -45,6 +46,7 @@ func verifyAuthRequestChannel(ctx context.Context, store LoginStore, authReq *st
 			"expected_channel": expected,
 			"actual_channel":   channel,
 			"client_id":        authReq.ClientID,
+			"client_name":      resolveClientName(ctx, store, authReq.ClientID),
 		})
 		return "channel_mismatch", http.StatusBadRequest
 	}
@@ -141,6 +143,7 @@ func (s *LoginService) handleExistingSession(ctx context.Context, user *storage.
 		"channel":        "browser",
 		"session_id":     sessionID,
 		"client_id":      authReq.ClientID,
+		"client_name":    resolveClientName(ctx, s.store, authReq.ClientID),
 		"reused_session": true,
 	})
 	return &LoginResult{Action: ActionAutoApprove, AuthRequestID: authRequestID}
@@ -198,10 +201,11 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 		return &CallbackResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
 	}
 	s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{
-		"channel":    "browser",
-		"session_id": sessionID,
-		"client_id":  authReq.ClientID,
-		"signup":     signedUp,
+		"channel":     "browser",
+		"session_id":  sessionID,
+		"client_id":   authReq.ClientID,
+		"client_name": resolveClientName(ctx, s.store, authReq.ClientID),
+		"signup":      signedUp,
 	})
 
 	return &CallbackResult{Action: ActionAutoApprove, AuthRequestID: authRequestID, SessionID: sessionID}

--- a/internal/service/login_unit_test.go
+++ b/internal/service/login_unit_test.go
@@ -21,6 +21,7 @@ type fakeLoginStore struct {
 	createSessionFn           func(ctx context.Context, userID string, ttl time.Duration) (string, error)
 	getAuthRequestModelFn     func(ctx context.Context, id string) (*storage.AuthRequestModel, error)
 	getClientLoginChannelFn   func(ctx context.Context, clientID string) (string, error)
+	resolveClientFn           func(ctx context.Context, clientID string) (*storage.ClientModel, error)
 }
 
 func (f *fakeLoginStore) GetValidSession(ctx context.Context, sessionID string) (*storage.User, error) {
@@ -330,6 +331,13 @@ func TestLogin_HandleLogin_NoSession_Redirect(t *testing.T) {
 func (f *fakeLoginStore) GetAuthRequestModel(ctx context.Context, id string) (*storage.AuthRequestModel, error) {
 	if f.getAuthRequestModelFn != nil {
 		return f.getAuthRequestModelFn(ctx, id)
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (f *fakeLoginStore) ResolveClient(ctx context.Context, clientID string) (*storage.ClientModel, error) {
+	if f.resolveClientFn != nil {
+		return f.resolveClientFn(ctx, clientID)
 	}
 	return nil, storage.ErrNotFound
 }

--- a/internal/service/mcp_login.go
+++ b/internal/service/mcp_login.go
@@ -116,9 +116,10 @@ func (s *MCPLoginService) HandleCallback(ctx context.Context, code, authRequestI
 		return &CallbackResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
 	}
 	s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{
-		"channel":    "mcp",
-		"session_id": sessionID,
-		"client_id":  authReq.ClientID,
+		"channel":     "mcp",
+		"session_id":  sessionID,
+		"client_id":   authReq.ClientID,
+		"client_name": resolveClientName(ctx, s.store, authReq.ClientID),
 	})
 	return &CallbackResult{Action: ActionAutoApprove, AuthRequestID: authRequestID, SessionID: sessionID}
 }

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -51,6 +51,20 @@ func normalizeIPAddress(addr string) string {
 	return ""
 }
 
+// auditClientName returns the human-readable client name for clientID, or
+// "" if it cannot be resolved. Used by storage-level audit call sites to
+// embed `client_name` alongside `client_id` per #147.
+func (s *Storage) auditClientName(ctx context.Context, clientID string) string {
+	if clientID == "" {
+		return ""
+	}
+	c, err := s.ResolveClient(ctx, clientID)
+	if err != nil || c == nil {
+		return ""
+	}
+	return c.Name
+}
+
 // AuditLog records a security/audit event on a best-effort basis. Failures are
 // logged via slog.ErrorContext but never propagated: callers have already
 // committed the underlying business transaction (login, token issue, etc.) and

--- a/internal/storage/clients.go
+++ b/internal/storage/clients.go
@@ -163,7 +163,11 @@ func (s *Storage) SetResourceBindingPolicy(policy ResourceBindingPolicy) {
 	s.resourcePolicy = policy
 }
 
-func (s *Storage) resolveClient(ctx context.Context, clientID string) (*ClientModel, error) {
+// ResolveClient looks up a client by ID through the configured client
+// resolution policy (in-memory registry plus the optional MCP/CIMD
+// fallback). Exported so service-layer audit helpers can fetch the
+// human-readable client name without holding a Storage pointer.
+func (s *Storage) ResolveClient(ctx context.Context, clientID string) (*ClientModel, error) {
 	// Safety net for tests constructing Storage without New().
 	if s.clientPolicy == nil {
 		s.clientPolicy = NewCoreClientResolutionPolicy(s)
@@ -176,7 +180,7 @@ func (s *Storage) resolveClient(ctx context.Context, clientID string) (*ClientMo
 // auth_request issued for one channel cannot be completed via the other
 // channel's login flow.
 func (s *Storage) GetClientLoginChannel(ctx context.Context, clientID string) (string, error) {
-	cm, err := s.resolveClient(ctx, clientID)
+	cm, err := s.ResolveClient(ctx, clientID)
 	if err != nil {
 		return "", err
 	}

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -31,7 +31,7 @@ func (s *Storage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest, 
 
 	resource := ResourceFromContext(ctx)
 	if resource == "" {
-		client, err := s.resolveClient(ctx, req.ClientID)
+		client, err := s.ResolveClient(ctx, req.ClientID)
 		if err == nil {
 			if err := s.resourcePolicy.ValidateAuthorizeRequest(ctx, client, resource); err != nil {
 				return nil, err
@@ -180,8 +180,9 @@ func (s *Storage) CreateAccessAndRefreshTokens(ctx context.Context, request op.T
 	if currentRefreshToken != "" {
 		info := clientinfo.FromContext(ctx)
 		s.AuditLog(ctx, &derived.userID, EventTokenRefresh, info.IP, info.UserAgent, map[string]any{
-			"client_id": derived.clientID,
-			"family_id": derived.familyID,
+			"client_id":   derived.clientID,
+			"client_name": s.auditClientName(ctx, derived.clientID),
+			"family_id":   derived.familyID,
 		})
 	}
 
@@ -257,12 +258,18 @@ func (s *Storage) RevokeToken(ctx context.Context, tokenOrTokenID string, userID
 	info := clientinfo.FromContext(ctx)
 
 	if tryRevokeRefreshByHash(ctx, q, tokenOrTokenID, now) {
-		s.AuditLog(ctx, &userID, EventAuthTokenRevoked, info.IP, info.UserAgent, map[string]any{"client_id": clientID})
+		s.AuditLog(ctx, &userID, EventAuthTokenRevoked, info.IP, info.UserAgent, map[string]any{
+			"client_id":   clientID,
+			"client_name": s.auditClientName(ctx, clientID),
+		})
 		return nil
 	}
 
 	if tryRevokeRefreshByIDReturning(ctx, q, tokenOrTokenID, now) {
-		s.AuditLog(ctx, &userID, EventAuthTokenRevoked, info.IP, info.UserAgent, map[string]any{"client_id": clientID})
+		s.AuditLog(ctx, &userID, EventAuthTokenRevoked, info.IP, info.UserAgent, map[string]any{
+			"client_id":   clientID,
+			"client_name": s.auditClientName(ctx, clientID),
+		})
 	}
 
 	// RFC 7009: always return 200 regardless of whether anything was revoked

--- a/internal/storage/storage_oidc_device.go
+++ b/internal/storage/storage_oidc_device.go
@@ -53,7 +53,7 @@ func (s *Storage) KeySet(ctx context.Context) ([]op.Key, error) {
 // --- op.Storage: OPStorage ---
 
 func (s *Storage) GetClientByClientID(ctx context.Context, clientID string) (op.Client, error) {
-	client, err := s.resolveClient(ctx, clientID)
+	client, err := s.ResolveClient(ctx, clientID)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (s *Storage) GetClientByClientID(ctx context.Context, clientID string) (op.
 }
 
 func (s *Storage) AuthorizeClientIDSecret(ctx context.Context, clientID, clientSecret string) error {
-	client, err := s.resolveClient(ctx, clientID)
+	client, err := s.ResolveClient(ctx, clientID)
 	if err != nil {
 		return ErrNotFound
 	}


### PR DESCRIPTION
Closes #147 (partial — see scope note).

## Summary
Audit rows surfaced via `/console/me/audit-log` carried only `client_id`, which is an opaque slug. Once a connection is revoked or the client is retired, the row's `client_id` cannot be resolved to a friendly name from any user-scoped endpoint, so the Activity tab degrades to unparseable noise.

## Change
Adds `client_name` next to every existing `client_id` audit metadata write:

- service layer: `auth.login` (browser/device/mcp), `auth.channel_mismatch`, `auth.connection_revoked`
- storage layer: `auth.refresh`, `auth.token_revoked`

Wiring:
- New service helper `resolveClientName(ctx, store, clientID)` (`internal/service/audit_helper.go`) and a parallel storage helper `(*Storage).auditClientName`. Both look up the current `ClientModel` via the existing client-resolution policy and return the human-readable name, falling back to `""` for unresolvable IDs (CIMD URL out of cache, removed registry entry).
- `LoginStore`, `DeviceStore`, `ConsoleStore` interfaces gain `ResolveClient`. `AccountStore` is unchanged because its only audit event (`auth.deletion_requested`) has no client context.
- Storage's previously-unexported `resolveClient` is exported as `ResolveClient` for the helpers; in-package callers updated.

## Scope note
The "audit coverage sweep" follow-up — adding `client_id` to `auth.inactive_user` / `auth.refresh_reuse_detected` / `auth.refresh_family_revoked` where client context exists but is currently absent — is intentionally **not** in this PR. The user-visible value of #147 is the `client_name` enrichment (renderable Activity tab). The coverage sweep is a separate concern and can land as a follow-up if the operators ask for it.

## Tests
- `TestConsole_RevokeConnection_ValidAuth_AuditLogsConnectionRevoked` is extended to wire `resolveClientFn` and assert `metadata["client_name"] == "App A"`. Other existing audit-emitting tests continue to pass against the new contract because the default `resolveClientFn` returns `(nil, ErrNotFound)`, which the helpers translate to `client_name: ""`.

## Docs
- `docs/tests/004-audit-events.md`: new `audit-011` row stating the policy + the channel-별 `auth.login` metadata table now includes `client_id, client_name`.

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [ ] CI green
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)