### PR TITLE
fix(storage): set typ=at+jwt on JWT access tokens per RFC 9068 (#187)

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -329,13 +329,14 @@ func registerProviderRoutes(mux *http.ServeMux, cfg *config.Config, store *stora
 		}
 		provider.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
 	})))
+	tokenWithAtJWT := storage.WrapAccessTokenJWTType(provider, store)
 	mux.Handle("/oauth/token", tokenLimiter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resource, err := storage.ResourceFromRequestStrict(r)
 		if err != nil {
 			writeInvalidTargetError(w, err)
 			return
 		}
-		provider.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
+		tokenWithAtJWT.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
 	})))
 	mux.Handle("/oauth/revoke", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !cfg.EnableMCP {

--- a/internal/integration/integration_at_jwt_test.go
+++ b/internal/integration/integration_at_jwt_test.go
@@ -55,6 +55,72 @@ func TestAccessToken_TypIsAtJWTAndIDTokenStaysJWT(t *testing.T) {
 	}
 }
 
+// #187 (refresh grant): the at+jwt typ rewrite must also apply to access
+// tokens minted via the refresh_token grant. Same code path through
+// /oauth/token, but worth exercising explicitly so the wrapper isn't
+// inadvertently bypassed by a future refactor that splits the routes.
+func TestRefreshGrant_AccessTokenTypIsAtJWT(t *testing.T) {
+	ts := SetupTestServer(t)
+	ctx := context.Background()
+
+	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
+		Email: "atjwt-refresh@test.com", EmailVerified: true, Name: "AT JWT Refresh",
+		Provider: "google", ProviderUserID: "test-google-sub",
+		ProviderEmail: "atjwt-refresh@test.com",
+	}); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	client := NewOAuthClient(t, ts.BaseURL)
+	code := completeLoginFlowToCode(t, ts, client)
+	first := client.ExchangeCode(code)
+	if first.StatusCode != http.StatusOK || first.RefreshToken == "" {
+		t.Fatalf("first exchange: status=%d body=%s", first.StatusCode, first.RawBody)
+	}
+
+	refreshed := client.RefreshToken(first.RefreshToken)
+	if refreshed.StatusCode != http.StatusOK {
+		t.Fatalf("refresh: status=%d body=%s", refreshed.StatusCode, refreshed.RawBody)
+	}
+	if refreshed.AccessToken == "" {
+		t.Fatal("expected non-empty refreshed access_token")
+	}
+	if got := jwtTyp(t, "refreshed access_token", refreshed.AccessToken); got != "at+jwt" {
+		t.Errorf("refreshed access_token typ = %q, want at+jwt", got)
+	}
+}
+
+// #187 (device grant): same invariant for tokens minted from a
+// device-code grant. Different grant_type in the same /oauth/token
+// handler — guard against a future grant-specific bypass.
+func TestDeviceGrant_AccessTokenTypIsAtJWT(t *testing.T) {
+	ts := SetupTestServer(t)
+	ctx := context.Background()
+
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
+		Email: "atjwt-device@test.com", EmailVerified: true, Name: "AT JWT Device",
+		Provider: "google", ProviderUserID: "test-google-sub",
+		ProviderEmail: "atjwt-device@test.com",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	authz := startDeviceAuthorization(t, ts)
+	if err := ts.Store.ApproveDeviceCode(ctx, authz.UserCode, user.ID); err != nil {
+		t.Fatalf("approve device code: %v", err)
+	}
+	result := pollDeviceToken(t, ts, authz.DeviceCode)
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("device token exchange: status=%d body=%s", result.StatusCode, result.RawBody)
+	}
+	if result.AccessToken == "" {
+		t.Fatal("expected non-empty device-grant access_token")
+	}
+	if got := jwtTyp(t, "device-grant access_token", result.AccessToken); got != "at+jwt" {
+		t.Errorf("device-grant access_token typ = %q, want at+jwt", got)
+	}
+}
+
 // jwtTyp decodes the JOSE header of a compact JWS and returns the typ
 // header value. Failures are reported via t.Fatalf rather than returned
 // so callers don't need extra error handling on a malformed input.

--- a/internal/integration/integration_at_jwt_test.go
+++ b/internal/integration/integration_at_jwt_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/kangheeyong/authgate/internal/storage"
+)
+
+// #187: RFC 9068 §2.1 mandates that JWT access tokens carry the JOSE
+// header `typ=at+jwt`. Resource servers that strictly validate the
+// profile reject tokens with `typ=JWT`, and the typ separation
+// prevents an access token from being misinterpreted as an id_token.
+// id_tokens MUST keep `typ=JWT` per OIDC Core 1.0 §2 — the headers
+// must differ.
+func TestAccessToken_TypIsAtJWTAndIDTokenStaysJWT(t *testing.T) {
+	ts := SetupTestServer(t)
+	ctx := context.Background()
+
+	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
+		Email: "atjwt@test.com", EmailVerified: true, Name: "AT JWT",
+		AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub",
+		ProviderEmail: "atjwt@test.com",
+	}); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	client := NewOAuthClient(t, ts.BaseURL)
+	code := completeLoginFlowToCode(t, ts, client)
+	tokens := client.ExchangeCode(code)
+	if tokens.StatusCode != http.StatusOK {
+		t.Fatalf("token exchange failed: status=%d body=%s", tokens.StatusCode, tokens.RawBody)
+	}
+	if tokens.AccessToken == "" {
+		t.Fatal("expected non-empty access_token")
+	}
+	if tokens.IDToken == "" {
+		t.Fatal("expected non-empty id_token")
+	}
+
+	atTyp := jwtTyp(t, "access_token", tokens.AccessToken)
+	if atTyp != "at+jwt" {
+		t.Errorf("access_token typ = %q, want %q (RFC 9068 §2.1)", atTyp, "at+jwt")
+	}
+
+	idTyp := jwtTyp(t, "id_token", tokens.IDToken)
+	if idTyp != "JWT" {
+		t.Errorf("id_token typ = %q, want %q (OIDC Core 1.0 — separation from access_token)", idTyp, "JWT")
+	}
+}
+
+// jwtTyp decodes the JOSE header of a compact JWS and returns the typ
+// header value. Failures are reported via t.Fatalf rather than returned
+// so callers don't need extra error handling on a malformed input.
+func jwtTyp(t *testing.T, label, token string) string {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("%s is not a compact JWS (got %d segments)", label, len(parts))
+	}
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("decode %s header: %v", label, err)
+	}
+	var header struct {
+		Typ string `json:"typ"`
+	}
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		t.Fatalf("parse %s header: %v", label, err)
+	}
+	return header.Typ
+}

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -181,13 +181,14 @@ func SetupTestServerWithOptions(t *testing.T, opts SetupOptions) *TestServer {
 		provider.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
 	}))
 	tokenRateLimiter := middleware.NewRateLimiter(rate.Limit(5), 5)
+	tokenWithAtJWT := storage.WrapAccessTokenJWTType(provider, store)
 	mux.Handle("/oauth/token", tokenRateLimiter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resource, err := storage.ResourceFromRequestStrict(r)
 		if err != nil {
 			writeInvalidTargetError(w, err)
 			return
 		}
-		provider.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
+		tokenWithAtJWT.ServeHTTP(w, r.WithContext(storage.WithResource(r.Context(), resource)))
 	})))
 	mux.Handle("/oauth/revoke", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !opts.EnableMCP {

--- a/internal/storage/access_token_typ.go
+++ b/internal/storage/access_token_typ.go
@@ -1,0 +1,164 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	jose "github.com/go-jose/go-jose/v4"
+)
+
+// WrapAccessTokenJWTType wraps the OIDC token endpoint and rewrites the
+// JOSE `typ` header of the JWT access token to `at+jwt` per RFC 9068
+// §2.1. zitadel/oidc's signer is hardcoded to `typ=JWT` for both access
+// tokens and id_tokens (pkg/op/signer.go SignerFromKey), and the library
+// exposes no public hook to override this for a single token type. This
+// middleware captures the JSON response on the way out, re-signs the
+// access_token JWT with our same key but the correct profile typ, and
+// passes the response on. The id_token is left untouched per OIDC Core
+// 1.0 (§2 keeps `typ=JWT` for id_tokens).
+//
+// On any error during the rewrite, the original response body is
+// preserved unchanged so the rewrite cannot make the endpoint less
+// available than it would be otherwise.
+func WrapAccessTokenJWTType(inner http.Handler, store *Storage) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := newCaptureRW(w)
+		inner.ServeHTTP(rec, r)
+
+		body := rec.body.Bytes()
+		if rec.code == http.StatusOK && len(body) > 0 {
+			if upgraded, err := upgradeAccessTokenTyp(r.Context(), store, body); err == nil {
+				body = upgraded
+			}
+		}
+
+		for k, vs := range rec.Header() {
+			w.Header()[k] = vs
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(rec.code)
+		_, _ = w.Write(body)
+	})
+}
+
+// upgradeAccessTokenTyp parses a token-endpoint JSON response, locates
+// the `access_token` field, and if it is a compact JWS with typ=JWT,
+// re-signs the same payload with typ=at+jwt using the storage's signing
+// key. Returns the (possibly modified) body. A non-nil error means the
+// caller should keep the original body — callers MUST treat error as a
+// signal to fall back, not propagate.
+func upgradeAccessTokenTyp(ctx context.Context, store *Storage, body []byte) ([]byte, error) {
+	var resp map[string]json.RawMessage
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	rawAT, ok := resp["access_token"]
+	if !ok {
+		return nil, errSkipUpgrade
+	}
+	var token string
+	if err := json.Unmarshal(rawAT, &token); err != nil {
+		return nil, err
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, errSkipUpgrade
+	}
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, err
+	}
+	var header map[string]any
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		return nil, err
+	}
+	if typ, _ := header["typ"].(string); typ == "at+jwt" {
+		return body, nil
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, err
+	}
+
+	sk, err := store.SigningKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: sk.SignatureAlgorithm(),
+		Key: &jose.JSONWebKey{
+			Key:   sk.Key(),
+			KeyID: sk.ID(),
+		},
+	}, (&jose.SignerOptions{}).WithType("at+jwt"))
+	if err != nil {
+		return nil, err
+	}
+	signed, err := signer.Sign(payload)
+	if err != nil {
+		return nil, err
+	}
+	rewritten, err := signed.CompactSerialize()
+	if err != nil {
+		return nil, err
+	}
+
+	encoded, err := json.Marshal(rewritten)
+	if err != nil {
+		return nil, err
+	}
+	resp["access_token"] = encoded
+	return json.Marshal(resp)
+}
+
+// errSkipUpgrade signals that the response is not eligible for typ
+// rewriting (e.g. no access_token field, or not a compact JWS). It is a
+// non-failure condition.
+var errSkipUpgrade = &jwtUpgradeSkip{}
+
+type jwtUpgradeSkip struct{}
+
+func (*jwtUpgradeSkip) Error() string { return "access_token typ upgrade skipped" }
+
+// captureRW buffers the entire response so the middleware can inspect
+// and rewrite it before flushing to the real ResponseWriter.
+type captureRW struct {
+	http.ResponseWriter
+	header http.Header
+	body   *bytes.Buffer
+	code   int
+	wrote  bool
+}
+
+func newCaptureRW(w http.ResponseWriter) *captureRW {
+	return &captureRW{
+		ResponseWriter: w,
+		header:         http.Header{},
+		body:           &bytes.Buffer{},
+		code:           http.StatusOK,
+	}
+}
+
+func (c *captureRW) Header() http.Header { return c.header }
+
+func (c *captureRW) WriteHeader(code int) {
+	if c.wrote {
+		return
+	}
+	c.code = code
+	c.wrote = true
+}
+
+func (c *captureRW) Write(b []byte) (int, error) {
+	if !c.wrote {
+		c.WriteHeader(http.StatusOK)
+	}
+	return c.body.Write(b)
+}

--- a/internal/storage/access_token_typ.go
+++ b/internal/storage/access_token_typ.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -32,14 +34,31 @@ func WrapAccessTokenJWTType(inner http.Handler, store *Storage) http.Handler {
 
 		body := rec.body.Bytes()
 		if rec.code == http.StatusOK && len(body) > 0 {
-			if upgraded, err := upgradeAccessTokenTyp(r.Context(), store, body); err == nil {
+			upgraded, err := upgradeAccessTokenTyp(r.Context(), store, body)
+			switch {
+			case err == nil:
 				body = upgraded
+			case errors.Is(err, errSkipUpgrade):
+				// Response is not eligible (no access_token, not a JWS).
+				// Forward the original body unchanged.
+			default:
+				// A real error means we'd be serving a typ=JWT access token
+				// despite the fix. Preserve availability (forward original
+				// body) but log loudly so the regression is visible.
+				slog.ErrorContext(r.Context(), "at+jwt typ rewrite failed; serving typ=JWT access token",
+					"error", err,
+				)
 			}
 		}
 
 		for k, vs := range rec.Header() {
 			w.Header()[k] = vs
 		}
+		// Strip any content-integrity headers zitadel may have set against
+		// the original body — they would now be inconsistent.
+		w.Header().Del("ETag")
+		w.Header().Del("Content-Digest")
+		w.Header().Del("Repr-Digest")
 		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 		w.WriteHeader(rec.code)
 		_, _ = w.Write(body)


### PR DESCRIPTION
## Summary

Fixes #187.

zitadel/oidc's signer hardcodes `typ=JWT` for both access tokens and id_tokens (`pkg/op/signer.go SignerFromKey` calls `SignerOptions.WithType("JWT")`), and the library exposes no public hook to override per token type. As a result:

- Resource servers that strictly validate RFC 9068 §2.1 reject our access tokens (interop break).
- The access_token vs id_token type separation that prevents one from being misinterpreted as the other (independent of the existing audience check from #170) is missing.

## Fix

`storage.WrapAccessTokenJWTType` is a token-endpoint response middleware that captures the JSON body and re-signs the access_token with the same RSA key but `typ=at+jwt`. id_tokens stay on `typ=JWT` as required by OIDC Core 1.0 — the headers must differ for the type separation to be load-bearing.

On any error during the rewrite the original body is preserved unchanged, so the middleware can never make `/oauth/token` less available than baseline.

The same wrapper is applied in `cmd/authgate/main.go` and the integration test server. Auth code, refresh, and device grant all flow through `/oauth/token`, so all three are covered.

## Test plan

- [x] TDD integration test `TestAccessToken_TypIsAtJWTAndIDTokenStaysJWT`:
  - `access_token` JOSE `typ` == `at+jwt`
  - `id_token` JOSE `typ` == `JWT`
- [x] `go build ./...`, `go vet ./...`, `go test ./...` clean.
- [x] `go test -tags=integration -count=1 ./internal/storage/ ./internal/service/ ./internal/integration/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)