### PR TITLE
fix(storage): harden audit log lifecycle controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ go run ./cmd/authgate
 | `SESSION_TTL` | `86400` | session TTL in seconds |
 | `ACCESS_TOKEN_TTL` | `900` | access token TTL in seconds |
 | `REFRESH_TOKEN_TTL` | `2592000` | refresh token TTL in seconds |
+| `AUDIT_LOG_PII_RETENTION_DAYS` | `1095` | Days before audit log PII (`user_id`, IP, User-Agent) is anonymized. Minimum `365`; use `730+` when scale/data class requires 2-year access-record retention. |
+| `SIGNING_KEY_PATH` | `signing_key.pem` | RSA signing key file path. Mount a persistent secret/volume in production. |
 | `HTTP_READ_HEADER_TIMEOUT_SEC` | `5` | HTTP server `ReadHeaderTimeout` in seconds |
 | `HTTP_READ_TIMEOUT_SEC` | `15` | HTTP server `ReadTimeout` in seconds |
 | `HTTP_WRITE_TIMEOUT_SEC` | `30` | HTTP server `WriteTimeout` in seconds |

--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -114,7 +114,7 @@ func main() {
 	var inflightRequests int64
 	srv, addr := buildHTTPServer(cfg, requestIDHandler, httpMetrics, &inflightRequests)
 
-	cleanupCancel := startCleanupService(db, clk)
+	cleanupCancel := startCleanupService(db, clk, cfg.AuditLogPIIRetention)
 	defer cleanupCancel()
 	installGracefulShutdown(srv, cfg, &inflightRequests, cleanupCancel, &isShuttingDown)
 
@@ -162,13 +162,13 @@ func mustBuildStore(cfg *config.Config, db *sql.DB, clk clock.Clock, gen idgen.C
 	store := storage.New(db, clk, gen, newStateChecker(), cfg.AccessTokenTTL, cfg.RefreshTokenTTL)
 	store.SetIssuer(cfg.PublicURL)
 	store.SetDevicePollInterval(devicePollInterval)
-	mustConfigureSigningKey(store)
+	mustConfigureSigningKey(store, cfg.SigningKeyPath)
 	configureMCPPoliciesIfEnabled(cfg, store)
 	return store
 }
 
-func mustConfigureSigningKey(store *storage.Storage) {
-	key, err := storage.LoadOrGenerateKey("signing_key.pem")
+func mustConfigureSigningKey(store *storage.Storage, path string) {
+	key, err := storage.LoadOrGenerateKey(path)
 	if err != nil {
 		log.Fatalf("signing key: %v", err)
 	}
@@ -306,17 +306,17 @@ func registerRoutes(
 func registerOAuthMetadataRoute(mux *http.ServeMux, cfg *config.Config) {
 	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
 		metadata := map[string]any{
-			"issuer":                        cfg.PublicURL,
-			"authorization_endpoint":        cfg.PublicURL + "/authorize",
-			"token_endpoint":                cfg.PublicURL + "/oauth/token",
-			"revocation_endpoint":           cfg.PublicURL + "/oauth/revoke",
-			"introspection_endpoint":        cfg.PublicURL + "/oauth/introspect",
-			"device_authorization_endpoint": cfg.PublicURL + "/oauth/device/authorize",
-			"userinfo_endpoint":             cfg.PublicURL + "/userinfo",
-			"end_session_endpoint":          cfg.PublicURL + "/end_session",
-			"jwks_uri":                      cfg.PublicURL + "/keys",
-			"response_types_supported":      []string{"code"},
-			"grant_types_supported":         []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
+			"issuer":                           cfg.PublicURL,
+			"authorization_endpoint":           cfg.PublicURL + "/authorize",
+			"token_endpoint":                   cfg.PublicURL + "/oauth/token",
+			"revocation_endpoint":              cfg.PublicURL + "/oauth/revoke",
+			"introspection_endpoint":           cfg.PublicURL + "/oauth/introspect",
+			"device_authorization_endpoint":    cfg.PublicURL + "/oauth/device/authorize",
+			"userinfo_endpoint":                cfg.PublicURL + "/userinfo",
+			"end_session_endpoint":             cfg.PublicURL + "/end_session",
+			"jwks_uri":                         cfg.PublicURL + "/keys",
+			"response_types_supported":         []string{"code"},
+			"grant_types_supported":            []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
 			"code_challenge_methods_supported": []string{"S256"},
 			// #189 / RFC 8414 §2: zitadel/oidc's /oauth/token branch always
 			// accepts `client_secret_basic` (the OIDC default), accepts
@@ -334,11 +334,11 @@ func registerOAuthMetadataRoute(mux *http.ServeMux, cfg *config.Config) {
 			// advertise only `client_secret_basic` here — matching
 			// zitadel/oidc's own discovery default in
 			// `AuthMethodsIntrospectionEndpoint`.
-			"token_endpoint_auth_methods_supported":          []string{"none", "client_secret_basic", "client_secret_post"},
-			"revocation_endpoint_auth_methods_supported":     []string{"none", "client_secret_basic", "client_secret_post"},
-			"introspection_endpoint_auth_methods_supported":  []string{"client_secret_basic"},
-			"scopes_supported":                               []string{"openid", "profile", "email", "offline_access"},
-			"client_id_metadata_document_supported":          cfg.EnableMCP,
+			"token_endpoint_auth_methods_supported":         []string{"none", "client_secret_basic", "client_secret_post"},
+			"revocation_endpoint_auth_methods_supported":    []string{"none", "client_secret_basic", "client_secret_post"},
+			"introspection_endpoint_auth_methods_supported": []string{"client_secret_basic"},
+			"scopes_supported":                              []string{"openid", "profile", "email", "offline_access"},
+			"client_id_metadata_document_supported":         cfg.EnableMCP,
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(metadata)
@@ -461,9 +461,10 @@ func buildHTTPServer(cfg *config.Config, mux http.Handler, httpMetrics *observab
 	}, addr
 }
 
-func startCleanupService(db *sql.DB, clk clock.Clock) context.CancelFunc {
+func startCleanupService(db *sql.DB, clk clock.Clock, auditLogPIIRetention time.Duration) context.CancelFunc {
 	cleanupRunner := storage.NewCleanupRunner(db)
 	cleanupSvc := service.NewCleanupService(cleanupRunner, clk, 10*time.Minute)
+	cleanupSvc.SetAuditLogPIIRetention(auditLogPIIRetention)
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
 	go cleanupSvc.Start(cleanupCtx)
 	return cleanupCancel

--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -135,7 +135,7 @@ erDiagram
 
 | 테이블 | 목적 | 수명 | 삭제 정책 |
 |--------|------|------|----------|
-| **audit_log** | 운영 이벤트 | 3년 보존 후 user_id 익명화 | 3년 후 user_id = NULL |
+| **audit_log** | 운영 이벤트 | `AUDIT_LOG_PII_RETENTION_DAYS` 후 PII 익명화 | 기본 3년 후 user_id/IP/User-Agent = NULL, 최소 1년 |
 
 #### event_type 목록
 
@@ -222,7 +222,7 @@ MCP
 | client_secret은 bcrypt 해시로 저장 | `clients.yaml`의 `client_secret_hash` 필드 |
 | access_token(JWT)은 DB에 저장하지 않음 | stateless |
 | PII 스크러빙 시 email, name, avatar_url 제거 | `deleted` 상태 전이 시 |
-| audit_log는 3년 후 user_id 익명화 | cleanup job |
+| audit_log는 보존기간 후 user_id/IP/User-Agent 익명화 | cleanup job + `AUDIT_LOG_PII_RETENTION_DAYS` |
 
 ## 감사 이벤트 (audit_log.event_type)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,15 +11,15 @@ import (
 )
 
 type Config struct {
-	Port                  int
-	DatabaseURL           string
-	DBMaxOpenConns        int
-	DBMaxIdleConns        int
-	DBConnMaxLifetime     time.Duration
-	DBConnMaxIdleTime     time.Duration
-	SessionSecret         string
-	PublicURL             string
-	OIDCIssuerURL         string
+	Port              int
+	DatabaseURL       string
+	DBMaxOpenConns    int
+	DBMaxIdleConns    int
+	DBConnMaxLifetime time.Duration
+	DBConnMaxIdleTime time.Duration
+	SessionSecret     string
+	PublicURL         string
+	OIDCIssuerURL     string
 	// OIDCIssuerHostAllowlist is an optional comma-separated list of hosts the
 	// OIDC_ISSUER_URL is allowed to point at. When non-empty, the issuer URL's
 	// host must match an entry exactly (host:port if a non-default port is in
@@ -28,67 +28,75 @@ type Config struct {
 	// fail-fast on misconfigured/compromised env vars that would otherwise
 	// redirect every login through an attacker-controlled IdP.
 	OIDCIssuerHostAllowlist []string
-	OIDCInternalURL       string // optional: internal base URL for server-to-server OIDC calls (Docker/K8s)
-	OIDCHTTPTimeout       time.Duration
-	OIDCClientID          string
-	OIDCClientSecret      string
-	SessionTTL            time.Duration
-	AccessTokenTTL        time.Duration
-	RefreshTokenTTL       time.Duration
-	DevMode               bool
-	EnableMCP             bool
-	ClientConfigPath      string
-	MigrationsPath        string
-	BrandName             string
-	HTTPReadHeaderTimeout time.Duration
-	HTTPReadTimeout       time.Duration
-	HTTPWriteTimeout      time.Duration
-	HTTPIdleTimeout       time.Duration
-	ShutdownTimeout       time.Duration
-	RateLimitTokenRPS     float64
-	RateLimitTokenBurst   int
-	RateLimitAuthRPS      float64
-	RateLimitAuthBurst    int
+	OIDCInternalURL         string // optional: internal base URL for server-to-server OIDC calls (Docker/K8s)
+	OIDCHTTPTimeout         time.Duration
+	OIDCClientID            string
+	OIDCClientSecret        string
+	SessionTTL              time.Duration
+	AccessTokenTTL          time.Duration
+	RefreshTokenTTL         time.Duration
+	AuditLogPIIRetention    time.Duration
+	DevMode                 bool
+	EnableMCP               bool
+	ClientConfigPath        string
+	MigrationsPath          string
+	SigningKeyPath          string
+	BrandName               string
+	HTTPReadHeaderTimeout   time.Duration
+	HTTPReadTimeout         time.Duration
+	HTTPWriteTimeout        time.Duration
+	HTTPIdleTimeout         time.Duration
+	ShutdownTimeout         time.Duration
+	RateLimitTokenRPS       float64
+	RateLimitTokenBurst     int
+	RateLimitAuthRPS        float64
+	RateLimitAuthBurst      int
 	// TrustedProxies is a comma-separated list of CIDRs whose source addresses
 	// are allowed to set X-Forwarded-For. Empty means no proxy is trusted —
 	// the safe default for a deployment without an explicitly configured edge.
-	TrustedProxies        string
+	TrustedProxies string
 }
 
 func Load() (*Config, error) {
+	if err := validateParseableEnv(); err != nil {
+		return nil, err
+	}
+
 	c := &Config{
-		Port:                  envInt("PORT", 8080),
-		DatabaseURL:           os.Getenv("DATABASE_URL"),
-		DBMaxOpenConns:        envInt("DB_MAX_OPEN_CONNS", 25),
-		DBMaxIdleConns:        envInt("DB_MAX_IDLE_CONNS", 25),
-		DBConnMaxLifetime:     time.Duration(envInt("DB_CONN_MAX_LIFETIME_SEC", 300)) * time.Second,
-		DBConnMaxIdleTime:     time.Duration(envInt("DB_CONN_MAX_IDLE_TIME_SEC", 120)) * time.Second,
-		SessionSecret:         os.Getenv("SESSION_SECRET"),
-		PublicURL:             os.Getenv("PUBLIC_URL"),
-		OIDCIssuerURL:         envDefault("OIDC_ISSUER_URL", "http://localhost:8082"),
+		Port:                    envInt("PORT", 8080),
+		DatabaseURL:             os.Getenv("DATABASE_URL"),
+		DBMaxOpenConns:          envInt("DB_MAX_OPEN_CONNS", 25),
+		DBMaxIdleConns:          envInt("DB_MAX_IDLE_CONNS", 25),
+		DBConnMaxLifetime:       time.Duration(envInt("DB_CONN_MAX_LIFETIME_SEC", 300)) * time.Second,
+		DBConnMaxIdleTime:       time.Duration(envInt("DB_CONN_MAX_IDLE_TIME_SEC", 120)) * time.Second,
+		SessionSecret:           os.Getenv("SESSION_SECRET"),
+		PublicURL:               os.Getenv("PUBLIC_URL"),
+		OIDCIssuerURL:           envDefault("OIDC_ISSUER_URL", "http://localhost:8082"),
 		OIDCIssuerHostAllowlist: envCommaList("OIDC_ISSUER_HOST_ALLOWLIST"),
-		OIDCInternalURL:       os.Getenv("OIDC_INTERNAL_URL"),
-		OIDCHTTPTimeout:       time.Duration(envInt("OIDC_HTTP_TIMEOUT_SEC", 10)) * time.Second,
-		OIDCClientID:          envDefault("OIDC_CLIENT_ID", "authgate"),
-		OIDCClientSecret:      os.Getenv("OIDC_CLIENT_SECRET"),
-		SessionTTL:            time.Duration(envInt("SESSION_TTL", 86400)) * time.Second,
-		AccessTokenTTL:        time.Duration(envInt("ACCESS_TOKEN_TTL", 900)) * time.Second,
-		RefreshTokenTTL:       time.Duration(envInt("REFRESH_TOKEN_TTL", 2592000)) * time.Second,
-		DevMode:               envBool("DEV_MODE", false),
-		EnableMCP:             envBool("ENABLE_MCP", true),
-		ClientConfigPath:      envDefault("CLIENT_CONFIG", "/etc/authgate/clients.yaml"),
-		MigrationsPath:        envDefault("MIGRATIONS_PATH", "/migrations"),
-		BrandName:             envDefault("BRAND_NAME", "authgate"),
-		HTTPReadHeaderTimeout: time.Duration(envInt("HTTP_READ_HEADER_TIMEOUT_SEC", 5)) * time.Second,
-		HTTPReadTimeout:       time.Duration(envInt("HTTP_READ_TIMEOUT_SEC", 15)) * time.Second,
-		HTTPWriteTimeout:      time.Duration(envInt("HTTP_WRITE_TIMEOUT_SEC", 30)) * time.Second,
-		HTTPIdleTimeout:       time.Duration(envInt("HTTP_IDLE_TIMEOUT_SEC", 60)) * time.Second,
-		ShutdownTimeout:       time.Duration(envInt("SHUTDOWN_TIMEOUT_SEC", 10)) * time.Second,
-		RateLimitTokenRPS:     envFloat("RATE_LIMIT_TOKEN_RPS", 30),
-		RateLimitTokenBurst:   envInt("RATE_LIMIT_TOKEN_BURST", 60),
-		RateLimitAuthRPS:      envFloat("RATE_LIMIT_AUTH_RPS", 10),
-		RateLimitAuthBurst:    envInt("RATE_LIMIT_AUTH_BURST", 20),
-		TrustedProxies:        os.Getenv("TRUSTED_PROXIES"),
+		OIDCInternalURL:         os.Getenv("OIDC_INTERNAL_URL"),
+		OIDCHTTPTimeout:         time.Duration(envInt("OIDC_HTTP_TIMEOUT_SEC", 10)) * time.Second,
+		OIDCClientID:            envDefault("OIDC_CLIENT_ID", "authgate"),
+		OIDCClientSecret:        os.Getenv("OIDC_CLIENT_SECRET"),
+		SessionTTL:              time.Duration(envInt("SESSION_TTL", 86400)) * time.Second,
+		AccessTokenTTL:          time.Duration(envInt("ACCESS_TOKEN_TTL", 900)) * time.Second,
+		RefreshTokenTTL:         time.Duration(envInt("REFRESH_TOKEN_TTL", 2592000)) * time.Second,
+		AuditLogPIIRetention:    time.Duration(envInt("AUDIT_LOG_PII_RETENTION_DAYS", 1095)) * 24 * time.Hour,
+		DevMode:                 envBool("DEV_MODE", false),
+		EnableMCP:               envBool("ENABLE_MCP", true),
+		ClientConfigPath:        envDefault("CLIENT_CONFIG", "/etc/authgate/clients.yaml"),
+		MigrationsPath:          envDefault("MIGRATIONS_PATH", "/migrations"),
+		SigningKeyPath:          envDefault("SIGNING_KEY_PATH", "signing_key.pem"),
+		BrandName:               envDefault("BRAND_NAME", "authgate"),
+		HTTPReadHeaderTimeout:   time.Duration(envInt("HTTP_READ_HEADER_TIMEOUT_SEC", 5)) * time.Second,
+		HTTPReadTimeout:         time.Duration(envInt("HTTP_READ_TIMEOUT_SEC", 15)) * time.Second,
+		HTTPWriteTimeout:        time.Duration(envInt("HTTP_WRITE_TIMEOUT_SEC", 30)) * time.Second,
+		HTTPIdleTimeout:         time.Duration(envInt("HTTP_IDLE_TIMEOUT_SEC", 60)) * time.Second,
+		ShutdownTimeout:         time.Duration(envInt("SHUTDOWN_TIMEOUT_SEC", 10)) * time.Second,
+		RateLimitTokenRPS:       envFloat("RATE_LIMIT_TOKEN_RPS", 30),
+		RateLimitTokenBurst:     envInt("RATE_LIMIT_TOKEN_BURST", 60),
+		RateLimitAuthRPS:        envFloat("RATE_LIMIT_AUTH_RPS", 10),
+		RateLimitAuthBurst:      envInt("RATE_LIMIT_AUTH_BURST", 20),
+		TrustedProxies:          os.Getenv("TRUSTED_PROXIES"),
 	}
 
 	if c.DatabaseURL == "" {
@@ -105,6 +113,9 @@ func Load() (*Config, error) {
 	}
 	if c.ShutdownTimeout <= 0 {
 		return nil, fmt.Errorf("SHUTDOWN_TIMEOUT_SEC must be > 0")
+	}
+	if c.AuditLogPIIRetention < 365*24*time.Hour {
+		return nil, fmt.Errorf("AUDIT_LOG_PII_RETENTION_DAYS must be >= 365")
 	}
 	if c.RateLimitTokenRPS <= 0 {
 		return nil, fmt.Errorf("RATE_LIMIT_TOKEN_RPS must be > 0")
@@ -161,6 +172,49 @@ func Load() (*Config, error) {
 	}
 
 	return c, nil
+}
+
+func validateParseableEnv() error {
+	for _, key := range []string{
+		"PORT",
+		"DB_MAX_OPEN_CONNS",
+		"DB_MAX_IDLE_CONNS",
+		"DB_CONN_MAX_LIFETIME_SEC",
+		"DB_CONN_MAX_IDLE_TIME_SEC",
+		"OIDC_HTTP_TIMEOUT_SEC",
+		"SESSION_TTL",
+		"ACCESS_TOKEN_TTL",
+		"REFRESH_TOKEN_TTL",
+		"AUDIT_LOG_PII_RETENTION_DAYS",
+		"HTTP_READ_HEADER_TIMEOUT_SEC",
+		"HTTP_READ_TIMEOUT_SEC",
+		"HTTP_WRITE_TIMEOUT_SEC",
+		"HTTP_IDLE_TIMEOUT_SEC",
+		"SHUTDOWN_TIMEOUT_SEC",
+		"RATE_LIMIT_TOKEN_BURST",
+		"RATE_LIMIT_AUTH_BURST",
+	} {
+		if v := os.Getenv(key); v != "" {
+			if _, err := strconv.Atoi(v); err != nil {
+				return fmt.Errorf("%s must be an integer", key)
+			}
+		}
+	}
+	for _, key := range []string{"DEV_MODE", "ENABLE_MCP"} {
+		if v := os.Getenv(key); v != "" {
+			if _, err := strconv.ParseBool(v); err != nil {
+				return fmt.Errorf("%s must be a boolean", key)
+			}
+		}
+	}
+	for _, key := range []string{"RATE_LIMIT_TOKEN_RPS", "RATE_LIMIT_AUTH_RPS"} {
+		if v := os.Getenv(key); v != "" {
+			if _, err := strconv.ParseFloat(v, 64); err != nil {
+				return fmt.Errorf("%s must be a number", key)
+			}
+		}
+	}
+	return nil
 }
 
 func envDefault(key, fallback string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,8 +12,9 @@ func clearEnv() {
 		"OIDC_ISSUER_URL", "OIDC_ISSUER_HOST_ALLOWLIST",
 		"OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET",
 		"OIDC_HTTP_TIMEOUT_SEC",
-		"SESSION_TTL", "ACCESS_TOKEN_TTL", "REFRESH_TOKEN_TTL",
+		"SESSION_TTL", "ACCESS_TOKEN_TTL", "REFRESH_TOKEN_TTL", "AUDIT_LOG_PII_RETENTION_DAYS",
 		"DEV_MODE", "ENABLE_MCP",
+		"SIGNING_KEY_PATH",
 		"DB_MAX_OPEN_CONNS", "DB_MAX_IDLE_CONNS",
 		"DB_CONN_MAX_LIFETIME_SEC", "DB_CONN_MAX_IDLE_TIME_SEC",
 		"HTTP_READ_HEADER_TIMEOUT_SEC", "HTTP_READ_TIMEOUT_SEC",
@@ -144,6 +145,12 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.RefreshTokenTTL.Seconds() != 2592000 {
 		t.Errorf("RefreshTokenTTL = %v, want 2592000s", cfg.RefreshTokenTTL)
 	}
+	if cfg.AuditLogPIIRetention.Hours() != 1095*24 {
+		t.Errorf("AuditLogPIIRetention = %v, want 1095 days", cfg.AuditLogPIIRetention)
+	}
+	if cfg.SigningKeyPath != "signing_key.pem" {
+		t.Errorf("SigningKeyPath = %q, want signing_key.pem", cfg.SigningKeyPath)
+	}
 	if !cfg.EnableMCP {
 		t.Error("EnableMCP = false, want true by default")
 	}
@@ -173,6 +180,48 @@ func TestLoad_Defaults(t *testing.T) {
 	}
 	if cfg.DBConnMaxIdleTime.Seconds() != 120 {
 		t.Errorf("DBConnMaxIdleTime = %v, want 120s", cfg.DBConnMaxIdleTime)
+	}
+}
+
+func TestLoad_InvalidNumericEnvFails(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("PORT", "not-a-number")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for invalid PORT")
+	}
+	if !strings.Contains(err.Error(), "PORT") {
+		t.Errorf("error = %v, want one mentioning PORT", err)
+	}
+}
+
+func TestLoad_InvalidBoolEnvFails(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("ENABLE_MCP", "sometimes")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for invalid ENABLE_MCP")
+	}
+	if !strings.Contains(err.Error(), "ENABLE_MCP") {
+		t.Errorf("error = %v, want one mentioning ENABLE_MCP", err)
+	}
+}
+
+func TestLoad_AuditLogPIIRetentionMinimum(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("AUDIT_LOG_PII_RETENTION_DAYS", "364")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for short audit log PII retention")
+	}
+	if !strings.Contains(err.Error(), "AUDIT_LOG_PII_RETENTION_DAYS") {
+		t.Errorf("error = %v, want one mentioning AUDIT_LOG_PII_RETENTION_DAYS", err)
 	}
 }
 

--- a/internal/db/queries/cleanup.sql
+++ b/internal/db/queries/cleanup.sql
@@ -56,7 +56,17 @@ WHERE id = sqlc.arg(user_id) AND status = 'pending_deletion' AND deletion_schedu
 INSERT INTO audit_log (user_id, event_type, created_at)
 VALUES (NULLIF(sqlc.arg(user_id)::text, '')::uuid, 'auth.deletion_completed', sqlc.arg(created_at));
 
+-- name: RedactAuditLogPIIByUserID :execrows
+UPDATE audit_log
+SET ip_address = NULL,
+    user_agent = NULL
+WHERE user_id = NULLIF(sqlc.arg(user_id)::text, '')::uuid
+  AND (ip_address IS NOT NULL OR user_agent IS NOT NULL);
+
 -- name: AnonymizeAuditLogBefore :execrows
 UPDATE audit_log
-SET user_id = NULL
-WHERE created_at < sqlc.arg(cutoff) AND user_id IS NOT NULL;
+SET user_id = NULL,
+    ip_address = NULL,
+    user_agent = NULL
+WHERE created_at < sqlc.arg(cutoff)
+  AND (user_id IS NOT NULL OR ip_address IS NOT NULL OR user_agent IS NOT NULL);

--- a/internal/db/storeq/cleanup.sql.go
+++ b/internal/db/storeq/cleanup.sql.go
@@ -13,8 +13,11 @@ import (
 
 const anonymizeAuditLogBefore = `-- name: AnonymizeAuditLogBefore :execrows
 UPDATE audit_log
-SET user_id = NULL
-WHERE created_at < $1 AND user_id IS NOT NULL
+SET user_id = NULL,
+    ip_address = NULL,
+    user_agent = NULL
+WHERE created_at < $1
+  AND (user_id IS NOT NULL OR ip_address IS NOT NULL OR user_agent IS NOT NULL)
 `
 
 func (q *Queries) AnonymizeAuditLogBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -183,6 +186,22 @@ type MarkUserDeletedByIDParams struct {
 
 func (q *Queries) MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedByIDParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, markUserDeletedByID, arg.DeletedAt, arg.UserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const redactAuditLogPIIByUserID = `-- name: RedactAuditLogPIIByUserID :execrows
+UPDATE audit_log
+SET ip_address = NULL,
+    user_agent = NULL
+WHERE user_id = NULLIF($1::text, '')::uuid
+  AND (ip_address IS NOT NULL OR user_agent IS NOT NULL)
+`
+
+func (q *Queries) RedactAuditLogPIIByUserID(ctx context.Context, userID string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, redactAuditLogPIIByUserID, userID)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -55,6 +55,7 @@ type Querier interface {
 	MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedByIDParams) (int64, error)
 	MarkUserPendingDeletionByID(ctx context.Context, arg MarkUserPendingDeletionByIDParams) (int64, error)
 	RecoverPendingDeletionUserByID(ctx context.Context, arg RecoverPendingDeletionUserByIDParams) error
+	RedactAuditLogPIIByUserID(ctx context.Context, userID string) (int64, error)
 	RevokeActiveRefreshTokensByUserID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDParams) error
 	RevokeActiveRefreshTokensByUserIDAndClientID(ctx context.Context, arg RevokeActiveRefreshTokensByUserIDAndClientIDParams) error
 	RevokeOtherActiveSessionsByUserID(ctx context.Context, arg RevokeOtherActiveSessionsByUserIDParams) error

--- a/internal/service/cleanup.go
+++ b/internal/service/cleanup.go
@@ -21,17 +21,25 @@ type cleanupRunner interface {
 }
 
 type CleanupService struct {
-	runner         cleanupRunner
-	clock          clock.Clock
-	interval       time.Duration
-	deleteUserHook func(ctx context.Context, userID string) error
+	runner            cleanupRunner
+	clock             clock.Clock
+	interval          time.Duration
+	auditPIIRetention time.Duration
+	deleteUserHook    func(ctx context.Context, userID string) error
 }
 
 func NewCleanupService(runner cleanupRunner, clk clock.Clock, interval time.Duration) *CleanupService {
 	return &CleanupService{
-		runner:   runner,
-		clock:    clk,
-		interval: interval,
+		runner:            runner,
+		clock:             clk,
+		interval:          interval,
+		auditPIIRetention: 3 * 365 * 24 * time.Hour,
+	}
+}
+
+func (c *CleanupService) SetAuditLogPIIRetention(retention time.Duration) {
+	if retention > 0 {
+		c.auditPIIRetention = retention
 	}
 }
 
@@ -117,8 +125,8 @@ func (c *CleanupService) runAllLocked(ctx context.Context) error {
 		}
 	}
 
-	// 6. Audit log anonymization: user_id NULL after 3 years (Spec 007)
-	if n, err := c.runner.AnonymizeAuditLogBefore(ctx, now.Add(-3*365*24*time.Hour)); err != nil {
+	// 6. Audit log PII anonymization: user_id/IP/User-Agent NULL after the configured retention.
+	if n, err := c.runner.AnonymizeAuditLogBefore(ctx, now.Add(-c.auditPIIRetention)); err != nil {
 		slog.Error("audit_log anonymization", "error", err)
 	} else if n > 0 {
 		slog.Info("audit_log anonymization", "anonymized", n)

--- a/internal/storage/audit_test.go
+++ b/internal/storage/audit_test.go
@@ -63,6 +63,42 @@ func TestAudit010And011_RefreshReuseAndFamilyRevoke(t *testing.T) {
 	}
 }
 
+func TestAuditLog_AppendOnlyGuardAllowsPIIRedactionOnly(t *testing.T) {
+	db := testutil.SetupPostgres(t)
+	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
+	store := New(db, clk, idgen.CryptoGenerator{}, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
+	ctx := context.Background()
+
+	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "audit-guard@test.com", EmailVerified: true, Name: "Audit Guard", AvatarURL: "", Provider: "google", ProviderUserID: "audit-guard-sub", ProviderEmail: "audit-guard@test.com"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	store.AuditLog(ctx, &user.ID, "auth.login", "198.51.100.9", "guard-agent", map[string]any{"session_id": "sess-1"})
+
+	if _, err := db.ExecContext(ctx, `UPDATE audit_log SET metadata = '{}'::jsonb WHERE user_id = $1`, user.ID); err == nil {
+		t.Fatal("expected immutable metadata update to fail")
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM audit_log WHERE user_id = $1`, user.ID); err == nil {
+		t.Fatal("expected audit_log delete to fail")
+	}
+
+	redacted, err := NewCleanupRunner(db).RedactAuditLogPIIByUserID(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("redact audit PII: %v", err)
+	}
+	if redacted != 1 {
+		t.Fatalf("redacted rows = %d, want 1", redacted)
+	}
+
+	var ip, ua sql.NullString
+	if err := db.QueryRowContext(ctx, `SELECT ip_address::text, user_agent FROM audit_log WHERE user_id = $1`, user.ID).Scan(&ip, &ua); err != nil {
+		t.Fatalf("query redacted audit row: %v", err)
+	}
+	if ip.Valid || ua.Valid {
+		t.Fatalf("PII not redacted: ip=%v ua=%v", ip, ua)
+	}
+}
+
 func requireStorageAuditEvent(t *testing.T, db *sql.DB, userID, eventType string) map[string]any {
 	t.Helper()
 

--- a/internal/storage/cleanup_runner.go
+++ b/internal/storage/cleanup_runner.go
@@ -81,6 +81,10 @@ func (r *CleanupRunner) AnonymizeAuditLogBefore(ctx context.Context, cutoff time
 	return storeq.New(r.db).AnonymizeAuditLogBefore(ctx, cutoff)
 }
 
+func (r *CleanupRunner) RedactAuditLogPIIByUserID(ctx context.Context, userID string) (int64, error) {
+	return storeq.New(r.db).RedactAuditLogPIIByUserID(ctx, userID)
+}
+
 func (r *CleanupRunner) DeleteUser(
 	ctx context.Context,
 	userID string,
@@ -124,6 +128,9 @@ func (r *CleanupRunner) DeleteUser(
 		return err
 	}
 	if err := qtx.DeleteRefreshTokensByUserID(ctx, userID); err != nil {
+		return err
+	}
+	if _, err := qtx.RedactAuditLogPIIByUserID(ctx, userID); err != nil {
 		return err
 	}
 	if hook != nil {

--- a/migrations/003_audit_log_immutability.down.sql
+++ b/migrations/003_audit_log_immutability.down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS audit_log_append_only_guard ON audit_log;
+DROP FUNCTION IF EXISTS audit_log_guard_append_only();

--- a/migrations/003_audit_log_immutability.up.sql
+++ b/migrations/003_audit_log_immutability.up.sql
@@ -1,0 +1,42 @@
+-- PIPA/SOC2 baseline: audit rows are append-only except for legal/privacy
+-- redaction. Core event facts cannot be edited, PII columns can only be
+-- nulled, and DELETE is blocked at the table boundary.
+CREATE OR REPLACE FUNCTION audit_log_guard_append_only()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'audit_log rows are append-only';
+  END IF;
+
+  IF NEW.id <> OLD.id
+     OR NEW.event_type <> OLD.event_type
+     OR NEW.created_at <> OLD.created_at
+     OR NEW.metadata IS DISTINCT FROM OLD.metadata THEN
+    RAISE EXCEPTION 'audit_log immutable fields cannot be updated';
+  END IF;
+
+  IF NOT (
+    NEW.user_id IS NOT DISTINCT FROM OLD.user_id OR NEW.user_id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'audit_log user_id can only be redacted to NULL';
+  END IF;
+
+  IF NOT (
+    NEW.ip_address IS NOT DISTINCT FROM OLD.ip_address OR NEW.ip_address IS NULL
+  ) THEN
+    RAISE EXCEPTION 'audit_log ip_address can only be redacted to NULL';
+  END IF;
+
+  IF NOT (
+    NEW.user_agent IS NOT DISTINCT FROM OLD.user_agent OR NEW.user_agent IS NULL
+  ) THEN
+    RAISE EXCEPTION 'audit_log user_agent can only be redacted to NULL';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER audit_log_append_only_guard
+BEFORE UPDATE OR DELETE ON audit_log
+FOR EACH ROW EXECUTE FUNCTION audit_log_guard_append_only();


### PR DESCRIPTION
## Summary

한국 PIPA / SOC 2 readiness Phase 1 기준으로 audit log lifecycle 통제를 보강한다.

현재 `audit_log` 는 이벤트 수집과 cleanup 익명화 경로는 있었지만, DB 레벨 append-only 강제와 개인정보 redaction 허용 범위가 명확하지 않았다. 운영 환경 설정도 일부 값이 parse 실패 시 기본값으로 조용히 fallback 되어, 보존기간/timeout/rate limit 오타가 startup 에서 드러나지 않는 문제가 있었다.

## Changes

- **`migrations/003_audit_log_immutability.*.sql`**:
  - `audit_log` DELETE 차단
  - `event_type`, `metadata`, `created_at` 등 이벤트 사실 필드 수정 차단
  - `user_id`, `ip_address`, `user_agent` 는 `NULL` redaction 만 허용
- **`internal/db/queries/cleanup.sql` / `internal/storage/cleanup_runner.go`**:
  - 계정 삭제 cleanup 시 audit log 의 IP/User-Agent redaction 수행
  - 장기 보존 만료 시 `user_id`, IP, User-Agent 동시 익명화
- **`internal/service/cleanup.go` / `cmd/authgate/main.go`**:
  - audit PII 보존기간을 `AUDIT_LOG_PII_RETENTION_DAYS` 로 설정 가능하게 wiring
  - 기본 1095일, 최소 365일
- **`internal/config/config.go`**:
  - numeric / bool / float env var parse 실패 시 startup fail-fast
  - `SIGNING_KEY_PATH` 추가로 production signing key mount 경로를 설정 가능하게 변경
- **Docs / tests**:
  - README, data-model spec 갱신
  - config parse 실패 회귀 테스트 추가
  - PostgreSQL trigger 가 immutable update/delete 를 막고 PII redaction 은 허용하는 integration test 추가

## Test plan

- [x] `go test ./...`
- [x] `go test -tags integration ./internal/...`
- [x] `go vet ./...`
- [x] `go list ./... | grep -v '/internal/testutil' | grep -v '/internal/integration' | xargs $(go env GOPATH)/bin/govulncheck`

## Checklist

- [x] Tests added or updated for changed behavior
- [x] Doc sync
  - [x] Env var change -> `README.md` updated
  - [x] Data lifecycle change -> `docs/spec/007-data-model.md` updated
- [x] No secrets committed (`.env`, keys, credentials)
- [x] `go test ./...` passes locally

## Design notes

- `audit_log` row 자체 hard delete 는 막고, 법적/개인정보 삭제 요청 대응에 필요한 PII redaction 만 허용한다.
- 보존기간 기본값은 기존 spec 의 3년과 호환되는 1095일로 두고, 소규모 서비스도 PIPA 접속기록 최소 보존선에 맞춰 365일 미만으로 낮출 수 없게 했다.
- full `govulncheck ./...` 는 testcontainers/docker test utility 경로까지 포함해 default branch 와 동일한 Docker advisory 를 잡을 수 있어, PR blocking 검증은 기존 CI 관례처럼 runtime package set 으로 제한했다.