### PR TITLE
fix(service): include client context on device approve/deny audit events (#205)

### DIFF
--- a/docs/tests/004-audit-events.md
+++ b/docs/tests/004-audit-events.md
@@ -19,8 +19,8 @@
 |----|----------|------------|-------------|
 | `audit-001` | Browser 신규 가입 | `auth.signup` | 계정 생성 직후 1회 기록 |
 | `audit-002` | Browser/MCP/Device 로그인 성공 | `auth.login` | `metadata.channel`이 `browser/device/mcp` 중 하나로 기록 |
-| `audit-003` | Device 승인 | `auth.device_approved` | 승인 시 1회 기록 |
-| `audit-004` | Device 거부 | `auth.device_denied` | 거부 시 1회 기록 |
+| `audit-003` | Device 승인 | `auth.device_approved` | 승인 시 1회 기록, `metadata.client_id` + `metadata.client_name` 포함 (#205) |
+| `audit-004` | Device 거부 | `auth.device_denied` | 거부 시 1회 기록, `metadata.client_id` + `metadata.client_name` 포함 (#205) |
 | `audit-005` | DELETE /account | `auth.deletion_requested` | 삭제 요청 시 즉시 기록 |
 | `audit-006` | pending_deletion Browser 복구 | `auth.deletion_cancelled` | 자동 복구 시 기록 |
 | `audit-007` | deletion cleanup 완료 | `auth.deletion_completed` | PII 스크러빙 완료 시 기록 |

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -241,7 +241,13 @@ func TestAudit004_DeviceApproved(t *testing.T) {
 		t.Fatalf("approve failed: %s", result.Message)
 	}
 
-	requireSingleAuditEvent(t, store.DB(), user.ID, "auth.device_approved")
+	event := requireSingleAuditEvent(t, store.DB(), user.ID, "auth.device_approved")
+	if event.Metadata["client_id"] != "test-client" {
+		t.Fatalf("client_id = %v, want test-client (#205)", event.Metadata["client_id"])
+	}
+	if event.Metadata["client_name"] != "Test Device Client" {
+		t.Fatalf("client_name = %v, want Test Device Client (#205)", event.Metadata["client_name"])
+	}
 }
 
 func TestAudit005_DeviceDenied(t *testing.T) {
@@ -260,7 +266,13 @@ func TestAudit005_DeviceDenied(t *testing.T) {
 		t.Fatalf("deny should fail")
 	}
 
-	requireSingleAuditEvent(t, store.DB(), user.ID, "auth.device_denied")
+	event := requireSingleAuditEvent(t, store.DB(), user.ID, "auth.device_denied")
+	if event.Metadata["client_id"] != "test-client" {
+		t.Fatalf("client_id = %v, want test-client (#205)", event.Metadata["client_id"])
+	}
+	if event.Metadata["client_name"] != "Test Device Client" {
+		t.Fatalf("client_name = %v, want Test Device Client (#205)", event.Metadata["client_name"])
+	}
 }
 
 func TestAudit006_DeletionRequested(t *testing.T) {

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -179,12 +180,18 @@ func (s *DeviceService) HandleDeviceApprove(ctx context.Context, userCode, actio
 		return &DeviceApproveResult{Success: false, Message: "account_inactive", ErrorCode: http.StatusForbidden}
 	}
 
-	if action == "deny" {
+	switch action {
+	case "approve":
+		return s.approveDeviceCode(ctx, userCode, user.ID, ipAddress, userAgent)
+	case "deny":
 		s.denyDeviceCode(ctx, userCode, user.ID, ipAddress, userAgent)
 		return &DeviceApproveResult{Success: false, Message: "You denied the authorization request. You can close this window."}
+	default:
+		// Reject any other form value to keep the device-consent surface
+		// strict. A blank-or-typo "action" must not silently fall through to
+		// approve and generate an auth.device_approved audit row (#205).
+		return &DeviceApproveResult{Success: false, Message: "invalid action", ErrorCode: http.StatusBadRequest}
 	}
-
-	return s.approveDeviceCode(ctx, userCode, user.ID, ipAddress, userAgent)
 }
 
 func (s *DeviceService) validateDevicePage(ctx context.Context, userCode string) *DevicePageResult {
@@ -242,13 +249,48 @@ func (s *DeviceService) ensureDeviceCallbackAccess(ctx context.Context, user *st
 }
 
 func (s *DeviceService) denyDeviceCode(ctx context.Context, userCode, userID, ipAddress, userAgent string) {
-	metadata := s.deviceAuditMetadata(ctx, userCode)
-	s.store.DenyDeviceCode(ctx, userCode)
+	dc, metadata, err := s.loadDeviceAuditContext(ctx, userCode)
+	if err != nil {
+		slog.WarnContext(ctx, "device deny: skipping audit (context lookup failed)",
+			"user_id", userID,
+			"error", err,
+		)
+		return
+	}
+	// DenyDeviceCodeByUserCode is `:exec` (no rows-affected check available),
+	// so guard against issuing audit when the row is already terminal — the
+	// underlying UPDATE would no-op and we must not record auth.device_denied
+	// for a code that was already approved/denied/consumed (#205).
+	if dc.State != "pending" {
+		slog.WarnContext(ctx, "device deny: skipping audit (state not pending)",
+			"user_id", userID,
+			"state", dc.State,
+		)
+		return
+	}
+	if err := s.store.DenyDeviceCode(ctx, userCode); err != nil {
+		slog.WarnContext(ctx, "device deny: skipping audit (mutation failed)",
+			"user_id", userID,
+			"error", err,
+		)
+		return
+	}
 	s.store.AuditLog(ctx, &userID, "auth.device_denied", ipAddress, userAgent, metadata)
 }
 
 func (s *DeviceService) approveDeviceCode(ctx context.Context, userCode, userID, ipAddress, userAgent string) *DeviceApproveResult {
-	metadata := s.deviceAuditMetadata(ctx, userCode)
+	_, metadata, err := s.loadDeviceAuditContext(ctx, userCode)
+	if err != nil {
+		// audit-011 requires client_id on the auth.device_approved row, so a
+		// failed lookup must abort the mutation+audit pair rather than emit a
+		// metadataless row (#205). Surface the same user-facing message as a
+		// stale code so the consent page does not leak the lookup failure.
+		slog.WarnContext(ctx, "device approve: aborting (context lookup failed)",
+			"user_id", userID,
+			"error", err,
+		)
+		return &DeviceApproveResult{Success: false, Message: "Device code expired or already processed.", ErrorCode: http.StatusBadRequest}
+	}
 	if err := s.store.ApproveDeviceCode(ctx, userCode, userID); err != nil {
 		return &DeviceApproveResult{Success: false, Message: "Device code expired or already processed.", ErrorCode: http.StatusBadRequest}
 	}
@@ -257,21 +299,24 @@ func (s *DeviceService) approveDeviceCode(ctx context.Context, userCode, userID,
 	return &DeviceApproveResult{Success: true, Message: "You have successfully authorized the CLI application. You can close this window."}
 }
 
-// deviceAuditMetadata loads client context for the device_code so the
+// loadDeviceAuditContext loads the device_code and resolves its client so the
 // auth.device_approved / auth.device_denied audit rows can identify which
-// CLI/client was acted upon (audit-011, #205). The lookup is done before the
-// approve/deny state mutation so the metadata reflects the same client_id
-// the user saw on the consent page. Returns nil when the device_code is
-// missing — audit is best-effort and a missing client should not block the
-// row.
-func (s *DeviceService) deviceAuditMetadata(ctx context.Context, userCode string) map[string]any {
+// CLI/client was acted upon (audit-011, #205). It returns the device_code
+// (callers may inspect State for additional guards) alongside a metadata map
+// suitable for AuditLog. A non-nil error means the row should not be audited
+// — audit-011 requires client_id, so we prefer skipping the audit (with a
+// warn log) over emitting a row with no client identification.
+func (s *DeviceService) loadDeviceAuditContext(ctx context.Context, userCode string) (*storage.DeviceCodeModel, map[string]any, error) {
 	dc, err := s.store.GetDeviceCodeByUserCode(ctx, userCode)
-	if err != nil || dc == nil {
-		return nil
+	if err != nil {
+		return nil, nil, err
+	}
+	if dc == nil {
+		return nil, nil, storage.ErrNotFound
 	}
 	md := map[string]any{"client_id": dc.ClientID}
 	if c, err := s.store.ResolveClient(ctx, dc.ClientID); err == nil && c != nil {
 		md["client_name"] = c.Name
 	}
-	return md
+	return dc, md, nil
 }

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -242,15 +242,36 @@ func (s *DeviceService) ensureDeviceCallbackAccess(ctx context.Context, user *st
 }
 
 func (s *DeviceService) denyDeviceCode(ctx context.Context, userCode, userID, ipAddress, userAgent string) {
+	metadata := s.deviceAuditMetadata(ctx, userCode)
 	s.store.DenyDeviceCode(ctx, userCode)
-	s.store.AuditLog(ctx, &userID, "auth.device_denied", ipAddress, userAgent, nil)
+	s.store.AuditLog(ctx, &userID, "auth.device_denied", ipAddress, userAgent, metadata)
 }
 
 func (s *DeviceService) approveDeviceCode(ctx context.Context, userCode, userID, ipAddress, userAgent string) *DeviceApproveResult {
+	metadata := s.deviceAuditMetadata(ctx, userCode)
 	if err := s.store.ApproveDeviceCode(ctx, userCode, userID); err != nil {
 		return &DeviceApproveResult{Success: false, Message: "Device code expired or already processed.", ErrorCode: http.StatusBadRequest}
 	}
 
-	s.store.AuditLog(ctx, &userID, "auth.device_approved", ipAddress, userAgent, nil)
+	s.store.AuditLog(ctx, &userID, "auth.device_approved", ipAddress, userAgent, metadata)
 	return &DeviceApproveResult{Success: true, Message: "You have successfully authorized the CLI application. You can close this window."}
+}
+
+// deviceAuditMetadata loads client context for the device_code so the
+// auth.device_approved / auth.device_denied audit rows can identify which
+// CLI/client was acted upon (audit-011, #205). The lookup is done before the
+// approve/deny state mutation so the metadata reflects the same client_id
+// the user saw on the consent page. Returns nil when the device_code is
+// missing — audit is best-effort and a missing client should not block the
+// row.
+func (s *DeviceService) deviceAuditMetadata(ctx context.Context, userCode string) map[string]any {
+	dc, err := s.store.GetDeviceCodeByUserCode(ctx, userCode)
+	if err != nil || dc == nil {
+		return nil
+	}
+	md := map[string]any{"client_id": dc.ClientID}
+	if c, err := s.store.ResolveClient(ctx, dc.ClientID); err == nil && c != nil {
+		md["client_name"] = c.Name
+	}
+	return md
 }

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -38,6 +38,9 @@ func setupDeviceService(t *testing.T) (*DeviceService, *storage.Storage, clock.C
 func insertDeviceCode(t *testing.T, store *storage.Storage, userCode string, clk clock.Clock) {
 	t.Helper()
 	ctx := context.Background()
+	// Register the test client so audit-row metadata (#205) can carry both
+	// client_id and the human-readable client_name resolved via ResolveClient.
+	store.LoadClients([]storage.ClientConfigEntry{{ClientID: "test-client", Name: "Test Device Client", LoginChannel: "browser"}})
 	err := store.StoreDeviceAuthorization(ctx, "test-client", "dc-"+userCode, userCode,
 		clk.Now().Add(5*time.Minute), []string{"openid"})
 	if err != nil {

--- a/internal/service/device_unit_test.go
+++ b/internal/service/device_unit_test.go
@@ -23,6 +23,9 @@ type fakeDeviceStore struct {
 }
 
 func (f *fakeDeviceStore) GetDeviceCodeByUserCode(ctx context.Context, userCode string) (*storage.DeviceCodeModel, error) {
+	if f.getDeviceCodeByUserCodeFn == nil {
+		return nil, storage.ErrNotFound
+	}
 	return f.getDeviceCodeByUserCodeFn(ctx, userCode)
 }
 
@@ -87,6 +90,9 @@ func TestDevice_HandleDeviceApprove_Deny(t *testing.T) {
 		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
 			return &storage.User{ID: "u1", Status: "active"}, nil
 		},
+		getDeviceCodeByUserCodeFn: func(context.Context, string) (*storage.DeviceCodeModel, error) {
+			return &storage.DeviceCodeModel{UserCode: "UCODE", ClientID: "test-client", State: "pending"}, nil
+		},
 		denyDeviceCodeFn: func(context.Context, string) error {
 			denyCalled = true
 			return nil
@@ -105,10 +111,93 @@ func TestDevice_HandleDeviceApprove_Deny(t *testing.T) {
 	}
 }
 
+// TestDevice_HandleDeviceApprove_Deny_NotPending_SkipsMutation asserts that
+// denyDeviceCode aborts when the device_code is no longer pending — the deny
+// mutation must not run and no auth.device_denied audit row may be emitted
+// (#205, Codex review blocker).
+func TestDevice_HandleDeviceApprove_Deny_NotPending_SkipsMutation(t *testing.T) {
+	denyCalled := false
+	auditCalled := false
+	store := &fakeDeviceStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return &storage.User{ID: "u1", Status: "active"}, nil
+		},
+		getDeviceCodeByUserCodeFn: func(context.Context, string) (*storage.DeviceCodeModel, error) {
+			return &storage.DeviceCodeModel{UserCode: "UCODE", ClientID: "test-client", State: "approved"}, nil
+		},
+		denyDeviceCodeFn: func(context.Context, string) error {
+			denyCalled = true
+			return nil
+		},
+		auditLogFn: func(context.Context, *string, string, string, string, map[string]any) {
+			auditCalled = true
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
+	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clock.RealClock{})
+
+	result := svc.HandleDeviceApprove(context.Background(), "UCODE", "deny", "sess", "127.0.0.1", "ua")
+
+	if result.Success {
+		t.Fatal("deny on non-pending should still return success=false to the user")
+	}
+	if denyCalled {
+		t.Fatal("DenyDeviceCode must not be called when state != pending")
+	}
+	if auditCalled {
+		t.Fatal("auth.device_denied audit must not be emitted when state != pending")
+	}
+}
+
+// TestDevice_HandleDeviceApprove_InvalidAction asserts that any action value
+// outside {approve, deny} returns 400 without running any mutation or audit
+// (#205, Codex review blocker — strict consent surface).
+func TestDevice_HandleDeviceApprove_InvalidAction(t *testing.T) {
+	approveCalled := false
+	denyCalled := false
+	auditCalled := false
+	store := &fakeDeviceStore{
+		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
+			return &storage.User{ID: "u1", Status: "active"}, nil
+		},
+		approveDeviceCodeFn: func(context.Context, string, string) error {
+			approveCalled = true
+			return nil
+		},
+		denyDeviceCodeFn: func(context.Context, string) error {
+			denyCalled = true
+			return nil
+		},
+		auditLogFn: func(context.Context, *string, string, string, string, map[string]any) {
+			auditCalled = true
+		},
+	}
+	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
+	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clock.RealClock{})
+
+	result := svc.HandleDeviceApprove(context.Background(), "UCODE", "bogus", "sess", "127.0.0.1", "ua")
+
+	if result.Success {
+		t.Fatal("invalid action must not return success")
+	}
+	if result.ErrorCode != 400 {
+		t.Fatalf("errorCode = %d, want 400", result.ErrorCode)
+	}
+	if approveCalled || denyCalled {
+		t.Fatal("invalid action must not run approve or deny mutations")
+	}
+	if auditCalled {
+		t.Fatal("invalid action must not emit audit rows")
+	}
+}
+
 func TestDevice_HandleDeviceApprove_ApproveError(t *testing.T) {
 	store := &fakeDeviceStore{
 		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
 			return &storage.User{ID: "u1", Status: "active"}, nil
+		},
+		getDeviceCodeByUserCodeFn: func(context.Context, string) (*storage.DeviceCodeModel, error) {
+			return &storage.DeviceCodeModel{UserCode: "UCODE", ClientID: "test-client", State: "pending"}, nil
 		},
 		approveDeviceCodeFn: func(context.Context, string, string) error {
 			return errors.New("expired")


### PR DESCRIPTION
## Summary

Closes #205 — `auth.device_approved` 와 `auth.device_denied` 두 audit 이벤트가 `metadata=nil` 로 발행되어 audit-011 요구사항(client_id + client_name 동시 기록)을 어겼다. `device_codes` 행에 client_id 가 있고 `DeviceStore` 에 `ResolveClient` 도 노출되어 있는데 사용되지 않아, phishing 으로 사용자가 승인하도록 유도된 device 가 어떤 client 였는지 audit_log 만으로 역추적 불가했다.

## Changes

- **`internal/service/device.go`**:
  - 새 helper `deviceAuditMetadata(ctx, userCode)` — device_code lookup → `{client_id, client_name}` 반환. lookup 실패 시 `nil` 로 best-effort 유지
  - `approveDeviceCode` / `denyDeviceCode` 가 state mutation 전에 metadata 를 캡처해 audit 에 전달 (mutation 이후 lookup 의 race 회피)
- **`internal/service/device_test.go`**: `insertDeviceCode` 가 `test-client` (Name="Test Device Client") 를 `LoadClients` 로 등록 — `ResolveClient` 가 의도된 값을 반환
- **`internal/service/audit_test.go`**:
  - `TestAudit004_DeviceApproved` — `client_id` + `client_name` 검증
  - `TestAudit005_DeviceDenied` — 동일 검증
- **`docs/tests/004-audit-events.md`**: audit-003 / audit-004 본문에 `metadata.client_id` + `metadata.client_name` 명시 (#205)

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] Device audit integration tests 통과 (Docker testcontainers)
- [ ] CI 풀 통합 테스트 그린

## Design notes

- `deviceAuditMetadata` 는 mutation 전에 한 번만 호출 — `ApproveDeviceCode` 후 다시 `GetDeviceCodeByUserCode` 호출하면 state 가 이미 변경된 row 반환 (`approved`/`denied`). client_id 자체는 변하지 않으므로 표시상 차이는 없지만, 변경 전 시점을 캡처하는 게 더 명확
- `ResolveClient` 실패 시 `client_name` 키를 생략. audit-011 enforcement 는 #204 / 이번 PR 로 점진 확립; 빈 string 명시는 별도 정책 결정 (현재 분포는 키 부재 = client 미등록 신호)

🤖 Generated with [Claude Code](https://claude.com/claude-code)