### PR TITLE
fix(security): rate limit device entry route

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -407,7 +407,7 @@ func registerAuthgateRoutes(
 		mux.Handle("/mcp/callback", authLimiter(http.HandlerFunc(mcpLoginHandler.HandleCallback)))
 	}
 	mux.Handle("/account", authLimiter(http.HandlerFunc(accountHandler.HandleDeleteAccount)))
-	mux.HandleFunc("/device", deviceHandler.HandleDevicePage)
+	mux.Handle("/device", authLimiter(http.HandlerFunc(deviceHandler.HandleDevicePage)))
 	mux.Handle("/device/approve", tokenLimiter(http.HandlerFunc(deviceHandler.HandleDeviceApprove)))
 	mux.Handle("/device/auth/callback", authLimiter(http.HandlerFunc(deviceHandler.HandleDeviceCallback)))
 	mux.Handle("/console/clients", authLimiter(http.HandlerFunc(consoleHandler.HandleListClients)))

--- a/cmd/authgate/main_test.go
+++ b/cmd/authgate/main_test.go
@@ -13,35 +13,52 @@ func rateLimitTestConfig() *config.Config {
 	return &config.Config{
 		EnableMCP:           true,
 		RateLimitAuthRPS:    1,
-		RateLimitAuthBurst:  0,
+		RateLimitAuthBurst:  1,
 		RateLimitTokenRPS:   1,
-		RateLimitTokenBurst: 0,
+		RateLimitTokenBurst: 1,
 	}
 }
 
 func assertRateLimited(t *testing.T, mux http.Handler, method, target string) {
 	t.Helper()
-	req := httptest.NewRequest(method, target, nil)
-	rec := httptest.NewRecorder()
 
-	mux.ServeHTTP(rec, req)
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(method, target, nil)
+		rec := httptest.NewRecorder()
+		panicked := serveHTTPRecovering(mux, rec, req)
 
-	if rec.Code != http.StatusTooManyRequests {
-		t.Fatalf("%s %s status = %d, want %d", method, target, rec.Code, http.StatusTooManyRequests)
-	}
-	if got := rec.Header().Get("Retry-After"); got != "1" {
-		t.Fatalf("%s %s Retry-After = %q, want 1", method, target, got)
+		if i == 0 {
+			if rec.Code == http.StatusTooManyRequests {
+				t.Fatalf("%s %s first request was unexpectedly rate limited", method, target)
+			}
+			continue
+		}
+		if panicked {
+			t.Fatalf("%s %s second request reached handler instead of being rate limited", method, target)
+		}
+		if rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("%s %s second request status = %d, want %d", method, target, rec.Code, http.StatusTooManyRequests)
+		}
+		if got := rec.Header().Get("Retry-After"); got != "1" {
+			t.Fatalf("%s %s Retry-After = %q, want 1", method, target, got)
+		}
 	}
 }
 
+func serveHTTPRecovering(h http.Handler, rec *httptest.ResponseRecorder, req *http.Request) (panicked bool) {
+	// The first request intentionally consumes a realistic burst token and may
+	// reach nil-backed handlers in this route-wiring test. The second request
+	// must be rejected by the limiter before any handler code runs.
+	defer func() {
+		if recover() != nil {
+			panicked = true
+		}
+	}()
+	h.ServeHTTP(rec, req)
+	return false
+}
+
 func TestRegisterProviderRoutes_RateLimitsSensitiveOAuthEndpoints(t *testing.T) {
-	mux := http.NewServeMux()
-	provider := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("provider should not be reached when limiter rejects %s", r.URL.Path)
-	})
-
-	registerProviderRoutes(mux, rateLimitTestConfig(), nil, provider)
-
 	tests := []struct {
 		method string
 		path   string
@@ -53,24 +70,18 @@ func TestRegisterProviderRoutes_RateLimitsSensitiveOAuthEndpoints(t *testing.T) 
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
+			mux := http.NewServeMux()
+			provider := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			registerProviderRoutes(mux, rateLimitTestConfig(), nil, provider)
+
 			assertRateLimited(t, mux, tt.method, tt.path)
 		})
 	}
 }
 
 func TestRegisterAuthgateRoutes_RateLimitsSensitiveAuthgateEndpoints(t *testing.T) {
-	mux := http.NewServeMux()
-
-	registerAuthgateRoutes(
-		mux,
-		rateLimitTestConfig(),
-		handler.NewLoginHandler(nil, true, "authgate"),
-		handler.NewDeviceHandler(nil, true, "authgate"),
-		handler.NewAccountHandler(nil, "http://authgate.example.com"),
-		handler.NewMCPLoginHandler(nil, true, "authgate"),
-		handler.NewConsoleHandler(nil),
-	)
-
 	tests := []struct {
 		method string
 		path   string
@@ -80,6 +91,7 @@ func TestRegisterAuthgateRoutes_RateLimitsSensitiveAuthgateEndpoints(t *testing.
 		{http.MethodGet, "/mcp/login"},
 		{http.MethodGet, "/mcp/callback"},
 		{http.MethodDelete, "/account"},
+		{http.MethodGet, "/device"},
 		{http.MethodPost, "/device/approve"},
 		{http.MethodGet, "/device/auth/callback"},
 		{http.MethodGet, "/console/clients"},
@@ -92,6 +104,17 @@ func TestRegisterAuthgateRoutes_RateLimitsSensitiveAuthgateEndpoints(t *testing.
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
+			mux := http.NewServeMux()
+			registerAuthgateRoutes(
+				mux,
+				rateLimitTestConfig(),
+				handler.NewLoginHandler(nil, true, "authgate"),
+				handler.NewDeviceHandler(nil, true, "authgate"),
+				handler.NewAccountHandler(nil, "http://authgate.example.com"),
+				handler.NewMCPLoginHandler(nil, true, "authgate"),
+				handler.NewConsoleHandler(nil),
+			)
+
 			assertRateLimited(t, mux, tt.method, tt.path)
 		})
 	}

--- a/docs/security/001-audit-evidence-matrix.md
+++ b/docs/security/001-audit-evidence-matrix.md
@@ -128,7 +128,7 @@ audit_log
 | `POST /oauth/revoke` | 토큰 폐기 | `auth.token_revoked` when matching refresh token | token limiter | DONE |
 | `POST /oauth/introspect` | 토큰 상태 검증 | `authgate_http_requests_total{method="POST",route="/oauth/introspect",status}` metric | token limiter | DONE |
 | `POST /oauth/device/authorize` | Device code 발급 | `auth.device_code_issued` | token limiter | DONE |
-| `GET /device` | Device 승인 화면 | 없음 | 없음 | N/A |
+| `GET /device` | Device 코드 입력/승인 화면 | 없음 | auth limiter | DONE |
 | `GET /device/auth/callback` | Device 로그인 완료 | `auth.login`, `auth.inactive_user` | auth limiter | DONE |
 | `POST /device/approve` | Device 승인/거부 | `auth.device_approved`, `auth.device_denied`, `auth.inactive_user` | token limiter | DONE |
 | `DELETE /account` | 계정 삭제 요청 | `auth.deletion_requested`, inactive user block | auth limiter | DONE |
@@ -139,10 +139,6 @@ audit_log
 | `DELETE /console/me/sessions/{id}` | 세션 폐기 | `auth.session_revoked` | auth limiter | DONE |
 | `POST /console/me/sessions/revoke-others` | 세션 일괄 폐기 | `auth.other_sessions_revoked` | auth limiter | DONE |
 | `GET /console/me/audit-log` | 감사 로그 조회 | `console.audit_log_viewed` | auth limiter | DONE |
-
-`PARTIAL`은 audit evidence가 전혀 없다는 뜻이 아니다. 현재 서버가 생성하는
-증거와 방어가 있지만, rate limit 또는 실패 접근 audit 같은 추가 보강 여지가
-있다는 뜻이다.
 
 ## 남은 GAP
 

--- a/docs/spec/003-device-login.md
+++ b/docs/spec/003-device-login.md
@@ -110,7 +110,7 @@ sequenceDiagram
 
 ```mermaid
 stateDiagram-v2
-    [*] --> pending: POST /device/authorize
+    [*] --> pending: POST /oauth/device/authorize
     pending --> approved: 사용자가 Allow 클릭
     pending --> denied: 사용자가 Deny 클릭
     pending --> expired: expires_at 초과

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -71,9 +71,9 @@ authgate를 처음 배포할 때 필요한 것:
 | `CLIENT_CONFIG` | X | `/etc/authgate/clients.yaml` | 클라이언트 설정 YAML 파일 경로 (없으면 무시) |
 | `MIGRATIONS_PATH` | X | `/migrations` | golang-migrate 마이그레이션 디렉터리 경로 (Docker 이미지 기본, 로컬 개발은 `./migrations`) |
 | `BRAND_NAME` | X | `authgate` | 디바이스 플로우 및 에러 페이지 좌측 상단에 표시되는 브랜드 이름 |
-| `RATE_LIMIT_TOKEN_RPS` | X | `30` | 토큰 엔드포인트 (`/oauth/token`, `/oauth/device/authorize`, `/device/approve`) 초당 허용 요청 수 |
+| `RATE_LIMIT_TOKEN_RPS` | X | `30` | 토큰성 엔드포인트 (`/oauth/token`, `/oauth/revoke`, `/oauth/introspect`, `/oauth/device/authorize`, `/device/approve`) 초당 허용 요청 수 |
 | `RATE_LIMIT_TOKEN_BURST` | X | `60` | 토큰 엔드포인트 버스트 허용 요청 수 (최솟값: 1) |
-| `RATE_LIMIT_AUTH_RPS` | X | `10` | 인증 엔드포인트 (`/authorize`, `/login`) 초당 허용 요청 수 |
+| `RATE_LIMIT_AUTH_RPS` | X | `10` | 인증/계정/console 엔드포인트 (`/authorize`, `/login`, `/login/callback`, `/mcp/*`, `/account`, `/device`, `/device/auth/callback`, `/console/*`) 초당 허용 요청 수 |
 | `RATE_LIMIT_AUTH_BURST` | X | `20` | 인증 엔드포인트 버스트 허용 요청 수 (최솟값: 1) |
 | `TRUSTED_PROXIES` | X | — | 프록시 hop으로 신뢰할 CIDR 목록 (콤마 구분). 직전 hop이 이 범위에 속할 때만 클라이언트 IP 추정에 (1) `X-Envoy-External-Address` 헤더 (envoy/istio 가 직접 계산하므로 spoof 불가), (2) `X-Forwarded-For` rightmost-untrusted walk 폴백을 사용한다. 비워두면 모든 프록시 헤더 무시. 예: `10.244.0.0/16,127.0.0.1/32`. istio ingressgateway 등 reverse proxy 뒤에서 운영할 때만 설정. |
 


### PR DESCRIPTION
## Summary
- add auth rate limiting to GET /device so user_code validation is not unlimited
- update rate-limit tests to use config-valid burst values and cover /device
- align security/operations/device-flow docs with the current routing and endpoint coverage

## Verification
- go test ./cmd/authgate
- go test ./...
- go vet ./...
- go run golang.org/x/vuln/cmd/govulncheck@latest ./...