### PR TITLE
fix(service): include client context on auth.signup audit event (#204)

### DIFF
--- a/docs/tests/004-audit-events.md
+++ b/docs/tests/004-audit-events.md
@@ -17,7 +17,7 @@
 
 | ID | 시나리오 | 기대 이벤트 | 검증 포인트 |
 |----|----------|------------|-------------|
-| `audit-001` | Browser 신규 가입 | `auth.signup` | 계정 생성 직후 1회 기록 |
+| `audit-001` | Browser 신규 가입 | `auth.signup` | 계정 생성 직후 1회 기록, `metadata.channel`=`browser` + `metadata.client_id` + `metadata.client_name` 포함 (#204) |
 | `audit-002` | Browser/MCP/Device 로그인 성공 | `auth.login` | `metadata.channel`이 `browser/device/mcp` 중 하나로 기록 |
 | `audit-003` | Device 승인 | `auth.device_approved` | 승인 시 1회 기록, `metadata.client_id` + `metadata.client_name` 포함 (#205) |
 | `audit-004` | Device 거부 | `auth.device_denied` | 거부 시 1회 기록, `metadata.client_id` + `metadata.client_name` 포함 (#205) |

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -75,7 +75,16 @@ func TestAudit001_BrowserSignup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get user: %v", err)
 	}
-	requireSingleAuditEvent(t, store.DB(), user.ID, "auth.signup")
+	event := requireSingleAuditEvent(t, store.DB(), user.ID, "auth.signup")
+	if event.Metadata["channel"] != "browser" {
+		t.Fatalf("channel = %v, want browser", event.Metadata["channel"])
+	}
+	if event.Metadata["client_id"] != "test-app" {
+		t.Fatalf("client_id = %v, want test-app (#204)", event.Metadata["client_id"])
+	}
+	if event.Metadata["client_name"] != "Test App" {
+		t.Fatalf("client_name = %v, want Test App (#204)", event.Metadata["client_name"])
+	}
 }
 
 func TestAudit002_LoginChannels(t *testing.T) {

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -219,7 +219,7 @@ func (s *LoginService) prepareBrowserCallbackUser(ctx context.Context, userInfo 
 		if result != nil {
 			return nil, false, nil, result
 		}
-		user, result := s.signupBrowserUser(ctx, providerName, userInfo, ipAddress, userAgent)
+		user, result := s.signupBrowserUser(ctx, providerName, userInfo, authReq, ipAddress, userAgent)
 		return user, true, authReq, result
 	}
 	if err != nil {
@@ -260,7 +260,7 @@ func (s *LoginService) recoverUser(ctx context.Context, userID, ipAddress, userA
 	return nil
 }
 
-func (s *LoginService) signupBrowserUser(ctx context.Context, providerName string, userInfo *upstream.UserInfo, ipAddress, userAgent string) (*storage.User, *CallbackResult) {
+func (s *LoginService) signupBrowserUser(ctx context.Context, providerName string, userInfo *upstream.UserInfo, authReq *storage.AuthRequestModel, ipAddress, userAgent string) (*storage.User, *CallbackResult) {
 	user, err := s.store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
 		Email:          userInfo.Email,
 		EmailVerified:  userInfo.EmailVerified,
@@ -277,7 +277,13 @@ func (s *LoginService) signupBrowserUser(ctx context.Context, providerName strin
 		return nil, &CallbackResult{Action: ActionError, Error: fmt.Sprintf("signup failed: %v", err), ErrorCode: http.StatusInternalServerError}
 	}
 
-	s.store.AuditLog(ctx, &user.ID, "auth.signup", ipAddress, userAgent, map[string]any{"channel": "browser"})
+	// audit-011 (#204): signup always happens inside an auth_request, so the
+	// originating client_id / client_name must be carried on the audit row.
+	s.store.AuditLog(ctx, &user.ID, "auth.signup", ipAddress, userAgent, map[string]any{
+		"channel":     "browser",
+		"client_id":   authReq.ClientID,
+		"client_name": resolveClientName(ctx, s.store, authReq.ClientID),
+	})
 	return user, nil
 }
 

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -187,7 +187,7 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 		return &CallbackResult{Action: ActionError, Error: "upstream_error", ErrorCode: http.StatusInternalServerError}
 	}
 
-	user, signedUp, _, result := s.prepareBrowserCallbackUser(ctx, userInfo, authRequestID, ipAddress, userAgent)
+	user, signedUp, result := s.prepareBrowserCallbackUser(ctx, userInfo, authReq, ipAddress, userAgent)
 	if result != nil {
 		return result
 	}
@@ -211,30 +211,28 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 	return &CallbackResult{Action: ActionAutoApprove, AuthRequestID: authRequestID, SessionID: sessionID}
 }
 
-func (s *LoginService) prepareBrowserCallbackUser(ctx context.Context, userInfo *upstream.UserInfo, authRequestID, ipAddress, userAgent string) (*storage.User, bool, *storage.AuthRequestModel, *CallbackResult) {
+// prepareBrowserCallbackUser performs the user-lookup or signup half of the
+// browser callback flow. The caller passes the already-fetched authReq so that
+// the signup audit row and the subsequent auth.login row reference the same
+// request context — duplicate getCallbackAuthRequest calls would otherwise
+// race against expiration/cleanup between fetch and audit (Codex review NIT
+// on PR #218).
+func (s *LoginService) prepareBrowserCallbackUser(ctx context.Context, userInfo *upstream.UserInfo, authReq *storage.AuthRequestModel, ipAddress, userAgent string) (*storage.User, bool, *CallbackResult) {
 	providerName := s.browserProvider.Name()
 	user, err := s.store.GetUserByProviderIdentity(ctx, providerName, userInfo.Sub)
 	if errors.Is(err, storage.ErrNotFound) {
-		authReq, result := s.getCallbackAuthRequest(ctx, authRequestID)
-		if result != nil {
-			return nil, false, nil, result
-		}
 		user, result := s.signupBrowserUser(ctx, providerName, userInfo, authReq, ipAddress, userAgent)
-		return user, true, authReq, result
+		return user, true, result
 	}
 	if err != nil {
-		return nil, false, nil, &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+		return nil, false, &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
 	}
 
 	user, result := s.ensureBrowserAccess(ctx, user, ipAddress, userAgent)
 	if result != nil {
-		return nil, false, nil, result
+		return nil, false, result
 	}
-	authReq, result := s.getCallbackAuthRequest(ctx, authRequestID)
-	if result != nil {
-		return nil, false, nil, result
-	}
-	return user, false, authReq, nil
+	return user, false, nil
 }
 
 func (s *LoginService) getCallbackAuthRequest(ctx context.Context, authRequestID string) (*storage.AuthRequestModel, *CallbackResult) {

--- a/internal/service/login_unit_test.go
+++ b/internal/service/login_unit_test.go
@@ -196,6 +196,9 @@ func TestLogin_HandleCallback_SignupAuditLogIncludesChannel(t *testing.T) {
 		completeAuthRequestFn: func(context.Context, string, string) error {
 			return nil
 		},
+		resolveClientFn: func(context.Context, string) (*storage.ClientModel, error) {
+			return &storage.ClientModel{ID: "client-a", Name: "Client A", LoginChannel: "browser"}, nil
+		},
 		auditLogFn: func(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 			gotEvents = append(gotEvents, auditEntry{eventType: eventType, metadata: metadata})
 		},
@@ -219,7 +222,13 @@ func TestLogin_HandleCallback_SignupAuditLogIncludesChannel(t *testing.T) {
 		t.Fatalf("auth.signup event not found in %v", gotEvents)
 	}
 	if signupEvent.metadata["channel"] != "browser" {
-		t.Fatalf("signup metadata = %#v", signupEvent.metadata)
+		t.Fatalf("signup channel = %v, want browser; metadata = %#v", signupEvent.metadata["channel"], signupEvent.metadata)
+	}
+	if signupEvent.metadata["client_id"] != "client-a" {
+		t.Fatalf("signup client_id = %v, want client-a (#204); metadata = %#v", signupEvent.metadata["client_id"], signupEvent.metadata)
+	}
+	if signupEvent.metadata["client_name"] != "Client A" {
+		t.Fatalf("signup client_name = %v, want \"Client A\" (#204); metadata = %#v", signupEvent.metadata["client_name"], signupEvent.metadata)
 	}
 }
 

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -271,7 +271,7 @@ func (s *Storage) setUserStatus(ctx context.Context, userID, status string) erro
 // The auth_request is bound to client_id "test-app" (registered with
 // login_channel="browser" so the channel-binding guard accepts it).
 func (s *Storage) CreateTestAuthRequest(ctx context.Context, label string) (string, error) {
-	s.LoadClients([]ClientConfigEntry{{ClientID: "test-app", LoginChannel: "browser"}})
+	s.LoadClients([]ClientConfigEntry{{ClientID: "test-app", Name: "Test App", LoginChannel: "browser"}})
 	id := s.idgen.NewUUID()
 	err := storeq.New(s.db).InsertTestAuthRequest(ctx, storeq.InsertTestAuthRequestParams{
 		ID:        id,
@@ -288,7 +288,7 @@ func (s *Storage) CreateTestAuthRequest(ctx context.Context, label string) (stri
 // The auth_request is bound to client_id "test-mcp-app" (registered with
 // login_channel="mcp" so the channel-binding guard accepts it).
 func (s *Storage) CreateTestAuthRequestWithResource(ctx context.Context, label, resource string) (string, error) {
-	s.LoadClients([]ClientConfigEntry{{ClientID: "test-mcp-app", LoginChannel: "mcp"}})
+	s.LoadClients([]ClientConfigEntry{{ClientID: "test-mcp-app", Name: "Test MCP App", LoginChannel: "mcp"}})
 	id := s.idgen.NewUUID()
 	now := s.clock.Now()
 	err := storeq.New(s.db).InsertTestAuthRequestWithResource(ctx, storeq.InsertTestAuthRequestWithResourceParams{


### PR DESCRIPTION
## Summary

Closes #204 — audit-011(#147)은 client context 가 있는 모든 audit 이벤트에 \`client_id\` + \`client_name\` 동시 기록을 요구. signup 은 항상 auth_request 컨텍스트에서 발생함에도 \`auth.signup\` 이 \`{channel: "browser"}\` 만 기록해 phishing client 가 어떤 사용자를 유도 가입시켰는지 audit_log 만으로 역추적 불가했다.

## Changes

- **\`internal/service/login.go\`**:
  - \`signupBrowserUser\` 시그니처에 \`authReq *storage.AuthRequestModel\` 추가
  - audit metadata 에 \`client_id\` + \`resolveClientName(...)\` 결과 \`client_name\` 포함
  - 호출자 \`prepareBrowserCallbackUser\` 는 이미 authReq 를 들고 있어 그대로 전달
- **\`internal/storage/users.go\`**: 테스트 헬퍼 \`CreateTestAuthRequest\` / \`CreateTestAuthRequestWithResource\` 의 \`LoadClients\` 가 \`Name\` 도 설정 — \`ResolveClient\` 가 의미 있는 client_name 반환
- **\`internal/service/audit_test.go\`**: \`TestAudit001_BrowserSignup\` 이 channel + client_id + client_name 모두 검증
- **\`docs/tests/004-audit-events.md\`**: audit-001 본문 갱신 (#204)

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] Service unit tests 통과
- [x] Integration regression (\`TestAudit001\`, \`TestAudit002\`, \`TestAudit_ReusedSession\`, \`TestAudit004/005\`, \`TestAuditSecurity003\`, \`TestAuditSecurity_MCPInactiveUser\`) 통과
- [ ] CI 풀 통합 테스트 그린

## Design notes

- \`CreateTestAuthRequestWithResource\` 의 Name 변경 (\`test-mcp-app\` → "Test MCP App") 은 #206 PR 의 \`TestAudit_ReusedSession_MCP_AuthLoginRecorded\` 검증과 호환. 그 테스트는 \`client_name\` key 존재만 확인하므로 빈 string → 채워진 값 변경에 영향 없음
- audit-011 enforcement 가 #204 (signup), #205 (device approve/deny), #206 (MCP reused-session), #209 (console revocation) 으로 점진 확립 중

🤖 Generated with [Claude Code](https://claude.com/claude-code)