### PR TITLE
fix(audit): log denied console access

### DIFF
--- a/docs/security/001-audit-evidence-matrix.md
+++ b/docs/security/001-audit-evidence-matrix.md
@@ -81,7 +81,7 @@ audit_log
 | KR-PIPA-INC-001 | 침해 의심 이벤트를 조사할 수 있는가 | refresh token reuse와 family revoke 이벤트 | `internal/storage/storage_auth_tokens.go` | `internal/storage/audit_test.go` | DONE |
 | KR-PIPA-INC-002 | audit log write 실패를 감지하는가 | `authgate_audit_log_write_failures_total` metric | `internal/observability/audit_metrics.go`, `docs/spec/009-operations.md` | `internal/storage/audit_failure_unit_test.go` | DONE |
 | KR-COMM-001 | IP/UA 등 접속 메타데이터를 추적할 수 있는가 | `audit_log.ip_address`, `audit_log.user_agent` | `internal/storage/audit.go`, `internal/clientinfo/*` | `internal/clientinfo/clientinfo_test.go` | DONE |
-| SOC2-CC6-001 | 민감한 console 조회 접근을 추적하는가 | console read access audit events | `internal/service/console.go` | `internal/service/console_unit_test.go` | DONE |
+| SOC2-CC6-001 | 민감한 console 조회 접근을 추적하는가 | console read/denied access audit events | `internal/service/console.go` | `internal/service/console_unit_test.go` | DONE |
 | SOC2-CC6-002 | session/connection revoke 같은 권한성 작업을 추적하는가 | `auth.connection_revoked`, `auth.session_revoked`, `auth.other_sessions_revoked` | `internal/service/console.go` | `internal/service/console_unit_test.go` | DONE |
 | SOC2-CC7-001 | 보안 이상징후를 탐지할 이벤트가 있는가 | inactive user access, refresh reuse detection, channel mismatch | `internal/service/*`, `internal/storage/storage_auth_tokens.go` | `internal/service/audit_test.go`, `internal/service/login_unit_test.go` | DONE |
 | SOC2-CC7-002 | abuse 방어가 있는가 | per-IP rate limit for auth/token/callback/console endpoints, CIMD failure rate limit | `cmd/authgate/main.go`, `internal/middleware/ratelimit.go`, `internal/adapter/mcp/cimd.go` | `cmd/authgate/main_test.go`, `internal/integration/integration_ratelimit_test.go`, `internal/adapter/mcp/*ratelimit*_test.go` | DONE |
@@ -113,6 +113,7 @@ audit_log
 | `console.connections_listed` | `/console/me/connections` 성공 조회 | user_id, IP, UA, created_at | `result_count` | `internal/service/console.go` | `internal/service/console_unit_test.go` | DONE |
 | `console.sessions_listed` | `/console/me/sessions` 성공 조회 | user_id, IP, UA, created_at | `result_count` | `internal/service/console.go` | `internal/service/console_unit_test.go` | DONE |
 | `console.audit_log_viewed` | `/console/me/audit-log` 성공 조회 | user_id, IP, UA, created_at | `page`, `limit`, `result_count` | `internal/service/console.go` | `internal/service/console_unit_test.go` | DONE |
+| `console.access_denied` | Console 401/403 접근 거부 | user_id(403만), IP, UA, created_at | `operation`, `status_code`, `reason`, `user_status` | `internal/service/console.go` | `internal/service/console_unit_test.go` | DONE |
 
 ## Endpoint Coverage Matrix
 
@@ -146,7 +147,6 @@ audit_log
 
 | GAP | 설명 | 다음 작업 후보 |
 |-----|------|----------------|
-| GAP-AUD-001 | console API의 401/403 실패 접근은 별도 audit event로 남기지 않는다. 성공 조회/변경은 기록된다. | 실패 접근 event 추가 여부 결정 |
 | GAP-AUD-002 | `oauth/device/authorize`의 device code 발급 자체는 provider 내부 처리라 authgate audit event가 없다. 승인/거부/로그인은 기록된다. | device code 발급 hook 가능성 검토 |
 | GAP-AUD-003 | `/oauth/introspect`는 provider 기본 라우트로 처리되며 authgate audit event가 없다. 고빈도 검증 endpoint라 audit_log 대상인지 별도 결정 필요. | metrics 중심 유지 또는 sampled audit 검토 |
 | GAP-OPS-001 | SOC 2 운영 evidence(PR 리뷰, access review, backup restore test)는 GitHub/운영 시스템에 존재해야 하며 authgate DB에는 저장하지 않는다. | 운영 evidence export/checklist 문서 |

--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -162,6 +162,7 @@ erDiagram
 | `console.connections_listed` | 연결/권한 목록 조회 | Console 조회 |
 | `console.sessions_listed` | 세션 목록 조회 | Console 조회 |
 | `console.audit_log_viewed` | 감사 로그 조회 | Console 조회 |
+| `console.access_denied` | Console 401/403 접근 거부 | Console 인증/권한 확인 |
 
 ## 인덱스
 
@@ -260,6 +261,7 @@ MCP
 | `console.connections_listed` | Console 연결/권한 조회 | `{result_count}` |
 | `console.sessions_listed` | Console 세션 조회 | `{result_count}` |
 | `console.audit_log_viewed` | Console audit log 조회 | `{page, limit, result_count}` |
+| `console.access_denied` | Console 접근 거부 | `{operation, status_code, reason, user_status}` |
 
 `metadata`는 `Storage.AuditLog`에서 event별 allowlist를 통과한 key만 저장한다.
 allowlist에 없는 email, token, secret, raw request payload 등은 저장하지 않는다.

--- a/docs/tests/004-audit-events.md
+++ b/docs/tests/004-audit-events.md
@@ -33,6 +33,7 @@
 | `audit-014` | audit metadata 저장 | (해당 이벤트) | 이벤트별 allowlist에 없는 key는 저장하지 않음. 예: `email`, token, secret류 임의 key는 drop |
 | `audit-015` | Console client/connection/session 조회 | `console.clients_listed`, `console.connections_listed`, `console.sessions_listed` | 성공 응답 후 `metadata.result_count` 기록. 응답의 IP/UA/세션 상세 자체는 metadata에 넣지 않음 |
 | `audit-016` | Console audit log 조회 | `console.audit_log_viewed` | 성공 응답 후 `metadata.page`, `metadata.limit`, `metadata.result_count` 기록 |
+| `audit-017` | Console 401/403 접근 거부 | `console.access_denied` | 401은 `user_id=NULL`, 403은 식별된 `user_id` + `metadata.user_status` 기록. `metadata.operation`, `status_code`, `reason` 포함 |
 
 ## 채널별 auth.login 검증
 

--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -142,12 +142,29 @@ func (s *ConsoleService) auditConsoleAccess(ctx context.Context, userID, eventTy
 	s.store.AuditLog(ctx, &userID, eventType, info.IP, info.UserAgent, metadata)
 }
 
+func (s *ConsoleService) auditConsoleDenied(ctx context.Context, user *storage.User, operation string, statusCode int, reason string) {
+	info := clientinfo.FromContext(ctx)
+	metadata := map[string]any{
+		"operation":   operation,
+		"status_code": statusCode,
+		"reason":      reason,
+	}
+	var userID *string
+	if user != nil {
+		userID = &user.ID
+		metadata["user_status"] = user.Status
+	}
+	s.store.AuditLog(ctx, userID, storage.EventConsoleAccessDenied, info.IP, info.UserAgent, metadata)
+}
+
 func (s *ConsoleService) ListClients(ctx context.Context, sessionID, authHeader string) *ClientsResult {
 	user, err := s.resolveUser(ctx, sessionID, authHeader)
 	if err != nil {
+		s.auditConsoleDenied(ctx, nil, "clients.list", http.StatusUnauthorized, "unauthenticated")
 		return &ClientsResult{ErrorCode: http.StatusUnauthorized}
 	}
 	if CheckAccess(user.Status, "browser") != AccessAllow {
+		s.auditConsoleDenied(ctx, user, "clients.list", http.StatusForbidden, "forbidden")
 		return &ClientsResult{ErrorCode: http.StatusForbidden}
 	}
 
@@ -179,9 +196,11 @@ func (s *ConsoleService) ListClients(ctx context.Context, sessionID, authHeader 
 func (s *ConsoleService) ListConnections(ctx context.Context, sessionID, authHeader string) *ConnectionsResult {
 	user, err := s.resolveUser(ctx, sessionID, authHeader)
 	if err != nil {
+		s.auditConsoleDenied(ctx, nil, "connections.list", http.StatusUnauthorized, "unauthenticated")
 		return &ConnectionsResult{ErrorCode: http.StatusUnauthorized}
 	}
 	if CheckAccess(user.Status, "browser") != AccessAllow {
+		s.auditConsoleDenied(ctx, user, "connections.list", http.StatusForbidden, "forbidden")
 		return &ConnectionsResult{ErrorCode: http.StatusForbidden}
 	}
 
@@ -225,9 +244,11 @@ func (s *ConsoleService) ListConnections(ctx context.Context, sessionID, authHea
 func (s *ConsoleService) ListSessions(ctx context.Context, sessionID, authHeader string) *SessionsResult {
 	auth, err := s.resolveAuth(ctx, sessionID, authHeader)
 	if err != nil {
+		s.auditConsoleDenied(ctx, nil, "sessions.list", http.StatusUnauthorized, "unauthenticated")
 		return &SessionsResult{ErrorCode: http.StatusUnauthorized}
 	}
 	if CheckAccess(auth.user.Status, "browser") != AccessAllow {
+		s.auditConsoleDenied(ctx, auth.user, "sessions.list", http.StatusForbidden, "forbidden")
 		return &SessionsResult{ErrorCode: http.StatusForbidden}
 	}
 
@@ -259,9 +280,11 @@ func (s *ConsoleService) ListSessions(ctx context.Context, sessionID, authHeader
 func (s *ConsoleService) RevokeConnection(ctx context.Context, sessionID, authHeader, clientID string) *RevokeConnectionResult {
 	auth, err := s.resolveAuth(ctx, sessionID, authHeader)
 	if err != nil {
+		s.auditConsoleDenied(ctx, nil, "connections.revoke", http.StatusUnauthorized, "unauthenticated")
 		return &RevokeConnectionResult{ErrorCode: http.StatusUnauthorized}
 	}
 	if CheckAccess(auth.user.Status, "browser") != AccessAllow {
+		s.auditConsoleDenied(ctx, auth.user, "connections.revoke", http.StatusForbidden, "forbidden")
 		return &RevokeConnectionResult{ErrorCode: http.StatusForbidden}
 	}
 	if clientID == "" {
@@ -284,9 +307,11 @@ func (s *ConsoleService) RevokeConnection(ctx context.Context, sessionID, authHe
 func (s *ConsoleService) RevokeSession(ctx context.Context, sessionID, authHeader, revokeSessionID string) *RevokeSessionResult {
 	auth, err := s.resolveAuth(ctx, sessionID, authHeader)
 	if err != nil {
+		s.auditConsoleDenied(ctx, nil, "sessions.revoke", http.StatusUnauthorized, "unauthenticated")
 		return &RevokeSessionResult{ErrorCode: http.StatusUnauthorized}
 	}
 	if CheckAccess(auth.user.Status, "browser") != AccessAllow {
+		s.auditConsoleDenied(ctx, auth.user, "sessions.revoke", http.StatusForbidden, "forbidden")
 		return &RevokeSessionResult{ErrorCode: http.StatusForbidden}
 	}
 	if revokeSessionID == "" {
@@ -303,9 +328,11 @@ func (s *ConsoleService) RevokeSession(ctx context.Context, sessionID, authHeade
 func (s *ConsoleService) RevokeOtherSessions(ctx context.Context, sessionID, authHeader string) *RevokeOtherSessionsResult {
 	auth, err := s.resolveAuth(ctx, sessionID, authHeader)
 	if err != nil {
+		s.auditConsoleDenied(ctx, nil, "sessions.revoke_others", http.StatusUnauthorized, "unauthenticated")
 		return &RevokeOtherSessionsResult{ErrorCode: http.StatusUnauthorized}
 	}
 	if CheckAccess(auth.user.Status, "browser") != AccessAllow {
+		s.auditConsoleDenied(ctx, auth.user, "sessions.revoke_others", http.StatusForbidden, "forbidden")
 		return &RevokeOtherSessionsResult{ErrorCode: http.StatusForbidden}
 	}
 	if auth.sessionID == "" {
@@ -322,9 +349,11 @@ func (s *ConsoleService) RevokeOtherSessions(ctx context.Context, sessionID, aut
 func (s *ConsoleService) GetAuditLog(ctx context.Context, sessionID, authHeader string, page, limit int) *AuditLogResult {
 	user, err := s.resolveUser(ctx, sessionID, authHeader)
 	if err != nil {
+		s.auditConsoleDenied(ctx, nil, "audit_log.view", http.StatusUnauthorized, "unauthenticated")
 		return &AuditLogResult{ErrorCode: http.StatusUnauthorized}
 	}
 	if CheckAccess(user.Status, "browser") != AccessAllow {
+		s.auditConsoleDenied(ctx, user, "audit_log.view", http.StatusForbidden, "forbidden")
 		return &AuditLogResult{ErrorCode: http.StatusForbidden}
 	}
 	if page < 1 {

--- a/internal/service/console_unit_test.go
+++ b/internal/service/console_unit_test.go
@@ -119,6 +119,38 @@ func TestConsole_ListClients_NoSession_Unauthorized(t *testing.T) {
 	}
 }
 
+func TestConsole_ListClients_Unauthorized_AuditLogged(t *testing.T) {
+	store := activeUserStore(nil, nil)
+	var got capturedAuditEvent
+	store.auditLogFn = func(_ context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
+		if userID != nil {
+			got.userID = *userID
+		}
+		got.eventType = eventType
+		got.ipAddress = ipAddress
+		got.userAgent = userAgent
+		got.metadata = metadata
+	}
+	ctx := clientinfo.WithContext(context.Background(), clientinfo.Info{IP: "198.51.100.20", UserAgent: "Probe"})
+	svc := NewConsoleService(store)
+	r := svc.ListClients(ctx, "", "")
+	if r.ErrorCode != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", r.ErrorCode)
+	}
+	if got.userID != "" || got.eventType != storage.EventConsoleAccessDenied {
+		t.Fatalf("audit userID=%q eventType=%q", got.userID, got.eventType)
+	}
+	if got.ipAddress != "198.51.100.20" || got.userAgent != "Probe" {
+		t.Fatalf("audit client info ip=%q ua=%q", got.ipAddress, got.userAgent)
+	}
+	if got.metadata["operation"] != "clients.list" || got.metadata["status_code"] != http.StatusUnauthorized || got.metadata["reason"] != "unauthenticated" {
+		t.Fatalf("audit metadata=%#v, want unauthorized clients.list", got.metadata)
+	}
+	if _, ok := got.metadata["user_status"]; ok {
+		t.Fatalf("user_status should be absent for unauthenticated access: %#v", got.metadata)
+	}
+}
+
 func TestConsole_ListClients_InvalidSession_Unauthorized(t *testing.T) {
 	store := &fakeConsoleStore{
 		getValidSessionFn: func(context.Context, string) (*storage.User, error) {
@@ -148,6 +180,35 @@ func TestConsole_ListClients_DisabledUser_Forbidden(t *testing.T) {
 	r := svc.ListClients(context.Background(), "sess-1", "")
 	if r.ErrorCode != http.StatusForbidden {
 		t.Fatalf("want 403, got %d", r.ErrorCode)
+	}
+}
+
+func TestConsole_ListClients_Forbidden_AuditLogged(t *testing.T) {
+	store := activeUserStore(nil, nil)
+	store.getValidSessionFn = func(context.Context, string) (*storage.User, error) {
+		return &storage.User{ID: "u-disabled", Status: "disabled"}, nil
+	}
+	var got capturedAuditEvent
+	store.auditLogFn = func(_ context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
+		if userID != nil {
+			got.userID = *userID
+		}
+		got.eventType = eventType
+		got.metadata = metadata
+	}
+	svc := NewConsoleService(store)
+	r := svc.ListClients(context.Background(), "sess-1", "")
+	if r.ErrorCode != http.StatusForbidden {
+		t.Fatalf("want 403, got %d", r.ErrorCode)
+	}
+	if got.userID != "u-disabled" || got.eventType != storage.EventConsoleAccessDenied {
+		t.Fatalf("audit userID=%q eventType=%q", got.userID, got.eventType)
+	}
+	if got.metadata["operation"] != "clients.list" || got.metadata["status_code"] != http.StatusForbidden || got.metadata["reason"] != "forbidden" {
+		t.Fatalf("audit metadata=%#v, want forbidden clients.list", got.metadata)
+	}
+	if got.metadata["user_status"] != "disabled" {
+		t.Fatalf("audit user_status=%v, want disabled", got.metadata["user_status"])
 	}
 }
 

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -44,6 +44,7 @@ const (
 	EventConsoleConnectionsListed = "console.connections_listed"
 	EventConsoleSessionsListed    = "console.sessions_listed"
 	EventConsoleAuditLogViewed    = "console.audit_log_viewed"
+	EventConsoleAccessDenied      = "console.access_denied"
 
 	EventTokenRefresh   = "token.refresh"
 	EventTokenRevoked   = "token.revoked"
@@ -126,6 +127,12 @@ var auditMetadataAllowlist = map[string]map[string]struct{}{
 		"page":         {},
 		"limit":        {},
 		"result_count": {},
+	},
+	EventConsoleAccessDenied: {
+		"operation":   {},
+		"status_code": {},
+		"reason":      {},
+		"user_status": {},
 	},
 }
 


### PR DESCRIPTION
## Summary
- Add `console.access_denied` audit events for console 401/403 paths.
- Record unauthenticated attempts with `user_id=NULL`, IP, UA, operation, status code, and reason.
- Record forbidden attempts with the identified user ID plus `metadata.user_status`.
- Update the audit metadata allowlist, security evidence matrix, data model spec, and audit test plan.

## Impact
- Closes `GAP-AUD-001` from the audit evidence matrix.
- Keeps denied-access metadata minimal: no token, session ID, raw request, or target resource payload is stored.
- Console success events remain unchanged.

## Validation
- `go test ./internal/service ./internal/storage`
- `go test ./...`
- `go vet ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
