### PR TITLE
fix(metadata): align AS metadata auth methods with OP server behavior (#189)

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -314,10 +314,18 @@ func registerOAuthMetadataRoute(mux *http.ServeMux, cfg *config.Config) {
 			"jwks_uri":                              cfg.PublicURL + "/keys",
 			"response_types_supported":              []string{"code"},
 			"grant_types_supported":                 []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
-			"code_challenge_methods_supported":      []string{"S256"},
-			"token_endpoint_auth_methods_supported": []string{"none", "client_secret_post"},
-			"scopes_supported":                      []string{"openid", "profile", "email", "offline_access"},
-			"client_id_metadata_document_supported": cfg.EnableMCP,
+			"code_challenge_methods_supported": []string{"S256"},
+			// #189 / RFC 8414 §2: zitadel/oidc's /oauth/token branch always
+			// accepts `client_secret_basic` (the OIDC default), accepts
+			// `client_secret_post` because op.Config.AuthMethodPost=true,
+			// and accepts `none` for public clients. Advertise all three so
+			// confidential clients trusting discovery don't pick the wrong
+			// credential location and silently fail. The /oauth/revoke
+			// branch (RFC 7009) accepts the same set, so mirror it.
+			"token_endpoint_auth_methods_supported":      []string{"none", "client_secret_basic", "client_secret_post"},
+			"revocation_endpoint_auth_methods_supported": []string{"none", "client_secret_basic", "client_secret_post"},
+			"scopes_supported":                           []string{"openid", "profile", "email", "offline_access"},
+			"client_id_metadata_document_supported":      cfg.EnableMCP,
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(metadata)

--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -304,16 +304,17 @@ func registerRoutes(
 func registerOAuthMetadataRoute(mux *http.ServeMux, cfg *config.Config) {
 	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
 		metadata := map[string]any{
-			"issuer":                                cfg.PublicURL,
-			"authorization_endpoint":                cfg.PublicURL + "/authorize",
-			"token_endpoint":                        cfg.PublicURL + "/oauth/token",
-			"revocation_endpoint":                   cfg.PublicURL + "/oauth/revoke",
-			"device_authorization_endpoint":         cfg.PublicURL + "/oauth/device/authorize",
-			"userinfo_endpoint":                     cfg.PublicURL + "/userinfo",
-			"end_session_endpoint":                  cfg.PublicURL + "/end_session",
-			"jwks_uri":                              cfg.PublicURL + "/keys",
-			"response_types_supported":              []string{"code"},
-			"grant_types_supported":                 []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
+			"issuer":                        cfg.PublicURL,
+			"authorization_endpoint":        cfg.PublicURL + "/authorize",
+			"token_endpoint":                cfg.PublicURL + "/oauth/token",
+			"revocation_endpoint":           cfg.PublicURL + "/oauth/revoke",
+			"introspection_endpoint":        cfg.PublicURL + "/oauth/introspect",
+			"device_authorization_endpoint": cfg.PublicURL + "/oauth/device/authorize",
+			"userinfo_endpoint":             cfg.PublicURL + "/userinfo",
+			"end_session_endpoint":          cfg.PublicURL + "/end_session",
+			"jwks_uri":                      cfg.PublicURL + "/keys",
+			"response_types_supported":      []string{"code"},
+			"grant_types_supported":         []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
 			"code_challenge_methods_supported": []string{"S256"},
 			// #189 / RFC 8414 §2: zitadel/oidc's /oauth/token branch always
 			// accepts `client_secret_basic` (the OIDC default), accepts
@@ -322,10 +323,20 @@ func registerOAuthMetadataRoute(mux *http.ServeMux, cfg *config.Config) {
 			// confidential clients trusting discovery don't pick the wrong
 			// credential location and silently fail. The /oauth/revoke
 			// branch (RFC 7009) accepts the same set, so mirror it.
-			"token_endpoint_auth_methods_supported":      []string{"none", "client_secret_basic", "client_secret_post"},
-			"revocation_endpoint_auth_methods_supported": []string{"none", "client_secret_basic", "client_secret_post"},
-			"scopes_supported":                           []string{"openid", "profile", "email", "offline_access"},
-			"client_id_metadata_document_supported":      cfg.EnableMCP,
+			//
+			// /oauth/introspect (RFC 7662) is mounted by zitadel by default
+			// at the OP's IntrospectionEndpoint() and authenticates via
+			// `ClientIDFromRequest` which only flips `authenticated=true`
+			// for `ClientBasicAuth` or `ClientJWTAuth`. Form-based Post
+			// credentials don't authenticate the introspector, so we
+			// advertise only `client_secret_basic` here — matching
+			// zitadel/oidc's own discovery default in
+			// `AuthMethodsIntrospectionEndpoint`.
+			"token_endpoint_auth_methods_supported":          []string{"none", "client_secret_basic", "client_secret_post"},
+			"revocation_endpoint_auth_methods_supported":     []string{"none", "client_secret_basic", "client_secret_post"},
+			"introspection_endpoint_auth_methods_supported":  []string{"client_secret_basic"},
+			"scopes_supported":                               []string{"openid", "profile", "email", "offline_access"},
+			"client_id_metadata_document_supported":          cfg.EnableMCP,
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(metadata)

--- a/docs/spec/004-mcp-login.md
+++ b/docs/spec/004-mcp-login.md
@@ -244,11 +244,15 @@ authgate는 `/.well-known/oauth-authorization-server`에서 최소한 아래를 
   "authorization_endpoint": "https://auth.example.com/authorize",
   "token_endpoint": "https://auth.example.com/oauth/token",
   "revocation_endpoint": "https://auth.example.com/oauth/revoke",
+  "token_endpoint_auth_methods_supported": ["none", "client_secret_basic", "client_secret_post"],
+  "revocation_endpoint_auth_methods_supported": ["none", "client_secret_basic", "client_secret_post"],
   "client_id_metadata_document_supported": true
 }
 ```
 
 `client_id_metadata_document_supported` 값은 런타임 설정 `ENABLE_MCP`에 따라 결정된다.
+
+`token_endpoint_auth_methods_supported` / `revocation_endpoint_auth_methods_supported`는 zitadel/oidc OP가 실제로 받아들이는 인증 방식 집합과 일치해야 한다 (RFC 8414 §2). 컨피덴셜 클라이언트는 이 광고 값을 신뢰해 자격증명 위치를 고를 수 있으므로 누락된 항목이 있으면 디스커버리 기반 클라이언트가 silently 실패한다.
 
 ## Client ID Metadata Document (CIMD)
 

--- a/docs/spec/004-mcp-login.md
+++ b/docs/spec/004-mcp-login.md
@@ -244,15 +244,17 @@ authgate는 `/.well-known/oauth-authorization-server`에서 최소한 아래를 
   "authorization_endpoint": "https://auth.example.com/authorize",
   "token_endpoint": "https://auth.example.com/oauth/token",
   "revocation_endpoint": "https://auth.example.com/oauth/revoke",
+  "introspection_endpoint": "https://auth.example.com/oauth/introspect",
   "token_endpoint_auth_methods_supported": ["none", "client_secret_basic", "client_secret_post"],
   "revocation_endpoint_auth_methods_supported": ["none", "client_secret_basic", "client_secret_post"],
+  "introspection_endpoint_auth_methods_supported": ["client_secret_basic"],
   "client_id_metadata_document_supported": true
 }
 ```
 
 `client_id_metadata_document_supported` 값은 런타임 설정 `ENABLE_MCP`에 따라 결정된다.
 
-`token_endpoint_auth_methods_supported` / `revocation_endpoint_auth_methods_supported`는 zitadel/oidc OP가 실제로 받아들이는 인증 방식 집합과 일치해야 한다 (RFC 8414 §2). 컨피덴셜 클라이언트는 이 광고 값을 신뢰해 자격증명 위치를 고를 수 있으므로 누락된 항목이 있으면 디스커버리 기반 클라이언트가 silently 실패한다.
+`token_endpoint_auth_methods_supported` / `revocation_endpoint_auth_methods_supported` / `introspection_endpoint_auth_methods_supported`는 zitadel/oidc OP가 실제로 받아들이는 인증 방식 집합과 일치해야 한다 (RFC 8414 §2). 컨피덴셜 클라이언트는 이 광고 값을 신뢰해 자격증명 위치를 고를 수 있으므로 누락된 항목이 있으면 디스커버리 기반 클라이언트가 silently 실패한다. `/oauth/introspect`는 zitadel이 기본 마운트하지만 `ClientIDFromRequest`가 Basic 자격증명만 `authenticated=true`로 표시하므로 introspection 광고 집합은 token/revocation보다 좁다.
 
 ## Client ID Metadata Document (CIMD)
 

--- a/internal/integration/integration_metadata_test.go
+++ b/internal/integration/integration_metadata_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"testing"
+)
+
+// #189 / RFC 8414 §2: discovery metadata MUST list the auth methods the AS
+// actually accepts. zitadel/oidc's /oauth/token branch always accepts
+// client_secret_basic (the OIDC default), and accepts client_secret_post
+// when AuthMethodPost is true. Public clients use `none`. Authgate has
+// AuthMethodPost=true, so all three are accepted — and must all be
+// advertised so confidential clients trusting discovery don't pick the
+// wrong credential location and silently fail.
+//
+// The same applies to /oauth/revoke per RFC 7009: AuthMethodsRevocationEndpoint
+// in zitadel/oidc returns the same set, so a `revocation_endpoint_auth_methods_supported`
+// entry must mirror it.
+func TestIntegration_ASMetadata_AdvertisesAllAcceptedAuthMethods(t *testing.T) {
+	ts := SetupTestServer(t)
+
+	resp, err := http.Get(ts.BaseURL + "/.well-known/oauth-authorization-server")
+	if err != nil {
+		t.Fatalf("metadata request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var metadata map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&metadata); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+
+	expected := []string{"client_secret_basic", "client_secret_post", "none"}
+
+	tokenMethods := stringSlice(t, metadata, "token_endpoint_auth_methods_supported")
+	if !sortedEqual(tokenMethods, expected) {
+		t.Errorf("token_endpoint_auth_methods_supported = %v, want %v", tokenMethods, expected)
+	}
+
+	revokeMethods := stringSlice(t, metadata, "revocation_endpoint_auth_methods_supported")
+	if !sortedEqual(revokeMethods, expected) {
+		t.Errorf("revocation_endpoint_auth_methods_supported = %v, want %v", revokeMethods, expected)
+	}
+}
+
+func stringSlice(t *testing.T, metadata map[string]any, key string) []string {
+	t.Helper()
+	raw, ok := metadata[key]
+	if !ok {
+		t.Fatalf("metadata missing key %q", key)
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("metadata[%q] is %T, want []any", key, raw)
+	}
+	out := make([]string, 0, len(arr))
+	for _, v := range arr {
+		s, ok := v.(string)
+		if !ok {
+			t.Fatalf("metadata[%q] entry is %T, want string", key, v)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func sortedEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := append([]string(nil), a...)
+	bc := append([]string(nil), b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	for i := range ac {
+		if ac[i] != bc[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/integration/integration_metadata_test.go
+++ b/internal/integration/integration_metadata_test.go
@@ -45,6 +45,17 @@ func TestIntegration_ASMetadata_AdvertisesAllAcceptedAuthMethods(t *testing.T) {
 	if !sortedEqual(revokeMethods, expected) {
 		t.Errorf("revocation_endpoint_auth_methods_supported = %v, want %v", revokeMethods, expected)
 	}
+
+	// /oauth/introspect is mounted by zitadel by default but only authenticates
+	// confidential clients via Basic; the metadata MUST advertise the
+	// endpoint and its narrower auth-method set so RFC 8414 §2 holds.
+	if got, _ := metadata["introspection_endpoint"].(string); got == "" {
+		t.Errorf("introspection_endpoint missing from metadata")
+	}
+	introspectMethods := stringSlice(t, metadata, "introspection_endpoint_auth_methods_supported")
+	if !sortedEqual(introspectMethods, []string{"client_secret_basic"}) {
+		t.Errorf("introspection_endpoint_auth_methods_supported = %v, want [client_secret_basic]", introspectMethods)
+	}
 }
 
 func stringSlice(t *testing.T, metadata map[string]any, key string) []string {

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -160,23 +160,27 @@ func SetupTestServerWithOptions(t *testing.T, opts SetupOptions) *TestServer {
 	// Routes
 	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
 		metadata := map[string]any{
-			"issuer":                                srv.URL,
-			"authorization_endpoint":                srv.URL + "/authorize",
-			"token_endpoint":                        srv.URL + "/oauth/token",
-			"revocation_endpoint":                   srv.URL + "/oauth/revoke",
-			"device_authorization_endpoint":         srv.URL + "/oauth/device/authorize",
-			"userinfo_endpoint":                     srv.URL + "/userinfo",
-			"end_session_endpoint":                  srv.URL + "/end_session",
-			"jwks_uri":                              srv.URL + "/keys",
-			"response_types_supported":              []string{"code"},
-			"grant_types_supported":                 []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
+			"issuer":                        srv.URL,
+			"authorization_endpoint":        srv.URL + "/authorize",
+			"token_endpoint":                srv.URL + "/oauth/token",
+			"revocation_endpoint":           srv.URL + "/oauth/revoke",
+			"introspection_endpoint":        srv.URL + "/oauth/introspect",
+			"device_authorization_endpoint": srv.URL + "/oauth/device/authorize",
+			"userinfo_endpoint":             srv.URL + "/userinfo",
+			"end_session_endpoint":          srv.URL + "/end_session",
+			"jwks_uri":                      srv.URL + "/keys",
+			"response_types_supported":      []string{"code"},
+			"grant_types_supported":         []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
 			"code_challenge_methods_supported": []string{"S256"},
 			// Mirror the production metadata contract: advertise every auth
 			// method the underlying op accepts (#189 / RFC 8414 §2).
-			"token_endpoint_auth_methods_supported":      []string{"none", "client_secret_basic", "client_secret_post"},
-			"revocation_endpoint_auth_methods_supported": []string{"none", "client_secret_basic", "client_secret_post"},
-			"scopes_supported":                           []string{"openid", "profile", "email", "offline_access"},
-			"client_id_metadata_document_supported":      opts.EnableMCP,
+			// Introspection only authenticates via Basic (see comment in
+			// cmd/authgate/main.go), so its set is narrower.
+			"token_endpoint_auth_methods_supported":         []string{"none", "client_secret_basic", "client_secret_post"},
+			"revocation_endpoint_auth_methods_supported":    []string{"none", "client_secret_basic", "client_secret_post"},
+			"introspection_endpoint_auth_methods_supported": []string{"client_secret_basic"},
+			"scopes_supported":                              []string{"openid", "profile", "email", "offline_access"},
+			"client_id_metadata_document_supported":         opts.EnableMCP,
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(metadata)

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -170,10 +170,13 @@ func SetupTestServerWithOptions(t *testing.T, opts SetupOptions) *TestServer {
 			"jwks_uri":                              srv.URL + "/keys",
 			"response_types_supported":              []string{"code"},
 			"grant_types_supported":                 []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
-			"code_challenge_methods_supported":      []string{"S256"},
-			"token_endpoint_auth_methods_supported": []string{"none", "client_secret_post"},
-			"scopes_supported":                      []string{"openid", "profile", "email", "offline_access"},
-			"client_id_metadata_document_supported": opts.EnableMCP,
+			"code_challenge_methods_supported": []string{"S256"},
+			// Mirror the production metadata contract: advertise every auth
+			// method the underlying op accepts (#189 / RFC 8414 §2).
+			"token_endpoint_auth_methods_supported":      []string{"none", "client_secret_basic", "client_secret_post"},
+			"revocation_endpoint_auth_methods_supported": []string{"none", "client_secret_basic", "client_secret_post"},
+			"scopes_supported":                           []string{"openid", "profile", "email", "offline_access"},
+			"client_id_metadata_document_supported":      opts.EnableMCP,
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(metadata)


### PR DESCRIPTION
## Summary

Fixes #189.

`/.well-known/oauth-authorization-server` advertised `token_endpoint_auth_methods_supported: ["none","client_secret_post"]`, but zitadel/oidc's /oauth/token branch always accepts `client_secret_basic` (the OIDC default per `pkg/op/discovery.go:AuthMethodsTokenEndpoint`), accepts `client_secret_post` because `op.Config.AuthMethodPost=true`, and accepts `none` for public clients. Confidential clients trusting discovery could conclude Basic is unsupported and silently fail by sending credentials in the wrong location.

## Fix

- Advertise the full set the server actually accepts: `["none", "client_secret_basic", "client_secret_post"]`.
- Add `revocation_endpoint_auth_methods_supported` mirror per RFC 7009; zitadel/oidc's revocation branch (`AuthMethodsRevocationEndpoint`) advertises the same set as the token endpoint.
- Apply identically to both `cmd/authgate/main.go` and `internal/integration/server.go` so prod and tests stay in lockstep.
- Update spec `docs/spec/004-mcp-login.md` to show the full metadata example and state the RFC 8414 §2 invariant ("advertise what we accept").

## Test

`TestIntegration_ASMetadata_AdvertisesAllAcceptedAuthMethods` fetches the metadata document and asserts both `token_endpoint_auth_methods_supported` and `revocation_endpoint_auth_methods_supported` equal `["none","client_secret_basic","client_secret_post"]` (set equality, order-independent).

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test -tags=integration -count=1 ./...`
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)