### PR TITLE
chore(deps): bump go to 1.25.10 to clear stdlib CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9-alpine AS builder
+FROM golang:1.25.10-alpine AS builder
 ENV GOTOOLCHAIN=local
 
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kangheeyong/authgate
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/go-jose/go-jose/v4 v4.1.3


### PR DESCRIPTION
## Summary

The CI Vulnerability Check began failing on every PR branch after the Go vulndb picked up four 1.25.9 stdlib CVEs. They are all fixed in 1.25.10:

| Advisory | Issue | Reachable in authgate |
|----------|-------|----------------------|
| GO-2026-4982 | `html/template` meta content URL escaping bypass → XSS | yes — `pages.RenderResult` |
| GO-2026-4980 | `html/template` escaper bypass → XSS | yes — `pages.RenderResult` |
| GO-2026-4971 | `net` Dial/LookupPort NUL byte panic on Windows | reached via `sql.Rows.Next`, `http.Transport.RoundTrip`, `net.Resolver.LookupIPAddr` |
| GO-2026-4918 | `golang.org/x/net` HTTP/2 infloop on bad SETTINGS_MAX_FRAME_SIZE | reached via `http.Transport.RoundTrip` |

govulncheck symbol traces show all four as **reachable** in the production package set, so this is a real exposure, not a "flagged but unreachable" finding.

## Changes

- `go.mod`: `go 1.25.9` → `go 1.25.10`. No source changes.

## Test plan

- [x] `go build ./...` clean on 1.25.10
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (unit)
- [x] `go list ./... | grep -v testutil | grep -v integration | xargs govulncheck` → **No vulnerabilities found**
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)