### PR TITLE
fix(service): emit auth.login audit on MCP reused-session approval (#206)

### DIFF
--- a/docs/tests/004-audit-events.md
+++ b/docs/tests/004-audit-events.md
@@ -37,7 +37,7 @@
 |----|------|------|---------------|
 | `audit-login-001` | browser | Browser 로그인 성공 | `{channel: "browser", client_id, client_name}` |
 | `audit-login-002` | device | Device 로그인 성공 | `{channel: "device", client_id, client_name}` |
-| `audit-login-003` | mcp | MCP 로그인 성공 (신규 callback 및 활성 세션 자동 승인 모두) | `{channel: "mcp", client_id, client_name}`; 세션 재사용 경로는 추가로 `reused_session: true`, `session_id` 포함 (#206, 브라우저 #131 mirror) |
+| `audit-login-003` | mcp | MCP 로그인 성공 (신규 callback 및 활성 세션 자동 승인 모두) | 공통 `{channel: "mcp", session_id, client_id, client_name}`; 세션 재사용 경로는 추가로 `reused_session: true` 포함 (#206, 브라우저 #131 mirror) |
 
 ## 보안 이벤트 검증
 

--- a/docs/tests/004-audit-events.md
+++ b/docs/tests/004-audit-events.md
@@ -37,7 +37,7 @@
 |----|------|------|---------------|
 | `audit-login-001` | browser | Browser 로그인 성공 | `{channel: "browser", client_id, client_name}` |
 | `audit-login-002` | device | Device 로그인 성공 | `{channel: "device", client_id, client_name}` |
-| `audit-login-003` | mcp | MCP 로그인 성공 | `{channel: "mcp", client_id, client_name}` |
+| `audit-login-003` | mcp | MCP 로그인 성공 (신규 callback 및 활성 세션 자동 승인 모두) | `{channel: "mcp", client_id, client_name}`; 세션 재사용 경로는 추가로 `reused_session: true`, `session_id` 포함 (#206, 브라우저 #131 mirror) |
 
 ## 보안 이벤트 검증
 

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -181,6 +181,50 @@ func TestAudit_ReusedSession_AuthLoginRecorded(t *testing.T) {
 	}
 }
 
+// Issue #206: MCP reused-session auto-approve was missing auth.login.
+// Mirrors TestAudit_ReusedSession_AuthLoginRecorded (browser, #131) — the MCP
+// flow must also emit auth.login with reused_session=true so audit history is
+// symmetric across channels.
+func TestAudit_ReusedSession_MCP_AuthLoginRecorded(t *testing.T) {
+	svc, store := setupMCPExtTest(t, "audit-mcp-reuse-sub")
+	ctx := context.Background()
+
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp-reuse@test.com", EmailVerified: true, Name: "MCP Reuse", AvatarURL: "", Provider: "google", ProviderUserID: "audit-mcp-reuse-sub", ProviderEmail: "audit-mcp-reuse@test.com"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	sessionID, err := store.CreateSession(ctx, user.ID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	arID, err := store.CreateTestAuthRequestWithResource(ctx, "audit-mcp-reuse", "http://localhost/mcp")
+	if err != nil {
+		t.Fatalf("create auth request: %v", err)
+	}
+
+	result := svc.HandleLogin(ctx, arID, sessionID, "127.0.0.1", "mcp-reuse-agent")
+	if result.Action != ActionAutoApprove {
+		t.Fatalf("action = %v, want AutoApprove", result.Action)
+	}
+
+	event := requireSingleAuditEvent(t, store.DB(), user.ID, "auth.login")
+	if event.Metadata["channel"] != "mcp" {
+		t.Fatalf("channel = %v, want mcp", event.Metadata["channel"])
+	}
+	if event.Metadata["reused_session"] != true {
+		t.Fatalf("reused_session = %v, want true", event.Metadata["reused_session"])
+	}
+	if event.Metadata["session_id"] != sessionID {
+		t.Fatalf("session_id = %v, want %s", event.Metadata["session_id"], sessionID)
+	}
+	if event.Metadata["client_id"] != "test-mcp-app" {
+		t.Fatalf("client_id = %v, want test-mcp-app", event.Metadata["client_id"])
+	}
+	if _, ok := event.Metadata["client_name"]; !ok {
+		t.Fatalf("client_name key missing in metadata: %v", event.Metadata)
+	}
+}
+
 func TestAudit004_DeviceApproved(t *testing.T) {
 	svc, store, clk := setupDeviceService(t)
 	ctx := context.Background()

--- a/internal/service/mcp_login.go
+++ b/internal/service/mcp_login.go
@@ -55,6 +55,13 @@ func (s *MCPLoginService) HandleLogin(ctx context.Context, authRequestID, sessio
 			if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
 				return &LoginResult{Action: ActionError, Error: "failed to complete auth request", ErrorCode: http.StatusInternalServerError}
 			}
+			s.store.AuditLog(ctx, &user.ID, "auth.login", ipAddress, userAgent, map[string]any{
+				"channel":        "mcp",
+				"session_id":     sessionID,
+				"client_id":      authReq.ClientID,
+				"client_name":    resolveClientName(ctx, s.store, authReq.ClientID),
+				"reused_session": true,
+			})
 			return &LoginResult{Action: ActionAutoApprove, AuthRequestID: authRequestID}
 		}
 	}


### PR DESCRIPTION
## Summary

Closes #206 — MCP 채널의 재사용 세션 자동 승인 경로에서 `auth.login` audit가 발행되지 않아 channel-symmetric audit 약속이 깨져 있었다.

- 브라우저 reused-session 경로(#131, `internal/service/login.go:142`)는 `auth.login` metadata `{channel, session_id, client_id, client_name, reused_session: true}` 발행
- MCP `HandleLogin` reused-session 경로(`internal/service/mcp_login.go:55-58`)는 `CompleteAuthRequest` 호출 후 audit 없이 `AutoApprove` 반환

결과: MCP 클라이언트의 자동 승인 history가 `audit_log`에 남지 않아 MCP 채널 침해 추적에 구멍.

## Changes

- `internal/service/mcp_login.go`: reused-session 분기에 `auth.login` audit 추가 — 브라우저 mirror metadata (`channel="mcp"`, `session_id`, `client_id`, `client_name`, `reused_session=true`)
- `internal/service/audit_test.go`: `TestAudit_ReusedSession_MCP_AuthLoginRecorded` 추가 — 브라우저 #131 mirror integration test
- `docs/tests/004-audit-events.md`: audit-login-003 명세를 "신규 callback + 재사용 자동 승인 모두" 로 정밀화

## Test plan

- [x] 새 integration test `TestAudit_ReusedSession_MCP_AuthLoginRecorded` 통과 (Docker testcontainers)
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [ ] CI 풀 통합 테스트 그린

## Notes

- client_name 빈 값 허용은 의도적 — 시드 `test-mcp-app` client에 Name 미지정. `client_name` 빈 문자열 강제는 #204/#205 PR scope (audit-011 enforcement)
- 브라우저 #131 fix와 동일 패턴/검증 강도

🤖 Generated with [Claude Code](https://claude.com/claude-code)