### PR TITLE
fix(observability): expose audit log write failures via Prometheus counter (#208)

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -94,6 +94,8 @@ func main() {
 	var isShuttingDown atomic.Bool
 	mux := http.NewServeMux()
 	httpMetrics := observability.NewHTTPMetrics()
+	auditMetrics := observability.NewAuditMetrics(httpMetrics.Registry())
+	store.SetAuditFailureRecorder(auditMetrics)
 	registerRoutes(mux, cfg, db, store, provider, loginHandler, deviceHandler, accountHandler, mcpLoginHandler, consoleHandler, httpMetrics, &isShuttingDown)
 
 	trustedProxies, err := clientinfo.ParseTrustedProxies(cfg.TrustedProxies)

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -321,6 +321,29 @@ SELECT * FROM audit_log WHERE event_type = 'auth.inactive_user' ORDER BY created
 | cleanup 고루틴 | audit_log에 `auth.deletion_completed` 확인 | 30일+ pending_deletion 유저 존재 |
 | signing_key | JWKS 엔드포인트 체크 | 키 0개 반환 |
 | 디스크 | signing_key.pem 파일 존재 확인 | 파일 없음 → 재시작마다 키 변경 |
+| audit 쓰기 실패 | `authgate_audit_log_write_failures_total` counter | 5분 내 증가 → 침해 탐지 인프라 silent broken (#208) |
+
+### audit_log 쓰기 실패 모니터링 (#208)
+
+`Storage.AuditLog`는 best-effort write이므로 marshal/insert 실패가 비즈니스 트랜잭션을 차단하지 않는다. 그러나 감사 로그가 silent하게 누락되면 침해 탐지 능력 자체가 무력화되므로 Prometheus counter로 노출되어 alert으로 감지한다.
+
+| Metric | Labels | 설명 |
+|--------|--------|------|
+| `authgate_audit_log_write_failures_total` | `stage="marshal"` | `json.Marshal(metadata)` 실패 — 호출자 입력 형상 버그 |
+| `authgate_audit_log_write_failures_total` | `stage="insert"` | `audit_log INSERT` 실패 — DB outage / 권한 / 디스크 |
+
+PrometheusRule 예시:
+
+```yaml
+- alert: AuthgateAuditWriteFailures
+  expr: increase(authgate_audit_log_write_failures_total[5m]) > 0
+  for: 1m
+  labels:
+    severity: critical
+  annotations:
+    summary: "authgate audit log writes are failing (stage={{ $labels.stage }})"
+    description: "감사 로그 쓰기가 silent하게 실패 중. 침해 탐지 인프라가 broken — 즉시 점검."
+```
 
 ## 백업/복구
 

--- a/internal/observability/audit_metrics.go
+++ b/internal/observability/audit_metrics.go
@@ -25,6 +25,11 @@ func NewAuditMetrics(reg *prometheus.Registry) *AuditMetrics {
 		[]string{"stage"},
 	)
 	reg.MustRegister(cv)
+	// Pre-create the known label series so increase()/rate() see a baseline
+	// of 0 from the first scrape — otherwise the alert in
+	// docs/spec/009-operations.md would miss the very first failure.
+	cv.WithLabelValues("marshal")
+	cv.WithLabelValues("insert")
 	return &AuditMetrics{writeFailures: cv}
 }
 

--- a/internal/observability/audit_metrics.go
+++ b/internal/observability/audit_metrics.go
@@ -1,0 +1,40 @@
+package observability
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// AuditMetrics owns Prometheus counters for audit-log write outcomes.
+// It registers into the shared HTTPMetrics registry so a single /metrics
+// scrape target exposes both groups.
+type AuditMetrics struct {
+	writeFailures *prometheus.CounterVec
+}
+
+// NewAuditMetrics registers audit-log counters into reg and returns a recorder.
+// Stages: "marshal" (json.Marshal of metadata failed before any DB call) and
+// "insert" (audit_log INSERT failed). Tracking the two separately lets alert
+// rules distinguish input-shape bugs from DB outages so an oncall responder
+// can route the page correctly.
+func NewAuditMetrics(reg *prometheus.Registry) *AuditMetrics {
+	cv := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "authgate_audit_log_write_failures_total",
+			Help: "Total number of audit log write failures, partitioned by stage (marshal|insert).",
+		},
+		[]string{"stage"},
+	)
+	reg.MustRegister(cv)
+	return &AuditMetrics{writeFailures: cv}
+}
+
+// RecordWriteFailure increments the failure counter for the given stage.
+// Callers pass either "marshal" or "insert"; other labels are accepted but
+// will not match the alert rules in docs/spec/009-operations.md.
+// Nil receivers are tolerated so test wiring can omit the recorder entirely.
+func (m *AuditMetrics) RecordWriteFailure(stage string) {
+	if m == nil {
+		return
+	}
+	m.writeFailures.WithLabelValues(stage).Inc()
+}

--- a/internal/observability/http_metrics.go
+++ b/internal/observability/http_metrics.go
@@ -68,6 +68,13 @@ func (m *HTTPMetrics) MetricsHandler() http.Handler {
 	return promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{})
 }
 
+// Registry exposes the shared Prometheus registry so adjacent metric groups
+// (e.g., observability.AuditMetrics) can register into the same /metrics
+// scrape target without spinning up a second endpoint.
+func (m *HTTPMetrics) Registry() *prometheus.Registry {
+	return m.registry
+}
+
 func (m *HTTPMetrics) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -93,6 +93,7 @@ func (s *Storage) AuditLog(ctx context.Context, userID *string, eventType, ipAdd
 	if metadata != nil {
 		marshaled, err := json.Marshal(metadata)
 		if err != nil {
+			s.auditFailureRec.RecordWriteFailure("marshal")
 			slog.ErrorContext(ctx, "audit log: marshal metadata",
 				"event_type", eventType,
 				"user_id", userIDLogValue(userID),
@@ -111,6 +112,7 @@ func (s *Storage) AuditLog(ctx context.Context, userID *string, eventType, ipAdd
 		Metadata:  nilIfEmptyBytes(metaJSON),
 		CreatedAt: s.clock.Now(),
 	}); err != nil {
+		s.auditFailureRec.RecordWriteFailure("insert")
 		slog.ErrorContext(ctx, "audit log: insert",
 			"event_type", eventType,
 			"user_id", userIDLogValue(userID),

--- a/internal/storage/audit_failure_unit_test.go
+++ b/internal/storage/audit_failure_unit_test.go
@@ -111,6 +111,83 @@ func TestAuditLog_MarshalFailure_DoesNotPropagateAndIsLogged(t *testing.T) {
 	}
 }
 
+// fakeAuditFailureRecorder counts RecordWriteFailure calls per stage so tests
+// can assert that AuditLog increments the right counter on each failure mode.
+type fakeAuditFailureRecorder struct {
+	marshalFailures int
+	insertFailures  int
+	otherFailures   int
+}
+
+func (f *fakeAuditFailureRecorder) RecordWriteFailure(stage string) {
+	switch stage {
+	case "marshal":
+		f.marshalFailures++
+	case "insert":
+		f.insertFailures++
+	default:
+		f.otherFailures++
+	}
+}
+
+// TestAuditLog_InsertFailure_IncrementsMetric asserts that an INSERT failure
+// causes the audit-failure recorder to see exactly one "insert"-stage event
+// (and no spurious "marshal" or other-stage events).
+func TestAuditLog_InsertFailure_IncrementsMetric(t *testing.T) {
+	captureSlog(t)
+	store := newClosedAuditStorage(t)
+	rec := &fakeAuditFailureRecorder{}
+	store.SetAuditFailureRecorder(rec)
+
+	uid := "33333333-3333-4333-8333-333333333333"
+	store.AuditLog(context.Background(), &uid, "auth.login", "", "", map[string]any{"k": "v"})
+
+	if rec.insertFailures != 1 {
+		t.Fatalf("insertFailures = %d, want 1", rec.insertFailures)
+	}
+	if rec.marshalFailures != 0 {
+		t.Fatalf("marshalFailures = %d, want 0", rec.marshalFailures)
+	}
+	if rec.otherFailures != 0 {
+		t.Fatalf("otherFailures = %d, want 0", rec.otherFailures)
+	}
+}
+
+// TestAuditLog_MarshalFailure_IncrementsMetric asserts that a marshal failure
+// (unsupported chan type) increments only the "marshal" counter and skips
+// the INSERT path entirely.
+func TestAuditLog_MarshalFailure_IncrementsMetric(t *testing.T) {
+	captureSlog(t)
+	store := newClosedAuditStorage(t)
+	rec := &fakeAuditFailureRecorder{}
+	store.SetAuditFailureRecorder(rec)
+
+	uid := "44444444-4444-4444-8444-444444444444"
+	store.AuditLog(context.Background(), &uid, "auth.signup", "", "", map[string]any{
+		"unmarshalable": make(chan int),
+	})
+
+	if rec.marshalFailures != 1 {
+		t.Fatalf("marshalFailures = %d, want 1", rec.marshalFailures)
+	}
+	if rec.insertFailures != 0 {
+		t.Fatalf("insertFailures = %d, want 0", rec.insertFailures)
+	}
+}
+
+// TestAuditLog_SetAuditFailureRecorder_NilResetsToNoop asserts that passing
+// nil restores the no-op recorder so call sites never need a nil guard.
+func TestAuditLog_SetAuditFailureRecorder_NilResetsToNoop(t *testing.T) {
+	captureSlog(t)
+	store := newClosedAuditStorage(t)
+	store.SetAuditFailureRecorder(&fakeAuditFailureRecorder{})
+	store.SetAuditFailureRecorder(nil)
+
+	uid := "55555555-5555-4555-8555-555555555555"
+	// Must not panic; noop recorder swallows the call.
+	store.AuditLog(context.Background(), &uid, "auth.login", "", "", nil)
+}
+
 // TestAuditLog_NilUserID_LogsEmpty asserts the signature change is safe when
 // userID is nil — the failure log emits an empty user_id rather than panicking.
 func TestAuditLog_NilUserID_LogsEmpty(t *testing.T) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -50,6 +50,18 @@ type ResourceBindingPolicy interface {
 	ValidateTokenRequest(ctx context.Context, clientID, storedResource, requestResource string) error
 }
 
+// AuditFailureRecorder receives an event whenever an audit-log write fails so
+// the silent best-effort policy in AuditLog (#208) is still observable via
+// metrics/alerts. main.go wires observability.AuditMetrics; tests can plug a
+// fake recorder. Stages: "marshal" or "insert".
+type AuditFailureRecorder interface {
+	RecordWriteFailure(stage string)
+}
+
+type noopAuditFailureRecorder struct{}
+
+func (noopAuditFailureRecorder) RecordWriteFailure(string) {}
+
 type Storage struct {
 	db              *sql.DB
 	clock           clock.Clock
@@ -74,6 +86,10 @@ type Storage struct {
 	// string falls back to clock-only validation for backward compatibility
 	// with tests that construct Storage without explicit issuer plumbing.
 	issuer string
+	// auditFailureRec receives a signal whenever AuditLog fails to marshal
+	// or insert. Defaults to a no-op in New() so call sites never need a nil
+	// guard; main.go installs observability.AuditMetrics at startup.
+	auditFailureRec AuditFailureRecorder
 }
 
 func New(db *sql.DB, clk clock.Clock, gen idgen.IDGenerator, checker StateChecker, accessTTL, refreshTTL time.Duration) *Storage {
@@ -85,6 +101,7 @@ func New(db *sql.DB, clk clock.Clock, gen idgen.IDGenerator, checker StateChecke
 		accessTokenTTL:     accessTTL,
 		refreshTokenTTL:    refreshTTL,
 		devicePollInterval: 5 * time.Second,
+		auditFailureRec:    noopAuditFailureRecorder{},
 	}
 	s.clientPolicy = NewCoreClientResolutionPolicy(s)
 	s.resourcePolicy = NewCoreResourceBindingPolicy()
@@ -97,6 +114,17 @@ func New(db *sql.DB, clk clock.Clock, gen idgen.IDGenerator, checker StateChecke
 // both the response shape and the server-side throttle.
 func (s *Storage) SetDevicePollInterval(d time.Duration) {
 	s.devicePollInterval = d
+}
+
+// SetAuditFailureRecorder installs a metric recorder that AuditLog invokes
+// when a write fails. main.go wires observability.AuditMetrics. Passing nil
+// resets to the no-op recorder so the call site contract holds either way.
+func (s *Storage) SetAuditFailureRecorder(r AuditFailureRecorder) {
+	if r == nil {
+		s.auditFailureRec = noopAuditFailureRecorder{}
+		return
+	}
+	s.auditFailureRec = r
 }
 
 // SetSigningKey sets the current RSA signing key used for JWT issuance.


### PR DESCRIPTION
## Summary

Closes #208 — `Storage.AuditLog` 가 best-effort write 라 marshal/insert 실패가 `slog` 에만 남고 운영에서 자동 탐지 불가했다. DB outage 또는 metadata marshal 버그가 audit 누락을 silent 하게 만들면 침해 탐지 인프라가 broken 인데 누구도 모르는 메타-갭이 생긴다.

## Changes

- **`internal/observability/audit_metrics.go`** (신규): `AuditMetrics` 타입 + `authgate_audit_log_write_failures_total{stage="marshal"|"insert"}` Counter
- **`internal/observability/http_metrics.go`**: `Registry()` getter 추가 — `/metrics` 단일 scrape target 유지
- **`internal/storage/storage.go`**: `AuditFailureRecorder` interface + noop default + `SetAuditFailureRecorder()` setter
- **`internal/storage/audit.go`**: marshal/insert 실패 지점에서 `RecordWriteFailure(stage)` 호출 (slog 호출 직전)
- **`cmd/authgate/main.go`**: `NewAuditMetrics(httpMetrics.Registry())` + `store.SetAuditFailureRecorder(auditMetrics)` wiring
- **`internal/storage/audit_failure_unit_test.go`**: `fakeAuditFailureRecorder` + stage 별 increment 검증 + `nil` resets to noop 회귀 가드
- **`docs/spec/009-operations.md`**: 모니터링 항목 표 + 새 sub-section (metric 명세 + PrometheusRule alert 예시)

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] storage + observability unit tests (\`go test\`) 통과
- [x] integration regression (\`TestAuditLog\`, \`TestAudit_\` prefixes) 통과
- [ ] CI 풀 통합 테스트 그린

## Design notes

- `noopAuditFailureRecorder` default: nil 가드 불필요. 테스트는 nil 명시적으로 전달하면 noop 으로 복귀
- `RecordWriteFailure` 에 `nil` receiver 허용 (`AuditMetrics`) — 테스트 wiring 단순화
- Counter 이름은 `_total` suffix + `_failures` 명사 (Prometheus 권장 패턴)
- 운영 alert 예시는 `increase(...[5m]) > 0 for 1m` — 즉시-알림보다 안정성 우선

🤖 Generated with [Claude Code](https://claude.com/claude-code)