### PR TITLE
fix(storage): recheck user status on device polling (#185)

### DIFF
--- a/internal/integration/integration_device_test.go
+++ b/internal/integration/integration_device_test.go
@@ -161,6 +161,57 @@ func TestIntegration_DeviceConcurrentPolling_ExactlyOneSuccess(t *testing.T) {
 	}
 }
 
+// device-008 / #185: tokens MUST NOT be issued for a user whose status flipped
+// to disabled (or any non-active state) between approve and poll. The device
+// code MUST remain in "approved" rather than transitioning to "consumed", so
+// polling continues to return invalid_grant rather than minting tokens once.
+func TestIntegration_DevicePolling_RechecksUserStatus(t *testing.T) {
+	ts := SetupTestServer(t)
+	ctx := context.Background()
+
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
+		Email: "device-disable@test.com", EmailVerified: true, Name: "Disabled Mid-Flow", AvatarURL: "",
+		Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-disable@test.com",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	authz := startDeviceAuthorization(t, ts)
+	if err := ts.Store.ApproveDeviceCode(ctx, authz.UserCode, user.ID); err != nil {
+		t.Fatalf("approve device code: %v", err)
+	}
+
+	// Operator disables the user AFTER approval, BEFORE poll.
+	if err := ts.Store.SetUserStatus(ctx, user.ID, "disabled"); err != nil {
+		t.Fatalf("disable user: %v", err)
+	}
+
+	result := pollDeviceToken(t, ts, authz.DeviceCode)
+	if result.StatusCode == http.StatusOK {
+		t.Fatalf("token exchange should reject disabled user, got 200 body=%s", result.RawBody)
+	}
+	// zitadel/oidc wraps our invalid_grant into access_denied at the device
+	// endpoint (RFC 8628 §3.5 lists access_denied as a valid device-grant
+	// error). Either signals the closed-account rejection.
+	if !strings.Contains(result.RawBody, "invalid_grant") && !strings.Contains(result.RawBody, "access_denied") {
+		t.Fatalf("expected invalid_grant or access_denied, got body=%s", result.RawBody)
+	}
+
+	// Re-approving (or any retry) must not have silently consumed the device
+	// code. State must still be "approved" so the operator can decide whether
+	// to extend or revoke; certainly not "consumed" which would leave the
+	// caller permanently locked out of retrieving tokens even after the
+	// account is reactivated within the device-code TTL.
+	dc, err := ts.Store.GetDeviceCodeByUserCode(ctx, authz.UserCode)
+	if err != nil {
+		t.Fatalf("re-read device code: %v", err)
+	}
+	if dc.State == "consumed" {
+		t.Errorf("device code state = %q, want %q (closed-account check must not consume the code)", dc.State, "approved")
+	}
+}
+
 // security-001: /device/approve rejects non-POST methods
 func TestIntegration_DeviceApprove_GetRejected(t *testing.T) {
 	ts := SetupTestServer(t)

--- a/internal/integration/integration_device_test.go
+++ b/internal/integration/integration_device_test.go
@@ -162,53 +162,64 @@ func TestIntegration_DeviceConcurrentPolling_ExactlyOneSuccess(t *testing.T) {
 }
 
 // device-008 / #185: tokens MUST NOT be issued for a user whose status flipped
-// to disabled (or any non-active state) between approve and poll. The device
-// code MUST remain in "approved" rather than transitioning to "consumed", so
-// polling continues to return invalid_grant rather than minting tokens once.
+// away from active (disabled, pending_deletion, deleted) between approve and
+// poll. The device code MUST remain in "approved" rather than transitioning
+// to "consumed", so polling continues to return an error rather than minting
+// tokens once after the account is reactivated within the code's TTL.
 func TestIntegration_DevicePolling_RechecksUserStatus(t *testing.T) {
-	ts := SetupTestServer(t)
-	ctx := context.Background()
+	cases := []struct {
+		name       string
+		flipStatus string
+	}{
+		{"disabled", "disabled"},
+		{"pending_deletion", "pending_deletion"},
+		{"deleted", "deleted"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := SetupTestServer(t)
+			ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
-		Email: "device-disable@test.com", EmailVerified: true, Name: "Disabled Mid-Flow", AvatarURL: "",
-		Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-disable@test.com",
-	})
-	if err != nil {
-		t.Fatalf("create user: %v", err)
-	}
+			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
+				Email: "device-" + tc.flipStatus + "@test.com", EmailVerified: true, Name: "Flipped Mid-Flow", AvatarURL: "",
+				Provider: "google", ProviderUserID: "test-google-sub-" + tc.flipStatus, ProviderEmail: "device-" + tc.flipStatus + "@test.com",
+			})
+			if err != nil {
+				t.Fatalf("create user: %v", err)
+			}
 
-	authz := startDeviceAuthorization(t, ts)
-	if err := ts.Store.ApproveDeviceCode(ctx, authz.UserCode, user.ID); err != nil {
-		t.Fatalf("approve device code: %v", err)
-	}
+			authz := startDeviceAuthorization(t, ts)
+			if err := ts.Store.ApproveDeviceCode(ctx, authz.UserCode, user.ID); err != nil {
+				t.Fatalf("approve device code: %v", err)
+			}
 
-	// Operator disables the user AFTER approval, BEFORE poll.
-	if err := ts.Store.SetUserStatus(ctx, user.ID, "disabled"); err != nil {
-		t.Fatalf("disable user: %v", err)
-	}
+			// Operator flips the user status AFTER approval, BEFORE poll.
+			if err := ts.Store.SetUserStatus(ctx, user.ID, tc.flipStatus); err != nil {
+				t.Fatalf("set status %s: %v", tc.flipStatus, err)
+			}
 
-	result := pollDeviceToken(t, ts, authz.DeviceCode)
-	if result.StatusCode == http.StatusOK {
-		t.Fatalf("token exchange should reject disabled user, got 200 body=%s", result.RawBody)
-	}
-	// zitadel/oidc wraps our invalid_grant into access_denied at the device
-	// endpoint (RFC 8628 §3.5 lists access_denied as a valid device-grant
-	// error). Either signals the closed-account rejection.
-	if !strings.Contains(result.RawBody, "invalid_grant") && !strings.Contains(result.RawBody, "access_denied") {
-		t.Fatalf("expected invalid_grant or access_denied, got body=%s", result.RawBody)
-	}
+			result := pollDeviceToken(t, ts, authz.DeviceCode)
+			if result.StatusCode == http.StatusOK {
+				t.Fatalf("token exchange should reject %s user, got 200 body=%s", tc.flipStatus, result.RawBody)
+			}
+			// zitadel/oidc wraps our invalid_grant into access_denied at the
+			// device endpoint (RFC 8628 §3.5 lists access_denied as a valid
+			// device-grant error). Either signals the closed-account rejection.
+			if !strings.Contains(result.RawBody, "invalid_grant") && !strings.Contains(result.RawBody, "access_denied") {
+				t.Fatalf("expected invalid_grant or access_denied, got body=%s", result.RawBody)
+			}
 
-	// Re-approving (or any retry) must not have silently consumed the device
-	// code. State must still be "approved" so the operator can decide whether
-	// to extend or revoke; certainly not "consumed" which would leave the
-	// caller permanently locked out of retrieving tokens even after the
-	// account is reactivated within the device-code TTL.
-	dc, err := ts.Store.GetDeviceCodeByUserCode(ctx, authz.UserCode)
-	if err != nil {
-		t.Fatalf("re-read device code: %v", err)
-	}
-	if dc.State == "consumed" {
-		t.Errorf("device code state = %q, want %q (closed-account check must not consume the code)", dc.State, "approved")
+			// Device code MUST still be in "approved" — not silently consumed,
+			// so the operator can still revoke or extend the approval, and the
+			// caller is not locked out for the remainder of the code's TTL.
+			dc, err := ts.Store.GetDeviceCodeByUserCode(ctx, authz.UserCode)
+			if err != nil {
+				t.Fatalf("re-read device code: %v", err)
+			}
+			if dc.State != "approved" {
+				t.Errorf("device code state = %q, want %q (closed-account check must preserve approval)", dc.State, "approved")
+			}
+		})
 	}
 }
 

--- a/internal/storage/storage_oidc_device.go
+++ b/internal/storage/storage_oidc_device.go
@@ -133,6 +133,23 @@ func (s *Storage) GetDeviceAuthorizatonState(ctx context.Context, clientID, devi
 		return nil, err
 	}
 
+	// #185: defense-in-depth — when an approved device code's bound subject
+	// is no longer authorized to receive tokens (admin disabled, deleted,
+	// pending_deletion), reject the polling attempt with invalid_grant
+	// without consuming the device code. The auth_code and refresh paths
+	// already run stateChecker at issuance; the device branch otherwise
+	// would mint tokens for a user whose status flipped between approve
+	// and poll.
+	if dc.State == "approved" && dc.Subject != nil && s.stateChecker != nil {
+		user, lookupErr := s.getUserByID(ctx, tx, *dc.Subject)
+		if lookupErr != nil {
+			return nil, &oidc.Error{ErrorType: "invalid_grant", Description: "subject lookup failed"}
+		}
+		if checkErr := s.stateChecker(user); checkErr != nil {
+			return nil, &oidc.Error{ErrorType: "invalid_grant", Description: checkErr.Error()}
+		}
+	}
+
 	return resolveDeviceAuthorizationState(ctx, tx, qtx, dc, s.clock.Now())
 }
 


### PR DESCRIPTION
## Summary

Fixes #185.

The device authorization grant's `approved → consumed` transition in `Storage.GetDeviceAuthorizatonState` previously bypassed the `stateChecker` policy that the auth_code and refresh paths run at token issuance. As a result, an admin disabling, deleting, or marking a user `pending_deletion` *after* device approval but *before* the device polled for its token would still mint tokens for the now-closed account.

This PR adds a defense-in-depth `stateChecker` call immediately before the `approved → consumed` transition. On rejection we return `invalid_grant` without consuming the device code, so the operator retains the option to revoke or extend the approval. zitadel/oidc wraps this as `access_denied` at the device endpoint, which is a valid RFC 8628 §3.5 device-grant error.

## Changes

- `internal/storage/storage_oidc_device.go`: stateChecker recheck on `approved` device codes; `invalid_grant` without consuming on failure.
- `internal/integration/integration_device_test.go`: new integration test `TestIntegration_DevicePolling_RechecksUserStatus` exercising the disable-mid-flow scenario, asserting both the rejection and device-code state preservation.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (unit)
- [x] `go test -tags=integration ./internal/storage/` clean
- [x] `go test -tags=integration ./internal/integration/` clean (full suite)
- [x] `TestIntegration_DevicePolling_RechecksUserStatus` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)