### PR TITLE
fix(storage): reject URL-form static client_id in clients.yaml (#190)

### DIFF
--- a/docs/spec/004-mcp-login.md
+++ b/docs/spec/004-mcp-login.md
@@ -290,6 +290,17 @@ authgate의 CIMD 처리:
   4. 검증 성공 → 메모리에서 ClientModel 생성 → 플로우 진행
 ```
 
+### URL-form static client_id 금지 (#190)
+
+`clients.yaml`의 정적 등록 항목 중 `client_id`가 CIMD URL 형식 (HTTPS + path 포함)이면
+설정 로드 시점에 거부한다. `ResolveClient`는 정적 in-memory 맵을 CIMD fetcher보다 먼저
+조회하므로, URL 형식 정적 등록을 허용하면 CIMDFetcher의 HTTPS / content-type / redirect /
+size 검증을 전부 우회하는 고리가 생긴다. 따라서:
+
+- 정적 client_id는 비-URL 형식이어야 한다 (예: `my-app`, `mcp-cli`).
+- URL 형식 client_id를 쓰려면 정적 등록 없이 dynamic CIMD 경로로만 진입한다.
+- 위반 시 `LoadClientConfig`가 `URL-form (CIMD-shaped) client_id cannot be registered statically` 에러를 반환한다.
+
 CIMD가 DCR을 대체하는 이유:
 
 | 항목 | DCR | CIMD |

--- a/internal/storage/clients.go
+++ b/internal/storage/clients.go
@@ -60,6 +60,14 @@ func LoadClientConfig(path string) (*ClientConfigFile, error) {
 		if len(c.ClientID) > maxYAMLClientIDLength {
 			return nil, fmt.Errorf("client[%d] %q: client_id exceeds %d chars", i, c.ClientID, maxYAMLClientIDLength)
 		}
+		// #190: a URL-form (CIMD-shaped) client_id MUST NOT be registered
+		// statically. ResolveClient consults the in-memory map before the
+		// CIMD fetcher fallback, so a static URL-form entry would bypass
+		// every HTTPS / content-type / redirect / size validation that
+		// CIMDFetcher applies on dynamic resolution.
+		if IsCIMDClientID(c.ClientID) {
+			return nil, fmt.Errorf("client[%d] %q: URL-form (CIMD-shaped) client_id cannot be registered statically; remove this entry and rely on dynamic CIMD resolution", i, c.ClientID)
+		}
 		if seen[c.ClientID] {
 			return nil, fmt.Errorf("client[%d] %q: duplicate client_id", i, c.ClientID)
 		}

--- a/internal/storage/clients.go
+++ b/internal/storage/clients.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -57,6 +58,13 @@ func LoadClientConfig(path string) (*ClientConfigFile, error) {
 		if c.ClientID == "" {
 			return nil, fmt.Errorf("client[%d]: client_id is required", i)
 		}
+		// #190: surrounding whitespace is rejected up front so the
+		// IsCIMDClientID check below — which delegates to url.ParseRequestURI
+		// and fails on leading/trailing space — cannot be tricked into
+		// admitting a CIMD-shaped value as an opaque static ID.
+		if strings.TrimSpace(c.ClientID) != c.ClientID {
+			return nil, fmt.Errorf("client[%d] %q: client_id must not have leading or trailing whitespace", i, c.ClientID)
+		}
 		if len(c.ClientID) > maxYAMLClientIDLength {
 			return nil, fmt.Errorf("client[%d] %q: client_id exceeds %d chars", i, c.ClientID, maxYAMLClientIDLength)
 		}
@@ -64,7 +72,9 @@ func LoadClientConfig(path string) (*ClientConfigFile, error) {
 		// statically. ResolveClient consults the in-memory map before the
 		// CIMD fetcher fallback, so a static URL-form entry would bypass
 		// every HTTPS / content-type / redirect / size validation that
-		// CIMDFetcher applies on dynamic resolution.
+		// CIMDFetcher applies on dynamic resolution. The check runs before
+		// the duplicate-id guard so the actionable "use dynamic CIMD"
+		// message wins over the generic "duplicate" error.
 		if IsCIMDClientID(c.ClientID) {
 			return nil, fmt.Errorf("client[%d] %q: URL-form (CIMD-shaped) client_id cannot be registered statically; remove this entry and rely on dynamic CIMD resolution", i, c.ClientID)
 		}
@@ -136,8 +146,20 @@ func ValidateClientChannels(clients []ClientConfigEntry, enableMCP bool) error {
 }
 
 // LoadClients loads client config entries into the in-memory client store.
+//
+// Production startup runs LoadClientConfig first, which already rejects
+// URL-form (CIMD-shaped) client_ids per #190. The defense-in-depth
+// re-check here protects test helpers and any future caller that bypasses
+// LoadClientConfig — a URL-form entry in the static map would bypass
+// every CIMDFetcher validation, so we log and skip rather than silently
+// admit it.
 func (s *Storage) LoadClients(clients []ClientConfigEntry) {
 	for _, c := range clients {
+		if IsCIMDClientID(c.ClientID) {
+			slog.Warn("LoadClients: dropping URL-form client_id from static registry — use dynamic CIMD resolution instead",
+				"client_id", c.ClientID)
+			continue
+		}
 		cm := &ClientModel{
 			ID:                   c.ClientID,
 			SecretHash:           c.ClientSecretHash,

--- a/internal/storage/clients_test.go
+++ b/internal/storage/clients_test.go
@@ -54,6 +54,42 @@ clients:
 	}
 }
 
+// #190 / Codex NIT-1: leading/trailing whitespace on client_id is rejected
+// up front so the IsCIMDClientID guard — which delegates to
+// url.ParseRequestURI and fails on space — cannot be tricked into admitting
+// a CIMD-shaped value as an opaque static ID.
+func TestLoadClientConfig_RejectsWhitespaceClientID(t *testing.T) {
+	cases := []struct {
+		name     string
+		clientID string
+	}{
+		{"leading", " https-shaped"},
+		{"trailing", "my-app "},
+		{"both", " my-app "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeClientConfigFile(t, `
+clients:
+  - client_id: "`+tc.clientID+`"
+    client_type: public
+    login_channel: browser
+    name: Whitespace
+    redirect_uris: ["https://app.example.com/callback"]
+    allowed_scopes: [openid]
+    allowed_grant_types: [authorization_code]
+`)
+			_, err := LoadClientConfig(path)
+			if err == nil {
+				t.Fatalf("expected whitespace client_id to be rejected, got nil")
+			}
+			if !strings.Contains(err.Error(), "whitespace") {
+				t.Fatalf("expected whitespace rejection error, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestLoadClientConfig_DuplicateClientID(t *testing.T) {
 	path := writeClientConfigFile(t, `
 clients:
@@ -203,5 +239,25 @@ func TestValidateClientChannels_MCPEnabledAllowsMCPClient(t *testing.T) {
 
 	if err := ValidateClientChannels(clients, true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// #190 / Codex NIT-3: LoadClients itself is a setter normally fed by the
+// validated output of LoadClientConfig. As a belt-and-suspenders, the
+// setter must drop URL-form client_ids if a future caller bypasses
+// LoadClientConfig — otherwise the static-vs-dynamic invariant breaks
+// silently for whatever test or admin path constructed the slice.
+func TestLoadClients_DropsCIMDShapedClientID(t *testing.T) {
+	s := &Storage{}
+	s.LoadClients([]ClientConfigEntry{
+		{ClientID: "static-ok", LoginChannel: "browser"},
+		{ClientID: "https://app.example.com/oauth/client.json", LoginChannel: "mcp"},
+	})
+
+	if _, ok := s.clients.Load("static-ok"); !ok {
+		t.Errorf("non-URL static-ok client should be loaded")
+	}
+	if _, ok := s.clients.Load("https://app.example.com/oauth/client.json"); ok {
+		t.Errorf("URL-form client_id should NOT be loaded into static registry")
 	}
 }

--- a/internal/storage/clients_test.go
+++ b/internal/storage/clients_test.go
@@ -16,6 +16,44 @@ func writeClientConfigFile(t *testing.T, body string) string {
 	return p
 }
 
+// #190: a URL-form static client_id (i.e. one that satisfies IsCIMDClientID)
+// must be rejected at config-load time. Otherwise an operator can register
+// a CIMD-shaped client_id in the static map, where ResolveClient hits the
+// in-memory hit before the CIMD fallback ever runs — bypassing every
+// HTTPS / content-type / redirect / size validation that CIMDFetcher
+// applies on dynamic resolution. Two cases pinned: a typical CIMD URL
+// and the canonical RFC example shape.
+func TestLoadClientConfig_RejectsCIMDShapedClientID(t *testing.T) {
+	cases := []struct {
+		name     string
+		clientID string
+	}{
+		{"https path", "https://app.example.com/oauth/client.json"},
+		{"https deep path", "https://example.com/.well-known/oauth-client"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeClientConfigFile(t, `
+clients:
+  - client_id: `+tc.clientID+`
+    client_type: public
+    login_channel: mcp
+    name: CIMD-shaped
+    redirect_uris: ["https://app.example.com/callback"]
+    allowed_scopes: [openid]
+    allowed_grant_types: [authorization_code]
+`)
+			_, err := LoadClientConfig(path)
+			if err == nil {
+				t.Fatalf("expected URL-form client_id to be rejected, got nil")
+			}
+			if !strings.Contains(err.Error(), "CIMD") && !strings.Contains(err.Error(), "URL-form") {
+				t.Fatalf("expected CIMD rejection error, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestLoadClientConfig_DuplicateClientID(t *testing.T) {
 	path := writeClientConfigFile(t, `
 clients:


### PR DESCRIPTION
## Summary

Fixes #190.

`Storage.ResolveClient` consults the static in-memory registry before falling back to the CIMD fetcher. So a URL-form `client_id` (one that satisfies `IsCIMDClientID` — HTTPS scheme, host, non-trivial path, no query/fragment/userinfo) registered statically in `clients.yaml` would silently bypass every check the CIMDFetcher applies on dynamic resolution: HTTPS scheme, allowed content-type, redirect-uri size/count limits, JSON shape validation.

Operator misconfiguration territory, but the failure mode is a foot-gun that widens the trust perimeter without warning.

## Fix

- `LoadClientConfig` rejects any entry whose `client_id` satisfies `IsCIMDClientID`, with an actionable error pointing to the dynamic-resolution path: `"URL-form (CIMD-shaped) client_id cannot be registered statically; remove this entry and rely on dynamic CIMD resolution"`.
- Spec doc `docs/spec/004-mcp-login.md` gets a "URL-form static client_id 금지 (#190)" subsection so the policy is explicit and discoverable, not just implicit in the validator.

## Test

`TestLoadClientConfig_RejectsCIMDShapedClientID` table-tests two CIMD-shaped IDs: a typical URL with path and a deeper `.well-known` style URL. Both must be rejected at config-load time.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test -tags=integration -count=1 ./...`
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)