### PR TITLE
fix(audit): log device code issuance

### DIFF
--- a/docs/security/001-audit-evidence-matrix.md
+++ b/docs/security/001-audit-evidence-matrix.md
@@ -96,6 +96,7 @@ audit_log
 | `auth.login` | Browser/Device/MCP 로그인 성공 | user_id, IP, UA, created_at | `channel`, `session_id`, `client_id`, `client_name`, `reused_session`, `signup` | `internal/service/login.go`, `internal/service/device.go`, `internal/service/mcp_login.go` | `internal/service/audit_test.go` | DONE |
 | `auth.channel_mismatch` | auth_request 채널 불일치 차단 | user_id, IP, UA, created_at | `expected_channel`, `actual_channel`, `client_id`, `client_name` | `internal/service/login.go` | `internal/service/login_unit_test.go` | DONE |
 | `auth.inactive_user` | disabled/pending_deletion/deleted 접근 차단 | user_id, IP, UA, created_at | `status`, `channel`, `phase` | `internal/service/account.go`, `internal/service/login.go`, `internal/service/device.go`, `internal/service/mcp_login.go` | `internal/service/audit_test.go` | DONE |
+| `auth.device_code_issued` | Device code 발급 | user_id(NULL), IP, UA, created_at | `client_id`, `client_name` | `internal/storage/storage_oidc_device.go` | `internal/storage/audit_test.go` | DONE |
 | `auth.device_approved` | Device code 승인 | user_id, IP, UA, created_at | `client_id`, `client_name` | `internal/service/device.go` | `internal/service/audit_test.go` | DONE |
 | `auth.device_denied` | Device code 거부 | user_id, IP, UA, created_at | `client_id`, `client_name` | `internal/service/device.go` | `internal/service/audit_test.go` | DONE |
 | `auth.deletion_requested` | `DELETE /account` 성공 | user_id, IP, UA, created_at | 없음 | `internal/service/account.go` | `internal/service/audit_test.go` | DONE |
@@ -126,7 +127,7 @@ audit_log
 | `POST /oauth/token` | 토큰 발급/갱신 | `token.refresh`, reuse events | token limiter | DONE |
 | `POST /oauth/revoke` | 토큰 폐기 | `auth.token_revoked` when matching refresh token | token limiter | DONE |
 | `POST /oauth/introspect` | 토큰 상태 검증 | `authgate_http_requests_total{method="POST",route="/oauth/introspect",status}` metric | token limiter | DONE |
-| `POST /oauth/device/authorize` | Device code 발급 | provider 처리, 별도 audit 없음 | token limiter | PARTIAL |
+| `POST /oauth/device/authorize` | Device code 발급 | `auth.device_code_issued` | token limiter | DONE |
 | `GET /device` | Device 승인 화면 | 없음 | 없음 | N/A |
 | `GET /device/auth/callback` | Device 로그인 완료 | `auth.login`, `auth.inactive_user` | auth limiter | DONE |
 | `POST /device/approve` | Device 승인/거부 | `auth.device_approved`, `auth.device_denied`, `auth.inactive_user` | token limiter | DONE |
@@ -147,7 +148,6 @@ audit_log
 
 | GAP | 설명 | 다음 작업 후보 |
 |-----|------|----------------|
-| GAP-AUD-002 | `oauth/device/authorize`의 device code 발급 자체는 provider 내부 처리라 authgate audit event가 없다. 승인/거부/로그인은 기록된다. | device code 발급 hook 가능성 검토 |
 | GAP-OPS-001 | SOC 2 운영 evidence(PR 리뷰, access review, backup restore test)는 GitHub/운영 시스템에 존재해야 하며 authgate DB에는 저장하지 않는다. | 운영 evidence export/checklist 문서 |
 
 ## 완료 기준

--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -246,6 +246,7 @@ MCP
 | `auth.deletion_requested` | 탈퇴 요청 | — |
 | `auth.deletion_cancelled` | 탈퇴 취소 (로그인 복구) | — |
 | `auth.deletion_completed` | PII 스크러빙 완료 | TX 커밋 이후 best-effort 기록 |
+| `auth.device_code_issued` | 디바이스 코드 발급 | `{client_id, client_name}` |
 | `auth.device_approved` | 디바이스 승인 | `{client_id, client_name}` |
 | `auth.device_denied` | 디바이스 거부 | `{client_id, client_name}` |
 | `token.refresh` | refresh token rotation 성공 | `{client_id, client_name, family_id}` |

--- a/docs/tests/004-audit-events.md
+++ b/docs/tests/004-audit-events.md
@@ -34,6 +34,7 @@
 | `audit-015` | Console client/connection/session 조회 | `console.clients_listed`, `console.connections_listed`, `console.sessions_listed` | 성공 응답 후 `metadata.result_count` 기록. 응답의 IP/UA/세션 상세 자체는 metadata에 넣지 않음 |
 | `audit-016` | Console audit log 조회 | `console.audit_log_viewed` | 성공 응답 후 `metadata.page`, `metadata.limit`, `metadata.result_count` 기록 |
 | `audit-017` | Console 401/403 접근 거부 | `console.access_denied` | 401은 `user_id=NULL`, 403은 식별된 `user_id` + `metadata.user_status` 기록. `metadata.operation`, `status_code`, `reason` 포함 |
+| `audit-018` | Device code 발급 | `auth.device_code_issued` | 승인 전 단계라 `user_id=NULL`. `metadata.client_id` + `metadata.client_name`만 기록하고 `device_code`/`user_code`는 저장하지 않음 |
 
 ## 채널별 auth.login 검증
 

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -36,6 +36,7 @@ const (
 	EventAuthLogout               = "auth.logout"
 	EventAuthTokenRevoked         = "auth.token_revoked"
 	EventAuthChannelMismatch      = "auth.channel_mismatch"
+	EventAuthDeviceCodeIssued     = "auth.device_code_issued"
 	EventAuthConnectionRevoked    = "auth.connection_revoked"
 	EventAuthSessionRevoked       = "auth.session_revoked"
 	EventAuthOtherSessionsRevoked = "auth.other_sessions_revoked"
@@ -82,6 +83,10 @@ var auditMetadataAllowlist = map[string]map[string]struct{}{
 		"client_name": {},
 	},
 	"auth.device_approved": {
+		"client_id":   {},
+		"client_name": {},
+	},
+	EventAuthDeviceCodeIssued: {
 		"client_id":   {},
 		"client_name": {},
 	},

--- a/internal/storage/audit_test.go
+++ b/internal/storage/audit_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/clock"
 	"github.com/kangheeyong/authgate/internal/idgen"
 	"github.com/kangheeyong/authgate/internal/testutil"
@@ -96,6 +97,57 @@ func TestAuditLog_AppendOnlyGuardAllowsPIIRedactionOnly(t *testing.T) {
 	}
 	if ip.Valid || ua.Valid {
 		t.Fatalf("PII not redacted: ip=%v ua=%v", ip, ua)
+	}
+}
+
+func TestAuditDeviceCodeIssued(t *testing.T) {
+	db := testutil.SetupPostgres(t)
+	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
+	store := New(db, clk, idgen.CryptoGenerator{}, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
+	store.LoadClients([]ClientConfigEntry{{
+		ClientID: "device-client",
+		Name:     "Device Client",
+	}})
+	ctx := clientinfo.WithContext(context.Background(), clientinfo.Info{IP: "198.51.100.31", UserAgent: "device-cli/1.0"})
+
+	if err := store.StoreDeviceAuthorization(ctx, "device-client", "secret-device-code", "USER-CODE", clk.Now().Add(5*time.Minute), []string{"openid"}); err != nil {
+		t.Fatalf("store device authorization: %v", err)
+	}
+
+	var userID sql.NullString
+	var ip sql.NullString
+	var ua sql.NullString
+	var raw []byte
+	if err := db.QueryRowContext(context.Background(),
+		`SELECT user_id::text, host(ip_address), user_agent, metadata
+		 FROM audit_log
+		 WHERE event_type = $1`,
+		EventAuthDeviceCodeIssued,
+	).Scan(&userID, &ip, &ua, &raw); err != nil {
+		t.Fatalf("query device code audit: %v", err)
+	}
+	if userID.Valid {
+		t.Fatalf("user_id valid = true, want NULL before user approval")
+	}
+	if !ip.Valid || ip.String != "198.51.100.31" {
+		t.Fatalf("ip = %v, want 198.51.100.31", ip)
+	}
+	if !ua.Valid || ua.String != "device-cli/1.0" {
+		t.Fatalf("user_agent = %v, want device-cli/1.0", ua)
+	}
+
+	var metadata map[string]any
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	if metadata["client_id"] != "device-client" || metadata["client_name"] != "Device Client" {
+		t.Fatalf("metadata = %#v, want client identity", metadata)
+	}
+	if _, ok := metadata["device_code"]; ok {
+		t.Fatalf("metadata must not include device_code: %#v", metadata)
+	}
+	if _, ok := metadata["user_code"]; ok {
+		t.Fatalf("metadata must not include user_code: %#v", metadata)
 	}
 }
 

--- a/internal/storage/storage_oidc_device.go
+++ b/internal/storage/storage_oidc_device.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"github.com/zitadel/oidc/v3/pkg/op"
 
+	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/db/storeq"
 )
 
@@ -110,7 +111,7 @@ func (s *Storage) Health(ctx context.Context) error {
 // --- DeviceAuthorizationStorage ---
 
 func (s *Storage) StoreDeviceAuthorization(ctx context.Context, clientID, deviceCode, userCode string, expires time.Time, scopes []string) error {
-	return storeq.New(s.db).InsertDeviceCode(ctx, storeq.InsertDeviceCodeParams{
+	if err := storeq.New(s.db).InsertDeviceCode(ctx, storeq.InsertDeviceCodeParams{
 		ID:         s.idgen.NewUUID(),
 		DeviceCode: deviceCode,
 		UserCode:   userCode,
@@ -118,7 +119,16 @@ func (s *Storage) StoreDeviceAuthorization(ctx context.Context, clientID, device
 		Scopes:     scopes,
 		ExpiresAt:  expires,
 		CreatedAt:  s.clock.Now(),
+	}); err != nil {
+		return err
+	}
+
+	info := clientinfo.FromContext(ctx)
+	s.AuditLog(ctx, nil, EventAuthDeviceCodeIssued, info.IP, info.UserAgent, map[string]any{
+		"client_id":   clientID,
+		"client_name": s.auditClientName(ctx, clientID),
 	})
+	return nil
 }
 
 func (s *Storage) GetDeviceAuthorizatonState(ctx context.Context, clientID, deviceCode string) (*op.DeviceAuthorizationState, error) {


### PR DESCRIPTION
## Summary
- emit auth.device_code_issued after successful device authorization storage
- keep device_code/user_code out of audit metadata while recording client/IP/UA evidence
- mark GAP-AUD-002 as closed in the audit evidence matrix

## Verification
- go test ./internal/storage
- go test -tags integration ./internal/storage -run TestAuditDeviceCodeIssued
- go test -tags integration ./internal/storage
- go test ./...
- go vet ./...
- go run golang.org/x/vuln/cmd/govulncheck@latest ./...