### PR TITLE
fix(storage): enforce RFC 8628 §3.5 slow_down on device-code polling (#188)

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -35,6 +35,13 @@ import (
 	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
+// devicePollInterval is the minimum gap between successive device-flow
+// polls. Wired into both `op.DeviceAuthorizationConfig.PollInterval` (the
+// value advertised to clients in the device-authorization response) and
+// `Storage.SetDevicePollInterval` (the server-side `slow_down` enforcement
+// per RFC 8628 §3.5) so the two stay in lockstep.
+const devicePollInterval = 5 * time.Second
+
 func main() {
 	cfg := mustLoadConfig()
 	db := mustOpenDB(cfg)
@@ -152,6 +159,7 @@ func newStateChecker() func(*storage.User) error {
 func mustBuildStore(cfg *config.Config, db *sql.DB, clk clock.Clock, gen idgen.CryptoGenerator) *storage.Storage {
 	store := storage.New(db, clk, gen, newStateChecker(), cfg.AccessTokenTTL, cfg.RefreshTokenTTL)
 	store.SetIssuer(cfg.PublicURL)
+	store.SetDevicePollInterval(devicePollInterval)
 	mustConfigureSigningKey(store)
 	configureMCPPoliciesIfEnabled(cfg, store)
 	return store
@@ -225,7 +233,7 @@ func buildOPConfig(cfg *config.Config) *op.Config {
 		SupportedScopes:       []string{"openid", "profile", "email", "offline_access"},
 		DeviceAuthorization: op.DeviceAuthorizationConfig{
 			Lifetime:     5 * time.Minute,
-			PollInterval: 5 * time.Second,
+			PollInterval: devicePollInterval,
 			UserFormPath: "/device",
 			UserCode: op.UserCodeConfig{
 				CharSet:      "BCDFGHJKLMNPQRSTVWXZ",

--- a/internal/db/queries/device_codes.sql
+++ b/internal/db/queries/device_codes.sql
@@ -3,7 +3,7 @@ INSERT INTO device_codes (id, device_code, user_code, client_id, scopes, state, 
 VALUES ($1, $2, $3, $4, $5, 'pending', $6, $7);
 
 -- name: GetDeviceAuthorizationForUpdate :one
-SELECT id, client_id, scopes, state, subject, expires_at, auth_time
+SELECT id, client_id, scopes, state, subject, expires_at, auth_time, last_polled_at
 FROM device_codes
 WHERE device_code = $1 AND client_id = $2
 FOR UPDATE;
@@ -12,6 +12,11 @@ FOR UPDATE;
 UPDATE device_codes
 SET state = 'consumed'
 WHERE id = $1;
+
+-- name: UpdateDeviceCodeLastPolledAt :exec
+UPDATE device_codes
+SET last_polled_at = $1
+WHERE id = $2;
 
 -- name: GetDeviceCodeByUserCode :one
 SELECT id, device_code, user_code, client_id, scopes, state, subject, expires_at, auth_time

--- a/internal/db/storeq/device_codes.sql.go
+++ b/internal/db/storeq/device_codes.sql.go
@@ -45,7 +45,7 @@ func (q *Queries) DenyDeviceCodeByUserCode(ctx context.Context, userCode string)
 }
 
 const getDeviceAuthorizationForUpdate = `-- name: GetDeviceAuthorizationForUpdate :one
-SELECT id, client_id, scopes, state, subject, expires_at, auth_time
+SELECT id, client_id, scopes, state, subject, expires_at, auth_time, last_polled_at
 FROM device_codes
 WHERE device_code = $1 AND client_id = $2
 FOR UPDATE
@@ -57,13 +57,14 @@ type GetDeviceAuthorizationForUpdateParams struct {
 }
 
 type GetDeviceAuthorizationForUpdateRow struct {
-	ID        string
-	ClientID  string
-	Scopes    []string
-	State     string
-	Subject   sql.NullString
-	ExpiresAt time.Time
-	AuthTime  sql.NullTime
+	ID           string
+	ClientID     string
+	Scopes       []string
+	State        string
+	Subject      sql.NullString
+	ExpiresAt    time.Time
+	AuthTime     sql.NullTime
+	LastPolledAt sql.NullTime
 }
 
 func (q *Queries) GetDeviceAuthorizationForUpdate(ctx context.Context, arg GetDeviceAuthorizationForUpdateParams) (GetDeviceAuthorizationForUpdateRow, error) {
@@ -77,6 +78,7 @@ func (q *Queries) GetDeviceAuthorizationForUpdate(ctx context.Context, arg GetDe
 		&i.Subject,
 		&i.ExpiresAt,
 		&i.AuthTime,
+		&i.LastPolledAt,
 	)
 	return i, err
 }
@@ -141,6 +143,22 @@ func (q *Queries) InsertDeviceCode(ctx context.Context, arg InsertDeviceCodePara
 		arg.ExpiresAt,
 		arg.CreatedAt,
 	)
+	return err
+}
+
+const updateDeviceCodeLastPolledAt = `-- name: UpdateDeviceCodeLastPolledAt :exec
+UPDATE device_codes
+SET last_polled_at = $1
+WHERE id = $2
+`
+
+type UpdateDeviceCodeLastPolledAtParams struct {
+	LastPolledAt sql.NullTime
+	ID           string
+}
+
+func (q *Queries) UpdateDeviceCodeLastPolledAt(ctx context.Context, arg UpdateDeviceCodeLastPolledAtParams) error {
+	_, err := q.db.ExecContext(ctx, updateDeviceCodeLastPolledAt, arg.LastPolledAt, arg.ID)
 	return err
 }
 

--- a/internal/db/storeq/models.go
+++ b/internal/db/storeq/models.go
@@ -41,16 +41,17 @@ type AuthRequest struct {
 }
 
 type DeviceCode struct {
-	ID         string
-	DeviceCode string
-	UserCode   string
-	ClientID   string
-	Scopes     []string
-	State      string
-	Subject    sql.NullString
-	ExpiresAt  time.Time
-	AuthTime   sql.NullTime
-	CreatedAt  time.Time
+	ID           string
+	DeviceCode   string
+	UserCode     string
+	ClientID     string
+	Scopes       []string
+	State        string
+	Subject      sql.NullString
+	ExpiresAt    time.Time
+	AuthTime     sql.NullTime
+	CreatedAt    time.Time
+	LastPolledAt sql.NullTime
 }
 
 type RefreshToken struct {

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -67,6 +67,7 @@ type Querier interface {
 	TryCleanupAdvisoryLock(ctx context.Context, lockKey int64) (bool, error)
 	UnlockCleanupAdvisoryLock(ctx context.Context, lockKey int64) (bool, error)
 	UpdateAuthRequestCode(ctx context.Context, arg UpdateAuthRequestCodeParams) error
+	UpdateDeviceCodeLastPolledAt(ctx context.Context, arg UpdateDeviceCodeLastPolledAtParams) error
 	UpdateDeviceCodeStateConsumedByID(ctx context.Context, id string) error
 }
 

--- a/internal/integration/integration_device_test.go
+++ b/internal/integration/integration_device_test.go
@@ -278,6 +278,52 @@ func TestIntegration_DevicePolling_EnforcesSlowDown(t *testing.T) {
 	}
 }
 
+// #188 follow-up: slow_down must scope to `pending` polls only. After the
+// user approves, the very next poll — even if it arrives within the same
+// `interval` window that just produced a slow_down — must consume the
+// device code and return tokens. This pins the pending-only scoping in
+// GetDeviceAuthorizatonState so a future refactor cannot silently widen
+// the gate to the approved branch.
+func TestIntegration_DevicePolling_SlowDownThenApprove_Succeeds(t *testing.T) {
+	ts := SetupTestServer(t)
+	ctx := context.Background()
+
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
+		Email: "device-slow-then-approve@test.com", EmailVerified: true, Name: "Slow Then Approve",
+		AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-slow-then-approve@test.com",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	authz := startDeviceAuthorization(t, ts)
+
+	first := pollDeviceToken(t, ts, authz.DeviceCode)
+	if !strings.Contains(first.RawBody, "authorization_pending") {
+		t.Fatalf("poll #1 want authorization_pending, got status=%d body=%s", first.StatusCode, first.RawBody)
+	}
+	second := pollDeviceToken(t, ts, authz.DeviceCode)
+	if !strings.Contains(second.RawBody, "slow_down") {
+		t.Fatalf("poll #2 want slow_down, got status=%d body=%s", second.StatusCode, second.RawBody)
+	}
+
+	if err := ts.Store.ApproveDeviceCode(ctx, authz.UserCode, user.ID); err != nil {
+		t.Fatalf("approve device code: %v", err)
+	}
+
+	// Poll without advancing the clock — last_polled_at is still inside
+	// the 5s interval from poll #2. The slow_down branch must not fire
+	// because the row is now `approved`, and the consume transition must
+	// proceed.
+	third := pollDeviceToken(t, ts, authz.DeviceCode)
+	if third.StatusCode != http.StatusOK {
+		t.Fatalf("post-approve poll within interval should succeed, got status=%d body=%s", third.StatusCode, third.RawBody)
+	}
+	if third.AccessToken == "" {
+		t.Fatal("post-approve poll should return access_token")
+	}
+}
+
 // security-001: /device/approve rejects non-POST methods
 func TestIntegration_DeviceApprove_GetRejected(t *testing.T) {
 	ts := SetupTestServer(t)

--- a/internal/integration/integration_device_test.go
+++ b/internal/integration/integration_device_test.go
@@ -241,6 +241,43 @@ func TestIntegration_DevicePolling_RechecksUserStatus(t *testing.T) {
 	}
 }
 
+// #188 / RFC 8628 §3.5: when a device-flow client polls the token endpoint
+// faster than the advertised `interval`, the AS MUST respond with
+// `slow_down` so the client backs off. Authgate previously kept returning
+// `authorization_pending` regardless of poll cadence, leaving aggressive
+// or buggy clients free to hammer the DB.
+//
+// Cadence under test (FixedClock):
+//   poll #1 (t=0)        — first poll seeds last_polled_at; expect authorization_pending
+//   poll #2 (t=0)        — same instant; delta=0 < 5s interval; expect slow_down
+//   advance clock +6s
+//   poll #3 (t=6s)       — delta=6s >= 5s; expect authorization_pending again
+func TestIntegration_DevicePolling_EnforcesSlowDown(t *testing.T) {
+	ts := SetupTestServer(t)
+
+	authz := startDeviceAuthorization(t, ts)
+
+	first := pollDeviceToken(t, ts, authz.DeviceCode)
+	if !strings.Contains(first.RawBody, "authorization_pending") {
+		t.Fatalf("poll #1 want authorization_pending, got status=%d body=%s", first.StatusCode, first.RawBody)
+	}
+
+	second := pollDeviceToken(t, ts, authz.DeviceCode)
+	if !strings.Contains(second.RawBody, "slow_down") {
+		t.Fatalf("poll #2 (within interval) want slow_down, got status=%d body=%s", second.StatusCode, second.RawBody)
+	}
+
+	// Advance the test clock past the 5s interval and confirm polling
+	// resumes its normal authorization_pending response — slow_down is a
+	// back-off signal, not a permanent denial.
+	ts.Clock.T = ts.Clock.T.Add(6 * time.Second)
+
+	third := pollDeviceToken(t, ts, authz.DeviceCode)
+	if !strings.Contains(third.RawBody, "authorization_pending") {
+		t.Fatalf("poll #3 (after interval) want authorization_pending, got status=%d body=%s", third.StatusCode, third.RawBody)
+	}
+}
+
 // security-001: /device/approve rejects non-POST methods
 func TestIntegration_DeviceApprove_GetRejected(t *testing.T) {
 	ts := SetupTestServer(t)

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -26,6 +26,11 @@ import (
 	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
+// devicePollInterval mirrors the production constant in cmd/authgate/main.go
+// so the integration server advertises and enforces the same RFC 8628 §3.5
+// poll cadence the binary ships with.
+const devicePollInterval = 5 * time.Second
+
 // TestServer holds everything needed for integration tests.
 type TestServer struct {
 	Server  *httptest.Server
@@ -60,6 +65,7 @@ func SetupTestServerWithOptions(t *testing.T, opts SetupOptions) *TestServer {
 	}
 
 	store := storage.New(db, clk, gen, stateChecker, 15*time.Minute, 30*24*time.Hour)
+	store.SetDevicePollInterval(devicePollInterval)
 	if opts.EnableMCP {
 		cimdFetcher := mcpadapter.NewHTTPCIMDFetcher()
 		clientPolicy := mcpadapter.NewClientResolutionPolicy(storage.NewCoreClientResolutionPolicy(store), cimdFetcher)
@@ -116,7 +122,7 @@ func SetupTestServerWithOptions(t *testing.T, opts SetupOptions) *TestServer {
 		SupportedScopes:       []string{"openid", "profile", "email", "offline_access"},
 		DeviceAuthorization: op.DeviceAuthorizationConfig{
 			Lifetime:     5 * time.Minute,
-			PollInterval: 5 * time.Second,
+			PollInterval: devicePollInterval,
 			UserFormPath: "/device",
 		},
 	}

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -193,6 +193,10 @@ type DeviceCodeModel struct {
 	Subject    *string
 	ExpiresAt  time.Time
 	AuthTime   *time.Time
+	// LastPolledAt is the timestamp of the last token-endpoint poll for
+	// this device_code, used by GetDeviceAuthorizatonState to enforce
+	// the RFC 8628 §3.5 `slow_down` cadence. NULL until the first poll.
+	LastPolledAt *time.Time
 }
 
 // --- Key Models ---

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -61,9 +61,14 @@ type Storage struct {
 	previousKeyID   string
 	accessTokenTTL  time.Duration
 	refreshTokenTTL time.Duration
-	clients         sync.Map // map[string]*ClientModel (client_id → client)
-	clientPolicy    ClientResolutionPolicy
-	resourcePolicy  ResourceBindingPolicy
+	// devicePollInterval is the minimum gap between successive device-flow
+	// token polls before the AS responds with `slow_down` (RFC 8628 §3.5).
+	// Defaults to 5s in New() to match the value advertised in
+	// `op.DeviceAuthorizationConfig.PollInterval`.
+	devicePollInterval time.Duration
+	clients            sync.Map // map[string]*ClientModel (client_id → client)
+	clientPolicy       ClientResolutionPolicy
+	resourcePolicy     ResourceBindingPolicy
 	// issuer is the expected `iss` claim for bearer-token validation on
 	// console APIs. Wired from cfg.PublicURL via SetIssuer at startup; empty
 	// string falls back to clock-only validation for backward compatibility
@@ -73,16 +78,25 @@ type Storage struct {
 
 func New(db *sql.DB, clk clock.Clock, gen idgen.IDGenerator, checker StateChecker, accessTTL, refreshTTL time.Duration) *Storage {
 	s := &Storage{
-		db:              db,
-		clock:           clk,
-		idgen:           gen,
-		stateChecker:    checker,
-		accessTokenTTL:  accessTTL,
-		refreshTokenTTL: refreshTTL,
+		db:                 db,
+		clock:              clk,
+		idgen:              gen,
+		stateChecker:       checker,
+		accessTokenTTL:     accessTTL,
+		refreshTokenTTL:    refreshTTL,
+		devicePollInterval: 5 * time.Second,
 	}
 	s.clientPolicy = NewCoreClientResolutionPolicy(s)
 	s.resourcePolicy = NewCoreResourceBindingPolicy()
 	return s
+}
+
+// SetDevicePollInterval overrides the device-flow poll interval used for
+// `slow_down` enforcement. main.go calls this with the same value advertised
+// in op.DeviceAuthorizationConfig.PollInterval so a single config flow drives
+// both the response shape and the server-side throttle.
+func (s *Storage) SetDevicePollInterval(d time.Duration) {
+	s.devicePollInterval = d
 }
 
 // SetSigningKey sets the current RSA signing key used for JWT issuance.

--- a/internal/storage/storage_oidc_device.go
+++ b/internal/storage/storage_oidc_device.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
@@ -133,6 +134,36 @@ func (s *Storage) GetDeviceAuthorizatonState(ctx context.Context, clientID, devi
 		return nil, err
 	}
 
+	// #188 / RFC 8628 §3.5: enforce the advertised poll `interval`. Compare
+	// the **previous** last_polled_at (read above) with `now`, then refresh
+	// last_polled_at to `now` so the next poll is measured against this
+	// attempt — clients that ignore slow_down keep tripping the gate. Only
+	// the `pending` branch returns slow_down because §3.5 frames slow_down
+	// as the "polling too fast while waiting" response; terminal states
+	// (denied/expired/consumed) and one-shot approved→consumed transitions
+	// keep their canonical RFC responses.
+	now := s.clock.Now()
+	tooSoon := dc.LastPolledAt != nil && now.Sub(*dc.LastPolledAt) < s.devicePollInterval
+	if err := qtx.UpdateDeviceCodeLastPolledAt(ctx, storeq.UpdateDeviceCodeLastPolledAtParams{
+		LastPolledAt: sql.NullTime{Time: now, Valid: true},
+		ID:           dc.ID,
+	}); err != nil {
+		return nil, err
+	}
+	if tooSoon && dc.State == "pending" {
+		if err := tx.Commit(); err != nil {
+			return nil, err
+		}
+		// zitadel/oidc op.CheckDeviceAuthorizationState only converts errors
+		// that satisfy `errors.Is(err, context.DeadlineExceeded)` into the
+		// RFC 8628 §3.5 `slow_down` response; every other error is wrapped
+		// as `access_denied`. Wrap the sentinel so the client receives the
+		// canonical slow_down it must back off on, not access_denied which
+		// signals a permanent rejection. (See pkg/op/device.go around the
+		// CheckDeviceAuthorizationState branch in zitadel/oidc/v3.)
+		return nil, fmt.Errorf("device polling too fast: %w", context.DeadlineExceeded)
+	}
+
 	// #185: defense-in-depth — when an approved device code's bound subject
 	// is no longer authorized to receive tokens (admin disabled, deleted,
 	// pending_deletion), reject the polling attempt with invalid_grant
@@ -150,7 +181,7 @@ func (s *Storage) GetDeviceAuthorizatonState(ctx context.Context, clientID, devi
 		}
 	}
 
-	return resolveDeviceAuthorizationState(ctx, tx, qtx, dc, s.clock.Now())
+	return resolveDeviceAuthorizationState(ctx, tx, qtx, dc, now)
 }
 
 // --- Device code business operations (called by service, not by zitadel) ---
@@ -214,13 +245,14 @@ func loadDeviceAuthorizationForUpdate(ctx context.Context, qtx *storeq.Queries, 
 		return nil, err
 	}
 	return &DeviceCodeModel{
-		ID:        row.ID,
-		ClientID:  row.ClientID,
-		Scopes:    StringArray(row.Scopes),
-		State:     row.State,
-		Subject:   nullStringToPtr(row.Subject),
-		ExpiresAt: row.ExpiresAt,
-		AuthTime:  nullTimePtr(row.AuthTime),
+		ID:           row.ID,
+		ClientID:     row.ClientID,
+		Scopes:       StringArray(row.Scopes),
+		State:        row.State,
+		Subject:      nullStringToPtr(row.Subject),
+		ExpiresAt:    row.ExpiresAt,
+		AuthTime:     nullTimePtr(row.AuthTime),
+		LastPolledAt: nullTimePtr(row.LastPolledAt),
 	}, nil
 }
 

--- a/internal/storage/storage_oidc_device.go
+++ b/internal/storage/storage_oidc_device.go
@@ -139,29 +139,39 @@ func (s *Storage) GetDeviceAuthorizatonState(ctx context.Context, clientID, devi
 	// last_polled_at to `now` so the next poll is measured against this
 	// attempt — clients that ignore slow_down keep tripping the gate. Only
 	// the `pending` branch returns slow_down because §3.5 frames slow_down
-	// as the "polling too fast while waiting" response; terminal states
-	// (denied/expired/consumed) and one-shot approved→consumed transitions
-	// keep their canonical RFC responses.
+	// as the "polling too fast while waiting" response; the approved branch
+	// is a one-shot `approved → consumed` transition that mustn't be
+	// throttled, and terminal states (denied/consumed) keep their canonical
+	// RFC responses regardless of cadence.
+	//
+	// last_polled_at is skipped on definitively-terminal states (denied,
+	// consumed) because cadence enforcement on a finished code is moot and
+	// the row would otherwise absorb an UPDATE per misbehaving poll.
 	now := s.clock.Now()
-	tooSoon := dc.LastPolledAt != nil && now.Sub(*dc.LastPolledAt) < s.devicePollInterval
-	if err := qtx.UpdateDeviceCodeLastPolledAt(ctx, storeq.UpdateDeviceCodeLastPolledAtParams{
-		LastPolledAt: sql.NullTime{Time: now, Valid: true},
-		ID:           dc.ID,
-	}); err != nil {
-		return nil, err
-	}
-	if tooSoon && dc.State == "pending" {
-		if err := tx.Commit(); err != nil {
+	if dc.State != "denied" && dc.State != "consumed" {
+		tooSoon := dc.LastPolledAt != nil && now.Sub(*dc.LastPolledAt) < s.devicePollInterval
+		if err := qtx.UpdateDeviceCodeLastPolledAt(ctx, storeq.UpdateDeviceCodeLastPolledAtParams{
+			LastPolledAt: sql.NullTime{Time: now, Valid: true},
+			ID:           dc.ID,
+		}); err != nil {
 			return nil, err
 		}
-		// zitadel/oidc op.CheckDeviceAuthorizationState only converts errors
-		// that satisfy `errors.Is(err, context.DeadlineExceeded)` into the
-		// RFC 8628 §3.5 `slow_down` response; every other error is wrapped
-		// as `access_denied`. Wrap the sentinel so the client receives the
-		// canonical slow_down it must back off on, not access_denied which
-		// signals a permanent rejection. (See pkg/op/device.go around the
-		// CheckDeviceAuthorizationState branch in zitadel/oidc/v3.)
-		return nil, fmt.Errorf("device polling too fast: %w", context.DeadlineExceeded)
+		if tooSoon && dc.State == "pending" {
+			if err := tx.Commit(); err != nil {
+				return nil, err
+			}
+			// zitadel/oidc op.CheckDeviceAuthorizationState (v3.45.5
+			// pkg/op/device.go) only converts errors that satisfy
+			// `errors.Is(err, context.DeadlineExceeded)` into the RFC 8628
+			// §3.5 `slow_down` response — every other error from
+			// GetDeviceAuthorizatonState is wrapped as `access_denied`.
+			// Wrapping the deadline sentinel surfaces the cadence violation
+			// as the canonical slow_down the client must back off on rather
+			// than a permanent rejection. If the upstream library ever
+			// changes that translation, the EnforcesSlowDown integration
+			// test will fail and pin the regression.
+			return nil, fmt.Errorf("device polling too fast: %w", context.DeadlineExceeded)
+		}
 	}
 
 	// #185: defense-in-depth — when an approved device code's bound subject

--- a/migrations/002_device_codes_last_polled_at.down.sql
+++ b/migrations/002_device_codes_last_polled_at.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE device_codes
+    DROP COLUMN IF EXISTS last_polled_at;

--- a/migrations/002_device_codes_last_polled_at.up.sql
+++ b/migrations/002_device_codes_last_polled_at.up.sql
@@ -1,0 +1,7 @@
+-- #188 / RFC 8628 §3.5: track the timestamp of the last token-endpoint poll
+-- per device_code so the AS can enforce the advertised `interval` and
+-- respond with `slow_down` when a client polls faster than allowed.
+-- NULL means "never polled yet" — the first poll always proceeds and
+-- seeds the column.
+ALTER TABLE device_codes
+    ADD COLUMN last_polled_at TIMESTAMPTZ;


### PR DESCRIPTION
## Summary

Fixes #188.

The device token branch returned `authorization_pending` on every poll regardless of cadence, even though the device-authorization response advertises `interval=5`. Aggressive or buggy clients could hammer the DB without ever receiving the back-off signal RFC 8628 §3.5 mandates.

## Fix

- Add `last_polled_at TIMESTAMPTZ` column to `device_codes` (migration 002).
- On every `GetDeviceAuthorizatonState` poll: read the prior `last_polled_at` (under `FOR UPDATE`), update to `now`, and — when the row is still `pending` and the prior poll was within the advertised interval — return `slow_down`. Updating regardless of branch means a client that ignores the signal keeps tripping the gate rather than getting a free pass after the next request.
- Bridge to zitadel/oidc: `CheckDeviceAuthorizationState` only converts errors satisfying `errors.Is(err, context.DeadlineExceeded)` into the `slow_down` response — every other error becomes `access_denied`. The cadence-violation sentinel wraps `context.DeadlineExceeded` so the client sees the canonical RFC error, not a permanent denial.
- Single source of truth: a `devicePollInterval` constant (5s) in both `cmd/authgate/main.go` and `internal/integration/server.go` is wired into both `op.DeviceAuthorizationConfig.PollInterval` (advertised) and `Storage.SetDevicePollInterval` (enforced).

## Why pending-only?

RFC 8628 §3.5 frames `slow_down` as the "polling too fast while waiting" response. Terminal states (`denied`, `expired`, `consumed`) and the one-shot `approved → consumed` transition keep their canonical responses regardless of cadence — `slow_down` would otherwise fight with `access_denied`/`expired_token`/`invalid_grant` and confuse clients.

## Tests

`TestIntegration_DevicePolling_EnforcesSlowDown` exercises the cadence:

- poll #1 (`t=0`) — first poll, seeds `last_polled_at`; expects `authorization_pending`
- poll #2 (`t=0`) — same instant, delta=0 < 5s; expects `slow_down`
- advance clock +6s
- poll #3 (`t=6s`) — delta=6s ≥ 5s; expects `authorization_pending` again

Existing tests (concurrent polling, closed-account state recheck #185, full-flow token issuance, consumed re-poll) keep passing — see test plan below.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (unit, no Docker)
- [x] `go test -tags=integration -count=1 ./...` (full integration suite, 17 device tests pass)
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)