### PR TITLE
fix(storage): gate DELETE /account on status='active' (#183)

### DIFF
--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -47,13 +47,13 @@ SET status = 'active',
     updated_at = $1
 WHERE id = $2 AND status = 'pending_deletion';
 
--- name: MarkUserPendingDeletionByID :exec
+-- name: MarkUserPendingDeletionByID :execrows
 UPDATE users
 SET status = 'pending_deletion',
     deletion_requested_at = $1,
     deletion_scheduled_at = $2,
     updated_at = $1
-WHERE id = $3;
+WHERE id = $3 AND status = 'active';
 
 -- name: RevokeActiveRefreshTokensByUserID :exec
 UPDATE refresh_tokens

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -53,7 +53,7 @@ type Querier interface {
 	ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff sql.NullTime) ([]string, error)
 	MarkRefreshTokenUsedAndRevokedByID(ctx context.Context, arg MarkRefreshTokenUsedAndRevokedByIDParams) error
 	MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedByIDParams) error
-	MarkUserPendingDeletionByID(ctx context.Context, arg MarkUserPendingDeletionByIDParams) error
+	MarkUserPendingDeletionByID(ctx context.Context, arg MarkUserPendingDeletionByIDParams) (int64, error)
 	RecoverPendingDeletionUserByID(ctx context.Context, arg RecoverPendingDeletionUserByIDParams) error
 	RevokeActiveRefreshTokensByUserID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDParams) error
 	RevokeActiveRefreshTokensByUserIDAndClientID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDAndClientIDParams) error

--- a/internal/db/storeq/users.sql.go
+++ b/internal/db/storeq/users.sql.go
@@ -301,13 +301,13 @@ func (q *Queries) InsertUserIdentity(ctx context.Context, arg InsertUserIdentity
 	return err
 }
 
-const markUserPendingDeletionByID = `-- name: MarkUserPendingDeletionByID :exec
+const markUserPendingDeletionByID = `-- name: MarkUserPendingDeletionByID :execrows
 UPDATE users
 SET status = 'pending_deletion',
     deletion_requested_at = $1,
     deletion_scheduled_at = $2,
     updated_at = $1
-WHERE id = $3
+WHERE id = $3 AND status = 'active'
 `
 
 type MarkUserPendingDeletionByIDParams struct {
@@ -316,9 +316,12 @@ type MarkUserPendingDeletionByIDParams struct {
 	ID                  string
 }
 
-func (q *Queries) MarkUserPendingDeletionByID(ctx context.Context, arg MarkUserPendingDeletionByIDParams) error {
-	_, err := q.db.ExecContext(ctx, markUserPendingDeletionByID, arg.DeletionRequestedAt, arg.DeletionScheduledAt, arg.ID)
-	return err
+func (q *Queries) MarkUserPendingDeletionByID(ctx context.Context, arg MarkUserPendingDeletionByIDParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, markUserPendingDeletionByID, arg.DeletionRequestedAt, arg.DeletionScheduledAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const recoverPendingDeletionUserByID = `-- name: RecoverPendingDeletionUserByID :exec

--- a/internal/service/account.go
+++ b/internal/service/account.go
@@ -54,6 +54,14 @@ func (s *AccountService) RequestDeletion(ctx context.Context, sessionID, ipAddre
 	}
 
 	if err := s.store.RequestDeletion(ctx, user.ID); err != nil {
+		// #183: storage rejects the conditional UPDATE when the row's status is
+		// no longer 'active' (e.g. the operator disabled the user between
+		// session validation and the UPDATE). Translate to the same 403
+		// account_inactive surface that GetValidSession's check uses.
+		if errors.Is(err, storage.ErrUserAccountClosed) {
+			s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "browser", "phase": "account_deletion"})
+			return &AccountResult{Success: false, Message: "account_inactive", ErrorCode: http.StatusForbidden}
+		}
 		return &AccountResult{Success: false, Message: "internal_error", ErrorCode: http.StatusInternalServerError}
 	}
 

--- a/internal/service/account.go
+++ b/internal/service/account.go
@@ -14,7 +14,11 @@ type AccountService struct {
 
 type AccountStore interface {
 	GetValidSession(ctx context.Context, sessionID string) (*storage.User, error)
-	RequestDeletion(ctx context.Context, userID string) error
+	// RequestDeletion returns the live user status (read inside the same TX as
+	// the conditional UPDATE) when err is ErrUserAccountClosed, so the caller
+	// can record the actual closed-account state in audit logs rather than the
+	// stale session-snapshot status. Empty string otherwise.
+	RequestDeletion(ctx context.Context, userID string) (string, error)
 	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any)
 }
 
@@ -53,13 +57,16 @@ func (s *AccountService) RequestDeletion(ctx context.Context, sessionID, ipAddre
 		return &AccountResult{Success: true, Message: "Already pending deletion. Login within 30 days to cancel."}
 	}
 
-	if err := s.store.RequestDeletion(ctx, user.ID); err != nil {
+	liveStatus, err := s.store.RequestDeletion(ctx, user.ID)
+	if err != nil {
 		// #183: storage rejects the conditional UPDATE when the row's status is
 		// no longer 'active' (e.g. the operator disabled the user between
 		// session validation and the UPDATE). Translate to the same 403
-		// account_inactive surface that GetValidSession's check uses.
+		// account_inactive surface that GetValidSession's check uses, and
+		// audit the *live* status returned by storage rather than the
+		// session-snapshot user.Status, which may already be stale.
 		if errors.Is(err, storage.ErrUserAccountClosed) {
-			s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": user.Status, "channel": "browser", "phase": "account_deletion"})
+			s.store.AuditLog(ctx, &user.ID, "auth.inactive_user", ipAddress, userAgent, map[string]any{"status": liveStatus, "channel": "browser", "phase": "account_deletion"})
 			return &AccountResult{Success: false, Message: "account_inactive", ErrorCode: http.StatusForbidden}
 		}
 		return &AccountResult{Success: false, Message: "internal_error", ErrorCode: http.StatusInternalServerError}

--- a/internal/service/account_unit_test.go
+++ b/internal/service/account_unit_test.go
@@ -11,7 +11,7 @@ import (
 
 type fakeAccountStore struct {
 	getValidSessionFn func(ctx context.Context, sessionID string) (*storage.User, error)
-	requestDeletionFn func(ctx context.Context, userID string) error
+	requestDeletionFn func(ctx context.Context, userID string) (string, error)
 	auditLogFn        func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any)
 }
 
@@ -19,7 +19,7 @@ func (f *fakeAccountStore) GetValidSession(ctx context.Context, sessionID string
 	return f.getValidSessionFn(ctx, sessionID)
 }
 
-func (f *fakeAccountStore) RequestDeletion(ctx context.Context, userID string) error {
+func (f *fakeAccountStore) RequestDeletion(ctx context.Context, userID string) (string, error) {
 	return f.requestDeletionFn(ctx, userID)
 }
 
@@ -36,9 +36,9 @@ func TestAccount_RequestDeletion_PendingDeletion_IsIdempotent(t *testing.T) {
 		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
 			return &storage.User{ID: "u1", Status: "pending_deletion"}, nil
 		},
-		requestDeletionFn: func(context.Context, string) error {
+		requestDeletionFn: func(context.Context, string) (string, error) {
 			calledDelete = true
-			return nil
+			return "", nil
 		},
 	}
 	svc := NewAccountService(store)
@@ -63,9 +63,9 @@ func TestAccount_RequestDeletion_ActiveUser_Success(t *testing.T) {
 		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
 			return &storage.User{ID: "u1", Status: "active"}, nil
 		},
-		requestDeletionFn: func(context.Context, string) error {
+		requestDeletionFn: func(context.Context, string) (string, error) {
 			calledDelete = true
-			return nil
+			return "", nil
 		},
 		auditLogFn: func(context.Context, *string, string, string, string, map[string]any) {
 			calledAudit = true
@@ -86,13 +86,63 @@ func TestAccount_RequestDeletion_ActiveUser_Success(t *testing.T) {
 	}
 }
 
+// #183: when storage returns ErrUserAccountClosed (because the user was
+// disabled between session validation and the conditional UPDATE), the
+// service must (a) return 403 account_inactive and (b) audit the *live*
+// status from storage, not the stale session-snapshot status. The audit
+// metadata must also carry phase=account_deletion so operators can
+// distinguish UPDATE-time rejections from session-time rejections.
+func TestAccount_RequestDeletion_StorageRejectsClosedAccount(t *testing.T) {
+	var auditMeta map[string]any
+	var auditEventType string
+	store := &fakeAccountStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			// session-time snapshot is still active (the race window)
+			return &storage.User{ID: "u1", Status: "active"}, nil
+		},
+		requestDeletionFn: func(context.Context, string) (string, error) {
+			// storage saw status flip to disabled inside its TX
+			return "disabled", storage.ErrUserAccountClosed
+		},
+		auditLogFn: func(_ context.Context, _ *string, eventType, _, _ string, metadata map[string]any) {
+			auditEventType = eventType
+			auditMeta = metadata
+		},
+	}
+	svc := NewAccountService(store)
+
+	result := svc.RequestDeletion(context.Background(), "sess-1", "127.0.0.1", "ua")
+
+	if result.Success {
+		t.Fatal("storage rejection must produce failure result")
+	}
+	if result.ErrorCode != 403 {
+		t.Errorf("errorCode = %d, want 403", result.ErrorCode)
+	}
+	if result.Message != "account_inactive" {
+		t.Errorf("message = %q, want account_inactive", result.Message)
+	}
+	if auditEventType != "auth.inactive_user" {
+		t.Errorf("audit event_type = %q, want auth.inactive_user", auditEventType)
+	}
+	if auditMeta["status"] != "disabled" {
+		t.Errorf("audit status = %v, want %q (live status from storage, not session snapshot)", auditMeta["status"], "disabled")
+	}
+	if auditMeta["phase"] != "account_deletion" {
+		t.Errorf("audit phase = %v, want account_deletion", auditMeta["phase"])
+	}
+	if auditMeta["channel"] != "browser" {
+		t.Errorf("audit channel = %v, want browser", auditMeta["channel"])
+	}
+}
+
 func TestAccount_RequestDeletion_InvalidSession(t *testing.T) {
 	store := &fakeAccountStore{
 		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
 			return nil, errors.New("invalid")
 		},
-		requestDeletionFn: func(context.Context, string) error {
-			return nil
+		requestDeletionFn: func(context.Context, string) (string, error) {
+			return "", nil
 		},
 	}
 	svc := NewAccountService(store)

--- a/internal/storage/storage_integration_test.go
+++ b/internal/storage/storage_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"database/sql"
 	"errors"
 	"sync"
 	"testing"
@@ -341,9 +342,12 @@ func TestRequestDeletion_RejectsClosedAccount(t *testing.T) {
 				t.Fatalf("flip status: %v", err)
 			}
 
-			err = s.RequestDeletion(ctx, user.ID)
+			liveStatus, err := s.RequestDeletion(ctx, user.ID)
 			if !errors.Is(err, tc.wantErr) {
 				t.Fatalf("RequestDeletion err = %v, want %v", err, tc.wantErr)
+			}
+			if liveStatus != tc.wantFinalState {
+				t.Errorf("liveStatus = %q, want %q (caller must see actual closed-account state for audit)", liveStatus, tc.wantFinalState)
 			}
 
 			got, err := s.GetUserByID(ctx, user.ID)
@@ -359,11 +363,18 @@ func TestRequestDeletion_RejectsClosedAccount(t *testing.T) {
 
 // #183 (companion): pending_deletion must remain idempotent — calling
 // RequestDeletion again returns nil and does not error, since the user is
-// already in the target state. The UPDATE must not double-bump
-// deletion_requested_at because that would extend the recovery window.
+// already in the target state. Critically, the UPDATE must NOT bump
+// deletion_requested_at on retry because that would extend the 30-day
+// recovery window every time a client retries — a vulnerability of its
+// own (the user could keep the account in indefinite "pending" by
+// hammering DELETE /account).
 func TestRequestDeletion_PendingDeletionIsIdempotent(t *testing.T) {
 	ctx := context.Background()
-	s := testStorage(t)
+	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
+	gen := idgen.CryptoGenerator{}
+	noopChecker := func(user *User) error { return nil }
+	db := testutil.SetupPostgres(t)
+	s := New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
 
 	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
 		Email: "del-idem@test.com", EmailVerified: true, Name: "Del Idem",
@@ -373,7 +384,7 @@ func TestRequestDeletion_PendingDeletionIsIdempotent(t *testing.T) {
 		t.Fatalf("create user: %v", err)
 	}
 
-	if err := s.RequestDeletion(ctx, user.ID); err != nil {
+	if _, err := s.RequestDeletion(ctx, user.ID); err != nil {
 		t.Fatalf("first RequestDeletion: %v", err)
 	}
 
@@ -381,13 +392,30 @@ func TestRequestDeletion_PendingDeletionIsIdempotent(t *testing.T) {
 	if got1.Status != "pending_deletion" {
 		t.Fatalf("first call status = %q, want pending_deletion", got1.Status)
 	}
+	var firstReq, firstSched sql.NullTime
+	if err := db.QueryRowContext(ctx, `SELECT deletion_requested_at, deletion_scheduled_at FROM users WHERE id = $1`, user.ID).Scan(&firstReq, &firstSched); err != nil {
+		t.Fatalf("read first deletion timestamps: %v", err)
+	}
 
-	// Second call: must succeed without changing deletion_requested_at.
-	if err := s.RequestDeletion(ctx, user.ID); err != nil {
+	// Advance clock so a buggy double-bump would be observable.
+	clk.T = clk.T.Add(48 * time.Hour)
+
+	if _, err := s.RequestDeletion(ctx, user.ID); err != nil {
 		t.Fatalf("second RequestDeletion: %v", err)
 	}
 	got2, _ := s.GetUserByID(ctx, user.ID)
 	if got2.Status != "pending_deletion" {
 		t.Errorf("second call status = %q, want pending_deletion", got2.Status)
+	}
+
+	var secondReq, secondSched sql.NullTime
+	if err := db.QueryRowContext(ctx, `SELECT deletion_requested_at, deletion_scheduled_at FROM users WHERE id = $1`, user.ID).Scan(&secondReq, &secondSched); err != nil {
+		t.Fatalf("read second deletion timestamps: %v", err)
+	}
+	if !secondReq.Time.Equal(firstReq.Time) {
+		t.Errorf("deletion_requested_at bumped on retry: first=%v second=%v (recovery window must not extend)", firstReq.Time, secondReq.Time)
+	}
+	if !secondSched.Time.Equal(firstSched.Time) {
+		t.Errorf("deletion_scheduled_at bumped on retry: first=%v second=%v", firstSched.Time, secondSched.Time)
 	}
 }

--- a/internal/storage/storage_integration_test.go
+++ b/internal/storage/storage_integration_test.go
@@ -305,3 +305,89 @@ func TestValidateBearerTokenWithClientID_StatusFilter(t *testing.T) {
 		})
 	}
 }
+
+// #183: RequestDeletion must NOT overwrite a closed-account status. The
+// browser-channel recovery path treats `pending_deletion` as recoverable, so
+// if `disabled` (operator suspension) silently became `pending_deletion`
+// because the conditional UPDATE was missing, the user could log back in and
+// reach `active` again — bypassing the suspension entirely.
+//
+// This test exercises the storage invariant directly (bypassing
+// GetValidSession's status filter) to model the operator-side race: a user
+// has a valid session, then gets disabled in between session validation and
+// the storage UPDATE.
+func TestRequestDeletion_RejectsClosedAccount(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name           string
+		flipStatus     string
+		wantErr        error
+		wantFinalState string
+	}{
+		{"disabled", "disabled", ErrUserAccountClosed, "disabled"},
+		{"deleted", "deleted", ErrUserAccountClosed, "deleted"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := testStorage(t)
+			user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+				Email: "del-" + tc.flipStatus + "@test.com", EmailVerified: true, Name: "Del " + tc.flipStatus,
+				Provider: "google", ProviderUserID: "del-sub-" + tc.flipStatus, ProviderEmail: "del-" + tc.flipStatus + "@test.com",
+			})
+			if err != nil {
+				t.Fatalf("create user: %v", err)
+			}
+			if err := s.SetUserStatus(ctx, user.ID, tc.flipStatus); err != nil {
+				t.Fatalf("flip status: %v", err)
+			}
+
+			err = s.RequestDeletion(ctx, user.ID)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("RequestDeletion err = %v, want %v", err, tc.wantErr)
+			}
+
+			got, err := s.GetUserByID(ctx, user.ID)
+			if err != nil {
+				t.Fatalf("re-read user: %v", err)
+			}
+			if got.Status != tc.wantFinalState {
+				t.Errorf("status after rejected deletion = %q, want %q (closed-account suspension lost)", got.Status, tc.wantFinalState)
+			}
+		})
+	}
+}
+
+// #183 (companion): pending_deletion must remain idempotent — calling
+// RequestDeletion again returns nil and does not error, since the user is
+// already in the target state. The UPDATE must not double-bump
+// deletion_requested_at because that would extend the recovery window.
+func TestRequestDeletion_PendingDeletionIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	s := testStorage(t)
+
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+		Email: "del-idem@test.com", EmailVerified: true, Name: "Del Idem",
+		Provider: "google", ProviderUserID: "del-idem-sub", ProviderEmail: "del-idem@test.com",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	if err := s.RequestDeletion(ctx, user.ID); err != nil {
+		t.Fatalf("first RequestDeletion: %v", err)
+	}
+
+	got1, _ := s.GetUserByID(ctx, user.ID)
+	if got1.Status != "pending_deletion" {
+		t.Fatalf("first call status = %q, want pending_deletion", got1.Status)
+	}
+
+	// Second call: must succeed without changing deletion_requested_at.
+	if err := s.RequestDeletion(ctx, user.ID); err != nil {
+		t.Fatalf("second RequestDeletion: %v", err)
+	}
+	got2, _ := s.GetUserByID(ctx, user.ID)
+	if got2.Status != "pending_deletion" {
+		t.Errorf("second call status = %q, want pending_deletion", got2.Status)
+	}
+}

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -179,7 +179,14 @@ func (s *Storage) SetUserStatus(ctx context.Context, userID, status string) erro
 // RequestDeletion sets a user to pending_deletion and revokes all refresh tokens. Single TX.
 // Sessions are intentionally NOT revoked here — they expire naturally (24h TTL).
 // Revoking refresh tokens immediately blocks new access token issuance, which is sufficient
-// per industry standard (Auth0, Okta pattern). Idempotent: safe to call multiple times.
+// per industry standard (Auth0, Okta pattern).
+//
+// #183: the UPDATE is gated on `status='active'` so an admin-set `disabled`
+// or a cleanup-set `deleted` cannot be silently overwritten. If the gate
+// rejects the row, we re-read the user inside the same TX:
+//   - `pending_deletion` → idempotent success (already in target state)
+//   - `disabled` / `deleted` → ErrUserAccountClosed (caller emits 403)
+//   - any other state → an error
 func (s *Storage) RequestDeletion(ctx context.Context, userID string) error {
 	now := s.clock.Now()
 	scheduledAt := now.Add(30 * 24 * time.Hour)
@@ -192,20 +199,41 @@ func (s *Storage) RequestDeletion(ctx context.Context, userID string) error {
 
 	qtx := storeq.New(tx)
 
-	err = markUserPendingDeletion(ctx, qtx, userID, now, scheduledAt)
+	rows, err := markUserPendingDeletion(ctx, qtx, userID, now, scheduledAt)
 	if err != nil {
 		return err
 	}
 
-	err = revokeActiveRefreshTokensForDeletion(ctx, qtx, userID, now)
-	if err != nil {
+	if rows == 0 {
+		current, err := s.getUserByID(ctx, tx, userID)
+		if err != nil {
+			return err
+		}
+		switch current.Status {
+		case "pending_deletion":
+			// Idempotent: already in target state. Re-running the refresh-token
+			// revoke is safe (`WHERE revoked_at IS NULL`) and protects against
+			// the case where the previous transition crashed between the
+			// status flip and the token revoke.
+			if err := revokeActiveRefreshTokensForDeletion(ctx, qtx, userID, now); err != nil {
+				return err
+			}
+			return tx.Commit()
+		case "disabled", "deleted":
+			return ErrUserAccountClosed
+		default:
+			return errors.New("unexpected user status for deletion: " + current.Status)
+		}
+	}
+
+	if err := revokeActiveRefreshTokensForDeletion(ctx, qtx, userID, now); err != nil {
 		return err
 	}
 
 	return tx.Commit()
 }
 
-func markUserPendingDeletion(ctx context.Context, qtx *storeq.Queries, userID string, now, scheduledAt time.Time) error {
+func markUserPendingDeletion(ctx context.Context, qtx *storeq.Queries, userID string, now, scheduledAt time.Time) (int64, error) {
 	return qtx.MarkUserPendingDeletionByID(ctx, storeq.MarkUserPendingDeletionByIDParams{
 		DeletionRequestedAt: sql.NullTime{Time: now, Valid: true},
 		DeletionScheduledAt: sql.NullTime{Time: scheduledAt, Valid: true},

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -187,13 +187,17 @@ func (s *Storage) SetUserStatus(ctx context.Context, userID, status string) erro
 //   - `pending_deletion` → idempotent success (already in target state)
 //   - `disabled` / `deleted` → ErrUserAccountClosed (caller emits 403)
 //   - any other state → an error
-func (s *Storage) RequestDeletion(ctx context.Context, userID string) error {
+//
+// Returns the live status read inside the TX when ErrUserAccountClosed is
+// returned, so the caller can record the *actual* state in audit logs
+// rather than the stale session-snapshot status. Empty string otherwise.
+func (s *Storage) RequestDeletion(ctx context.Context, userID string) (string, error) {
 	now := s.clock.Now()
 	scheduledAt := now.Add(30 * 24 * time.Hour)
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer tx.Rollback()
 
@@ -201,13 +205,13 @@ func (s *Storage) RequestDeletion(ctx context.Context, userID string) error {
 
 	rows, err := markUserPendingDeletion(ctx, qtx, userID, now, scheduledAt)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	if rows == 0 {
 		current, err := s.getUserByID(ctx, tx, userID)
 		if err != nil {
-			return err
+			return "", err
 		}
 		switch current.Status {
 		case "pending_deletion":
@@ -216,21 +220,21 @@ func (s *Storage) RequestDeletion(ctx context.Context, userID string) error {
 			// the case where the previous transition crashed between the
 			// status flip and the token revoke.
 			if err := revokeActiveRefreshTokensForDeletion(ctx, qtx, userID, now); err != nil {
-				return err
+				return "", err
 			}
-			return tx.Commit()
+			return "", tx.Commit()
 		case "disabled", "deleted":
-			return ErrUserAccountClosed
+			return current.Status, ErrUserAccountClosed
 		default:
-			return errors.New("unexpected user status for deletion: " + current.Status)
+			return current.Status, errors.New("unexpected user status for deletion: " + current.Status)
 		}
 	}
 
 	if err := revokeActiveRefreshTokensForDeletion(ctx, qtx, userID, now); err != nil {
-		return err
+		return "", err
 	}
 
-	return tx.Commit()
+	return "", tx.Commit()
 }
 
 func markUserPendingDeletion(ctx context.Context, qtx *storeq.Queries, userID string, now, scheduledAt time.Time) (int64, error) {


### PR DESCRIPTION
## Summary

Fixes #183.

`MarkUserPendingDeletionByID` had no status filter, so a `DELETE /account` request that landed concurrently with an admin transitioning the user to `disabled` silently overwrote the operator suspension with `pending_deletion`. Since the browser-channel recovery path treats `pending_deletion` as recoverable, the user could then log in and reach `active` again — defeating the suspension.

The bug was a TOCTOU between `GetValidSession` (status check at session lookup) and the unconditional storage UPDATE.

## Fix

- **SQL**: gate the UPDATE on `status='active'`, change to `:execrows` so the caller sees whether the row matched.
- **storage.RequestDeletion**: when `rows == 0`, re-read user inside the same TX and branch on the live status:
  - `pending_deletion` → idempotent success (re-runs the refresh-token revoke for crash safety)
  - `disabled` / `deleted` → `ErrUserAccountClosed`
  - other → error
- **service.RequestDeletion**: translate `ErrUserAccountClosed` to the same 403 `account_inactive` surface emitted by `GetValidSession`'s check, with audit metadata tagged `phase=account_deletion` to distinguish UPDATE-time rejections from session-time rejections.

## Test plan

- [x] TDD: new storage-level test confirms the bug exists on baseline (status overwrite happens) and is fixed.
- [x] `disabled`, `deleted` cases: `ErrUserAccountClosed` returned, status preserved.
- [x] `pending_deletion` companion test: idempotent (no error).
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean.
- [x] `go test -tags=integration ./internal/storage/ ./internal/service/ ./internal/integration/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)