### PR TITLE
docs(security): document introspection evidence

### DIFF
--- a/docs/security/001-audit-evidence-matrix.md
+++ b/docs/security/001-audit-evidence-matrix.md
@@ -125,7 +125,7 @@ audit_log
 | `GET /mcp/callback` | MCP 인증 완료 | `auth.login`, `auth.inactive_user` | auth limiter | DONE |
 | `POST /oauth/token` | 토큰 발급/갱신 | `token.refresh`, reuse events | token limiter | DONE |
 | `POST /oauth/revoke` | 토큰 폐기 | `auth.token_revoked` when matching refresh token | token limiter | DONE |
-| `POST /oauth/introspect` | 토큰 상태 검증 | provider 처리, 별도 audit 없음 | token limiter | PARTIAL |
+| `POST /oauth/introspect` | 토큰 상태 검증 | `authgate_http_requests_total{method="POST",route="/oauth/introspect",status}` metric | token limiter | DONE |
 | `POST /oauth/device/authorize` | Device code 발급 | provider 처리, 별도 audit 없음 | token limiter | PARTIAL |
 | `GET /device` | Device 승인 화면 | 없음 | 없음 | N/A |
 | `GET /device/auth/callback` | Device 로그인 완료 | `auth.login`, `auth.inactive_user` | auth limiter | DONE |
@@ -148,7 +148,6 @@ audit_log
 | GAP | 설명 | 다음 작업 후보 |
 |-----|------|----------------|
 | GAP-AUD-002 | `oauth/device/authorize`의 device code 발급 자체는 provider 내부 처리라 authgate audit event가 없다. 승인/거부/로그인은 기록된다. | device code 발급 hook 가능성 검토 |
-| GAP-AUD-003 | `/oauth/introspect`는 provider 기본 라우트로 처리되며 authgate audit event가 없다. 고빈도 검증 endpoint라 audit_log 대상인지 별도 결정 필요. | metrics 중심 유지 또는 sampled audit 검토 |
 | GAP-OPS-001 | SOC 2 운영 evidence(PR 리뷰, access review, backup restore test)는 GitHub/운영 시스템에 존재해야 하며 authgate DB에는 저장하지 않는다. | 운영 evidence export/checklist 문서 |
 
 ## 완료 기준

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -321,7 +321,17 @@ SELECT * FROM audit_log WHERE event_type = 'auth.inactive_user' ORDER BY created
 | cleanup 고루틴 | audit_log에 `auth.deletion_completed` 확인 | 30일+ pending_deletion 유저 존재 |
 | signing_key | JWKS 엔드포인트 체크 | 키 0개 반환 |
 | 디스크 | signing_key.pem 파일 존재 확인 | 파일 없음 → 재시작마다 키 변경 |
+| token introspection | `authgate_http_requests_total{route="/oauth/introspect"}` | 4xx/5xx 급증 또는 비정상 트래픽 급증 |
 | audit 쓰기 실패 | `authgate_audit_log_write_failures_total` counter | 5분 내 증가 → 침해 탐지 인프라 silent broken (#208) |
+
+### token introspection 증적
+
+`/oauth/introspect`는 리소스 서버가 access token 상태를 자주 검증하는 고빈도 endpoint다. 호출마다 `audit_log` row를 만들면 저장량과 PII 노출면이 커지므로, 행 단위 감사 로그 대신 HTTP metric을 운영 증적으로 사용한다.
+
+| Metric | Labels | 설명 |
+|--------|--------|------|
+| `authgate_http_requests_total` | `method="POST", route="/oauth/introspect", status` | introspection 요청 수와 결과 상태 |
+| `authgate_http_request_duration_seconds` | `method="POST", route="/oauth/introspect", status` | introspection 지연 시간 |
 
 ### audit_log 쓰기 실패 모니터링 (#208)
 

--- a/internal/observability/http_metrics_test.go
+++ b/internal/observability/http_metrics_test.go
@@ -81,3 +81,38 @@ func TestMiddleware_UsesInboundRequestID(t *testing.T) {
 		t.Fatalf("X-Request-ID = %q, want req-123", got)
 	}
 }
+
+func TestMiddleware_RecordsOAuthIntrospectionRouteEvidence(t *testing.T) {
+	m := NewHTTPMetrics()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth/introspect", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := wrapWithRequestID(m.Middleware(mux))
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/introspect", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	metrics, err := m.registry.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+
+	for _, mf := range metrics {
+		if mf.GetName() != "authgate_http_requests_total" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range metric.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["method"] == http.MethodPost && labels["route"] == "/oauth/introspect" && labels["status"] == "200" {
+				return
+			}
+		}
+	}
+
+	t.Fatal("authgate_http_requests_total did not include POST /oauth/introspect 200 evidence")
+}


### PR DESCRIPTION
## Summary
- treat /oauth/introspect as metric-based evidence instead of per-request audit_log rows
- mark GAP-AUD-003 as closed in the audit evidence matrix
- add a test pinning the route/status metric label for POST /oauth/introspect

## Verification
- go test ./internal/observability
- go test ./...
- go vet ./...
- go run golang.org/x/vuln/cmd/govulncheck@latest ./...