### PR TITLE
fix(storage): close cleanup-vs-recovery race by inverting DeleteUser TX order (#182)

### DIFF
--- a/internal/db/queries/cleanup.sql
+++ b/internal/db/queries/cleanup.sql
@@ -41,7 +41,7 @@ WHERE user_id = $1;
 DELETE FROM refresh_tokens
 WHERE user_id = $1;
 
--- name: MarkUserDeletedByID :exec
+-- name: MarkUserDeletedByID :execrows
 UPDATE users SET
   email = 'deleted-' || id::text || '@deleted.invalid',
   name = NULL,

--- a/internal/db/storeq/cleanup.sql.go
+++ b/internal/db/storeq/cleanup.sql.go
@@ -164,7 +164,7 @@ func (q *Queries) ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff s
 	return items, nil
 }
 
-const markUserDeletedByID = `-- name: MarkUserDeletedByID :exec
+const markUserDeletedByID = `-- name: MarkUserDeletedByID :execrows
 UPDATE users SET
   email = 'deleted-' || id::text || '@deleted.invalid',
   name = NULL,
@@ -181,9 +181,12 @@ type MarkUserDeletedByIDParams struct {
 	UserID    string
 }
 
-func (q *Queries) MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedByIDParams) error {
-	_, err := q.db.ExecContext(ctx, markUserDeletedByID, arg.DeletedAt, arg.UserID)
-	return err
+func (q *Queries) MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedByIDParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, markUserDeletedByID, arg.DeletedAt, arg.UserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const tryCleanupAdvisoryLock = `-- name: TryCleanupAdvisoryLock :one

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -52,7 +52,7 @@ type Querier interface {
 	InsertUserIdentity(ctx context.Context, arg InsertUserIdentityParams) error
 	ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff sql.NullTime) ([]string, error)
 	MarkRefreshTokenUsedAndRevokedByID(ctx context.Context, arg MarkRefreshTokenUsedAndRevokedByIDParams) error
-	MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedByIDParams) error
+	MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedByIDParams) (int64, error)
 	MarkUserPendingDeletionByID(ctx context.Context, arg MarkUserPendingDeletionByIDParams) (int64, error)
 	RecoverPendingDeletionUserByID(ctx context.Context, arg RecoverPendingDeletionUserByIDParams) error
 	RevokeActiveRefreshTokensByUserID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDParams) error

--- a/internal/service/cleanup_test.go
+++ b/internal/service/cleanup_test.go
@@ -223,3 +223,79 @@ func TestCleanup_DeletionPIIScrub_Idempotent(t *testing.T) {
 		t.Fatalf("deletion_completed audit count = %d, want 1", auditCount)
 	}
 }
+
+// #182: cleanup must NOT wipe identity/session/refresh-token rows of an
+// active user. The race is between ListPendingDeletionUserIDsBefore (the
+// snapshot) and DeleteUser (the wipe TX): a browser-channel recovery can
+// transition status pending_deletion → active in between, but the
+// child-row deletes were unguarded and proceeded anyway, leaving a user
+// with status='active' but zero identities — defeating OIDC `sub`
+// continuity and producing an account that can no longer log in (signup
+// path then trips on email unique constraint).
+//
+// We model the race directly: pre-recover the user before invoking
+// DeleteUser. The fix must abort the TX entirely (no child deletes, no
+// parent UPDATE), so the row remains usable.
+func TestCleanup_DeletionRaceWithRecovery(t *testing.T) {
+	db, store, clk := setupCleanupTest(t)
+	ctx := context.Background()
+
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
+		Email: "race-recover@test.com", EmailVerified: true, Name: "Race",
+		Provider: "google", ProviderUserID: "race-recover-sub", ProviderEmail: "race@test.com",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if _, err := store.CreateSession(ctx, user.ID, 24*time.Hour); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	// Stage the user as the cleanup pipeline would have observed them at the
+	// snapshot read: pending_deletion, scheduled in the past.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE users SET status = 'pending_deletion', deletion_scheduled_at = $1 WHERE id = $2`,
+		clk.Now().Add(-1*time.Hour), user.ID,
+	); err != nil {
+		t.Fatalf("stage pending_deletion: %v", err)
+	}
+
+	// Race window: user recovers via browser-channel before DeleteUser runs.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE users SET status = 'active', deletion_requested_at = NULL, deletion_scheduled_at = NULL WHERE id = $1`,
+		user.ID,
+	); err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+
+	runner := storage.NewCleanupRunner(db)
+	if err := runner.DeleteUser(ctx, user.ID, clk.Now(), nil); err != nil {
+		t.Fatalf("DeleteUser returned err = %v, want nil (skip silently when no longer eligible)", err)
+	}
+
+	// The user must remain active and intact.
+	var status string
+	if err := db.QueryRowContext(ctx, `SELECT status FROM users WHERE id = $1`, user.ID).Scan(&status); err != nil {
+		t.Fatalf("re-read status: %v", err)
+	}
+	if status != "active" {
+		t.Errorf("user status = %q, want active (recovery race must not be overwritten)", status)
+	}
+
+	var identityCount, sessionCount int
+	db.QueryRowContext(ctx, `SELECT count(*) FROM user_identities WHERE user_id = $1`, user.ID).Scan(&identityCount)
+	db.QueryRowContext(ctx, `SELECT count(*) FROM sessions WHERE user_id = $1`, user.ID).Scan(&sessionCount)
+	if identityCount == 0 {
+		t.Errorf("user_identities row was wiped on a recovered user — OIDC sub continuity broken (this is the bug)")
+	}
+	if sessionCount == 0 {
+		t.Errorf("session row was wiped on a recovered user")
+	}
+
+	// And no spurious deletion_completed audit must have been emitted.
+	var auditCount int
+	db.QueryRowContext(ctx, `SELECT count(*) FROM audit_log WHERE user_id = $1 AND event_type = 'auth.deletion_completed'`, user.ID).Scan(&auditCount)
+	if auditCount != 0 {
+		t.Errorf("auth.deletion_completed audit count = %d, want 0 (no deletion happened)", auditCount)
+	}
+}

--- a/internal/storage/cleanup_runner.go
+++ b/internal/storage/cleanup_runner.go
@@ -94,6 +94,29 @@ func (r *CleanupRunner) DeleteUser(
 	defer tx.Rollback()
 	qtx := storeq.New(tx)
 
+	// #182: run the guarded parent UPDATE first so the child deletes only
+	// happen for a user that is still pending_deletion and still past the
+	// scheduled date. The successful UPDATE acquires a row-level lock that
+	// holds for the rest of the TX, preventing a concurrent
+	// browser-channel recovery from flipping the user back to active
+	// while we're wiping their identities.
+	rows, err := qtx.MarkUserDeletedByID(ctx, storeq.MarkUserDeletedByIDParams{
+		DeletedAt: sql.NullTime{Time: now, Valid: true},
+		UserID:    userID,
+	})
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		// User is no longer eligible (recovered to active, or another
+		// cleanup tick already deleted them). Roll back and skip silently —
+		// the runner is best-effort and idempotent across ticks.
+		slog.InfoContext(ctx, "deletion cleanup skipped: user no longer eligible",
+			"user_id", userID,
+		)
+		return nil
+	}
+
 	if err := qtx.DeleteUserIdentitiesByUserID(ctx, userID); err != nil {
 		return err
 	}
@@ -107,13 +130,6 @@ func (r *CleanupRunner) DeleteUser(
 		if err := hook(ctx, userID); err != nil {
 			return err
 		}
-	}
-
-	if err := qtx.MarkUserDeletedByID(ctx, storeq.MarkUserDeletedByIDParams{
-		DeletedAt: sql.NullTime{Time: now, Valid: true},
-		UserID:    userID,
-	}); err != nil {
-		return err
 	}
 
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
## Summary

Fixes #182.

The deletion cleanup pipeline had a TOCTOU between `ListPendingDeletionUserIDsBefore` (snapshot at T1) and `DeleteUser` (TX at T2). A browser-channel recovery between T1 and T2 transitioned the user `pending_deletion → active`, but the child deletes (identities, sessions, refresh tokens) were unguarded and proceeded anyway. Only the parent `MarkUserDeletedByID` was guarded on status — and matched 0 rows.

**Result**: a now-active user with zero identities. Subsequent IdP login enters the signup path and trips the `email` unique constraint, orphaning the account. This also breaks OIDC Core 1.0 §2 `sub` continuity.

## Fix

Invert the TX order. Run the guarded `MarkUserDeletedByID` **first**:

- PostgreSQL's UPDATE acquires a row-level lock that holds for the rest of the TX on the matched row — concurrent recovery cannot race in.
- If the UPDATE matches 0 rows, the user is no longer eligible (recovered, or another tick won the race). Rollback, log info, return nil. The runner is best-effort and idempotent across ticks.
- Only when the UPDATE claimed the row do we proceed with child deletes and the post-commit `deletion_completed` audit.

This makes the cleanup invariant explicit: **child rows are only deleted for a user whose parent row is, at this moment in this TX, simultaneously `status='pending_deletion'` and past `deletion_scheduled_at` — and that state is held under row lock until commit.**

## Changes

- `internal/db/queries/cleanup.sql`: `MarkUserDeletedByID :exec` → `:execrows`.
- `internal/storage/cleanup_runner.go`: invert TX order; branch on `rows == 0` (skip silently) vs `rows == 1` (proceed).
- `internal/db/storeq/`: regenerated.
- `internal/service/cleanup_test.go`: integration test reproducing the recovery race.

## Test plan

- [x] TDD: new integration test fails on baseline (identity_count drops to 0 on a recovered user).
- [x] After fix: TDD test passes — identity preserved, status remains `active`, no spurious `deletion_completed` audit.
- [x] Existing `TestCleanup_DeletionPIIScrub` and `TestCleanup_DeletionPIIScrub_Idempotent` still pass.
- [x] `go build ./...`, `go vet ./...`, `go test ./...` clean.
- [x] `go test -tags=integration ./internal/storage/ ./internal/service/ ./internal/integration/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)