### PR TITLE
fix(service): validate user_code before upstream Exchange in /device/auth/callback (#186)

### DIFF
--- a/docs/spec/003-device-login.md
+++ b/docs/spec/003-device-login.md
@@ -131,10 +131,16 @@ Device 플로우의 주요 사용자(CLI 첫 사용자)는 브라우저 세션�
 1. /device?user_code=XXXX → 세션 없음 감지
 2. IdP 로그인 redirect (state=user_code, redirect_uri=/device/auth/callback)
 3. IdP 인증 성공 → /device/auth/callback?code=...&state=user_code
-4. 기존 유저 확인 → user.Status 상태 검사 (active가 아니면 즉시 차단)
-5. 세션 생성 → /device?user_code=XXXX로 302 redirect
-6. 승인 페이지 표시 → 사용자 승인
+4. user_code state 사전 검증 (pending 아니면 invalid_request 400, IdP Exchange 호출 안 함)
+5. IdP Exchange → 기존 유저 확인 → user.Status 상태 검사 (active가 아니면 즉시 차단)
+6. 세션 생성 → /device?user_code=XXXX로 302 redirect
+7. 승인 페이지 표시 → 사용자 승인
 ```
+
+**Step 4 (validate-before-exchange) 는 보안상 load-bearing이다.**
+`user_code`가 unknown/expired/non-pending 상태에서는 IdP token 엔드포인트
+호출 자체를 막아 outbound traffic 증폭과 IdP quota 소모 공격을 차단한다.
+브라우저 callback도 동일 패턴(#171)을 사용한다.
 
 **`/login/callback`과 분리된 별도 엔드포인트를 사용한다.**
 `state`의 의미가 엔드포인트별로 고정되며, 다른 형식이면 `invalid_request`로 거부한다:

--- a/internal/integration/integration_device_test.go
+++ b/internal/integration/integration_device_test.go
@@ -10,12 +10,24 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/kangheeyong/authgate/internal/storage"
 )
 
 func TestIntegration_DeviceCallback_NewUser_Rejected(t *testing.T) {
 	ts := SetupTestServer(t)
+	ctx := context.Background()
+
+	// #186 made the device callback front-load the user_code lookup
+	// before calling provider.Exchange. The "no user account" branch is
+	// now post-Exchange and only reachable when the user_code is valid
+	// and pending — seed one explicitly so this test still exercises
+	// the account_not_found surface rather than tripping the new gate.
+	if err := ts.Store.StoreDeviceAuthorization(ctx, "test-client", "fresh-dc", "TEST-CODE", ts.Clock.Now().Add(5*time.Minute), []string{"openid"}); err != nil {
+		t.Fatalf("seed device_code: %v", err)
+	}
+
 	resp, err := http.Get(ts.BaseURL + "/device/auth/callback?code=fake-code&state=TEST-CODE")
 	if err != nil {
 		t.Fatalf("device callback: %v", err)
@@ -42,6 +54,12 @@ func TestIntegration_DeviceCallback_PendingDeletion_Rejected(t *testing.T) {
 	}
 	if _, err := ts.DB.ExecContext(ctx, `UPDATE users SET status = 'pending_deletion' WHERE id = $1`, user.ID); err != nil {
 		t.Fatalf("set pending_deletion: %v", err)
+	}
+
+	// #186: seed a pending user_code so the front-load gate passes; the
+	// account_inactive surface this test cares about is still post-Exchange.
+	if err := ts.Store.StoreDeviceAuthorization(ctx, "test-client", "pending-dc", "TEST-CODE", ts.Clock.Now().Add(5*time.Minute), []string{"openid"}); err != nil {
+		t.Fatalf("seed device_code: %v", err)
 	}
 
 	resp, err := http.Get(ts.BaseURL + "/device/auth/callback?code=fake-code&state=TEST-CODE")

--- a/internal/service/account_test.go
+++ b/internal/service/account_test.go
@@ -214,6 +214,7 @@ func TestAccount004_PendingDeletion_DeviceRejected(t *testing.T) {
 
 	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pd-device@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "pd@test.com"})
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
+	insertDeviceCode(t, fx.Store, "PD-CODE", fx.Clock)
 
 	result := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "PD-CODE", "127.0.0.1", "test")
 	if result.Action != DeviceError {

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -301,7 +301,7 @@ func TestAudit009_InactiveUser(t *testing.T) {
 }
 
 func TestAuditSecurity003_DeviceInactiveUser(t *testing.T) {
-	svc, store, _ := setupDeviceExtTest(t, "audit-device-inactive-sub")
+	svc, store, clk := setupDeviceExtTest(t, "audit-device-inactive-sub")
 	ctx := context.Background()
 
 	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-inactive@test.com", EmailVerified: true, Name: "Inactive Device", AvatarURL: "", Provider: "google", ProviderUserID: "audit-device-inactive-sub", ProviderEmail: "audit-device-inactive@test.com"})
@@ -311,6 +311,7 @@ func TestAuditSecurity003_DeviceInactiveUser(t *testing.T) {
 	if err := store.SetUserStatus(ctx, user.ID, "disabled"); err != nil {
 		t.Fatalf("disable user: %v", err)
 	}
+	insertDeviceCode(t, store, "AUDT-INAC", clk)
 
 	result := svc.HandleDeviceCallback(ctx, "fake-code", "AUDT-INAC", "127.0.0.1", "device-inactive-agent")
 	if result.Action != DeviceError {
@@ -324,7 +325,7 @@ func TestAuditSecurity003_DeviceInactiveUser(t *testing.T) {
 }
 
 func TestAuditSecurity_DevicePendingDeletionInactiveUser(t *testing.T) {
-	svc, store, _ := setupDeviceExtTest(t, "audit-device-pending-sub")
+	svc, store, clk := setupDeviceExtTest(t, "audit-device-pending-sub")
 	ctx := context.Background()
 
 	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-pending@test.com", EmailVerified: true, Name: "Pending Device", AvatarURL: "", Provider: "google", ProviderUserID: "audit-device-pending-sub", ProviderEmail: "audit-device-pending@test.com"})
@@ -334,6 +335,7 @@ func TestAuditSecurity_DevicePendingDeletionInactiveUser(t *testing.T) {
 	if err := store.SetUserStatus(ctx, user.ID, "pending_deletion"); err != nil {
 		t.Fatalf("set pending_deletion: %v", err)
 	}
+	insertDeviceCode(t, store, "AUDT-PEND", clk)
 
 	result := svc.HandleDeviceCallback(ctx, "fake-code", "AUDT-PEND", "127.0.0.1", "device-pending-agent")
 	if result.Action != DeviceError {

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -101,6 +101,29 @@ func (s *DeviceService) HandleDeviceCallback(ctx context.Context, code, userCode
 		return &DevicePageResult{Action: DeviceError, Error: "invalid_request", ErrorCode: http.StatusBadRequest}
 	}
 
+	// #186: validate the local user_code state BEFORE calling provider.Exchange.
+	// Without this gate an attacker can drive arbitrary callbacks at the
+	// upstream IdP token endpoint (amplification + quota burn) without ever
+	// holding a valid user_code. The browser callback got the same fix in
+	// #171; this matches that ordering invariant for RFC 8628 §3.3/§3.5.
+	deviceCode, err := s.store.GetDeviceCodeByUserCode(ctx, userCode)
+	if errors.Is(err, storage.ErrNotFound) {
+		return &DevicePageResult{Action: DeviceError, Error: "invalid_request", ErrorCode: http.StatusBadRequest}
+	}
+	if err != nil {
+		return &DevicePageResult{Action: DeviceError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+	}
+	if s.clock.Now().After(deviceCode.ExpiresAt) {
+		return &DevicePageResult{Action: DeviceError, Error: "invalid_request", ErrorCode: http.StatusBadRequest}
+	}
+	// Only `pending` user_codes are eligible for callback consumption.
+	// `approved`/`consumed`/`denied` already finished their lifecycle and
+	// must not silently re-bind a freshly-IdP-authenticated subject; the
+	// device-flow client is expected to start a new device-authorization.
+	if deviceCode.State != "pending" {
+		return &DevicePageResult{Action: DeviceError, Error: "invalid_request", ErrorCode: http.StatusBadRequest}
+	}
+
 	// Exchange code for user info
 	userInfo, err := s.provider.Exchange(ctx, code)
 	if err != nil {
@@ -113,14 +136,6 @@ func (s *DeviceService) HandleDeviceCallback(ctx context.Context, code, userCode
 	}
 	if result := s.ensureDeviceCallbackAccess(ctx, user, ipAddress, userAgent); result != nil {
 		return result
-	}
-
-	deviceCode, err := s.store.GetDeviceCodeByUserCode(ctx, userCode)
-	if errors.Is(err, storage.ErrNotFound) {
-		return &DevicePageResult{Action: DeviceError, Error: "invalid_request", ErrorCode: http.StatusBadRequest}
-	}
-	if err != nil {
-		return &DevicePageResult{Action: DeviceError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
 	}
 
 	sessionID, err := s.store.CreateSession(ctx, user.ID, s.sessionTTL)

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -154,7 +154,11 @@ func TestDeviceApprove_NoSession_Unauthorized(t *testing.T) {
 }
 
 func TestDeviceCallback_NewUser_SignupRequired(t *testing.T) {
-	svc, _, _ := setupDeviceService(t)
+	svc, store, clk := setupDeviceService(t)
+	// #186: callback now front-loads the user_code lookup, so seed a
+	// pending row before invoking — the post-Exchange "no user account"
+	// branch is what this test is asserting.
+	insertDeviceCode(t, store, "CBCK-CODE", clk)
 	// FakeProvider returns a user that doesn't exist in DB yet
 	result := svc.HandleDeviceCallback(context.Background(), "fake-code", "CBCK-CODE", "127.0.0.1", "test")
 	if result.Action != DeviceError {
@@ -186,11 +190,12 @@ func TestDeviceCallback_ExistingUser_RedirectBack(t *testing.T) {
 
 // device-005: recoverable_browser_only callback → account_inactive
 func TestDevice005_RecoverableCallback_Rejected(t *testing.T) {
-	svc, store, _ := setupDeviceExtTest(t, "dev-recover-sub")
+	svc, store, clk := setupDeviceExtTest(t, "dev-recover-sub")
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-recover@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-recover-sub", ProviderEmail: "drc@test.com"})
 	store.SetUserStatus(ctx, user.ID, "pending_deletion")
+	insertDeviceCode(t, store, "RECV-CODE", clk)
 
 	result := svc.HandleDeviceCallback(ctx, "fake-code", "RECV-CODE", "127.0.0.1", "test")
 	if result.Action != DeviceError {
@@ -203,11 +208,12 @@ func TestDevice005_RecoverableCallback_Rejected(t *testing.T) {
 
 // device-006: inactive callback → account_inactive
 func TestDevice006_InactiveCallback_Rejected(t *testing.T) {
-	svc, store, _ := setupDeviceExtTest(t, "dev-inactive-sub")
+	svc, store, clk := setupDeviceExtTest(t, "dev-inactive-sub")
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-inactive@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-inactive-sub", ProviderEmail: "di@test.com"})
 	store.DisableUser(ctx, user.ID)
+	insertDeviceCode(t, store, "INAC-CODE", clk)
 
 	result := svc.HandleDeviceCallback(ctx, "fake-code", "INAC-CODE", "127.0.0.1", "test")
 	if result.Action != DeviceError {
@@ -220,11 +226,12 @@ func TestDevice006_InactiveCallback_Rejected(t *testing.T) {
 
 // device-004: deleted callback -> account_inactive
 func TestDeviceCallback_DeletedUser_Rejected(t *testing.T) {
-	svc, store, _ := setupDeviceExtTest(t, "dev-deleted-sub")
+	svc, store, clk := setupDeviceExtTest(t, "dev-deleted-sub")
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-deleted@test.com", EmailVerified: true, Name: "Deleted", AvatarURL: "", Provider: "google", ProviderUserID: "dev-deleted-sub", ProviderEmail: "dev-deleted@test.com"})
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
+	insertDeviceCode(t, store, "DELD-CODE", clk)
 
 	result := svc.HandleDeviceCallback(ctx, "fake-code", "DELD-CODE", "127.0.0.1", "test")
 	if result.Action != DeviceError {

--- a/internal/service/device_unit_test.go
+++ b/internal/service/device_unit_test.go
@@ -127,6 +127,66 @@ func TestDevice_HandleDeviceApprove_ApproveError(t *testing.T) {
 	}
 }
 
+// countingProvider is an upstream.Provider that records Exchange call
+// count so tests can assert "Exchange must not be called when local
+// state is invalid" — the load-bearing invariant for #186 (and the
+// matching browser fix #171).
+type countingProvider struct {
+	exchangeCalls int
+	user          *upstream.UserInfo
+}
+
+func (c *countingProvider) Name() string                 { return "counting" }
+func (c *countingProvider) AuthURL(state string) string  { return "/auth?state=" + state }
+func (c *countingProvider) Exchange(_ context.Context, _ string) (*upstream.UserInfo, error) {
+	c.exchangeCalls++
+	if c.user == nil {
+		return nil, errors.New("counting provider: no user")
+	}
+	return c.user, nil
+}
+
+// #186: device callback must NOT call provider.Exchange before
+// validating the local user_code state. An attacker hammering
+// /device/auth/callback?code=X&state=BOGUS otherwise amplifies traffic
+// to the upstream IdP and can drive token-endpoint quota burn for free.
+//
+// Three local-state failure modes — not_found, expired, non-pending —
+// must each fail fast without an outbound IdP call.
+func TestDevice_HandleDeviceCallback_RejectsBeforeExchange(t *testing.T) {
+	clk := &clock.FixedClock{T: time.Date(2026, 4, 3, 0, 0, 0, 0, time.UTC)}
+	cases := []struct {
+		name string
+		dc   *storage.DeviceCodeModel
+		err  error
+	}{
+		{name: "not_found", err: storage.ErrNotFound},
+		{name: "expired", dc: &storage.DeviceCodeModel{UserCode: "UCODE", State: "pending", ExpiresAt: clk.Now().Add(-1 * time.Minute)}},
+		{name: "consumed", dc: &storage.DeviceCodeModel{UserCode: "UCODE", State: "consumed", ExpiresAt: clk.Now().Add(5 * time.Minute)}},
+		{name: "approved", dc: &storage.DeviceCodeModel{UserCode: "UCODE", State: "approved", ExpiresAt: clk.Now().Add(5 * time.Minute)}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeDeviceStore{
+				getDeviceCodeByUserCodeFn: func(context.Context, string) (*storage.DeviceCodeModel, error) {
+					return tc.dc, tc.err
+				},
+			}
+			provider := &countingProvider{user: &upstream.UserInfo{Sub: "sub"}}
+			svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clk)
+
+			result := svc.HandleDeviceCallback(context.Background(), "code", "UCODE", "127.0.0.1", "ua")
+
+			if result.Action != DeviceError {
+				t.Errorf("action = %v, want DeviceError", result.Action)
+			}
+			if provider.exchangeCalls != 0 {
+				t.Errorf("provider.Exchange called %d times, want 0 (must validate local state first)", provider.exchangeCalls)
+			}
+		})
+	}
+}
+
 func TestDevice_HandleDeviceCallback_AuditLogIncludesSessionAndClient(t *testing.T) {
 	var gotEventType string
 	var gotMetadata map[string]any


### PR DESCRIPTION
## Summary

Fixes #186.

`HandleDeviceCallback` called `provider.Exchange` against the upstream IdP for any incoming `?code=...&state=...` pair **before** consulting local `user_code` state. That asymmetry is an outbound-amplification surface — an attacker hitting `/device/auth/callback` at high volume drives one IdP token-endpoint request per call without ever needing a valid `user_code`.

This mirrors the browser-callback fix shipped in #171.

## Fix

Front-load `GetDeviceCodeByUserCode` and reject before Exchange when:

- the `user_code` is unknown (`ErrNotFound` → `invalid_request` 400)
- it has expired (`now > ExpiresAt` → `invalid_request` 400)
- it is no longer in the `pending` state (`approved` / `consumed` / `denied` rows already finished their lifecycle and must not silently re-bind a freshly-IdP-authenticated subject; the device client is expected to start a new device-authorization)

This matches the channel-binding ordering invariant from #171 and RFC 8628 §3.3/§3.5 user/device code state.

## Test plan

- [x] TDD unit test `TestDevice_HandleDeviceCallback_RejectsBeforeExchange` asserts `provider.Exchange` is **NOT** called for any of `{not_found, expired, consumed, approved}` via a counting Provider. Confirmed test fails on baseline (panic in `findDeviceCallbackUser`, demonstrating Exchange ran), passes after fix.
- [x] Tests that previously relied on the post-Exchange branches (`TestDeviceCallback_NewUser_SignupRequired`, `TestDevice005_RecoverableCallback_Rejected`, `TestDevice006_InactiveCallback_Rejected`, `TestDeviceCallback_DeletedUser_Rejected`, `TestAccount004_PendingDeletion_DeviceRejected`, `TestAuditSecurity003_DeviceInactiveUser`, `TestAuditSecurity_DevicePendingDeletionInactiveUser`, `TestIntegration_DeviceCallback_NewUser_Rejected`, `TestIntegration_DeviceCallback_PendingDeletion_Rejected`) were seeded with a pending `user_code` so they continue to exercise the `account_not_found` / `account_inactive` surfaces they care about.
- [x] `go build ./...`, `go vet ./...`, `go test ./...` clean.
- [x] `go test -tags=integration -count=1 ./internal/storage/ ./internal/service/ ./internal/integration/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)