### PR TITLE
fix(storage): add audit log lookup indexes

### DIFF
--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -299,11 +299,16 @@ UPDATE users SET status = 'disabled', updated_at = NOW() WHERE email = 'bad@exam
 SELECT * FROM audit_log WHERE event_type = 'auth.login' ORDER BY created_at DESC LIMIT 50;
 
 -- 특정 유저 이력
-SELECT * FROM audit_log WHERE user_id = 'uuid-...' ORDER BY created_at DESC;
+SELECT * FROM audit_log WHERE user_id = 'uuid-...' ORDER BY created_at DESC LIMIT 100;
 
 -- 의심스러운 이벤트
-SELECT * FROM audit_log WHERE event_type = 'auth.inactive_user' ORDER BY created_at DESC;
+SELECT * FROM audit_log WHERE event_type = 'auth.inactive_user' ORDER BY created_at DESC LIMIT 50;
 ```
+
+위 조회는 `audit_log_event_created_idx` / `audit_log_user_created_idx`를 타도록
+`event_type` 또는 `user_id` 필터와 `created_at DESC` 정렬을 함께 사용한다.
+보존 cleanup의 `created_at < cutoff` 스캔은 `audit_log_created_brin_idx`가
+보조한다.
 
 ## 모니터링
 

--- a/internal/storage/audit_test.go
+++ b/internal/storage/audit_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -100,6 +101,70 @@ func TestAuditLog_AppendOnlyGuardAllowsPIIRedactionOnly(t *testing.T) {
 	}
 }
 
+func TestAuditLogIndexes(t *testing.T) {
+	db := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	wantIndexes := map[string]string{
+		"audit_log_user_created_idx":  "btree (user_id, created_at DESC)",
+		"audit_log_event_created_idx": "btree (event_type, created_at DESC)",
+		"audit_log_created_brin_idx":  "brin (created_at)",
+	}
+
+	rows, err := db.QueryContext(ctx,
+		`SELECT indexname, indexdef
+		 FROM pg_indexes
+		 WHERE schemaname = 'public'
+		   AND tablename = 'audit_log'
+		   AND indexname IN (
+		       'audit_log_user_created_idx',
+		       'audit_log_event_created_idx',
+		       'audit_log_created_brin_idx'
+		   )`,
+	)
+	if err != nil {
+		t.Fatalf("query audit_log indexes: %v", err)
+	}
+	defer rows.Close()
+
+	found := map[string]string{}
+	for rows.Next() {
+		var name, def string
+		if err := rows.Scan(&name, &def); err != nil {
+			t.Fatalf("scan index: %v", err)
+		}
+		found[name] = def
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate indexes: %v", err)
+	}
+
+	for name, fragment := range wantIndexes {
+		def, ok := found[name]
+		if !ok {
+			t.Fatalf("missing index %s; found %#v", name, found)
+		}
+		if !strings.Contains(def, fragment) {
+			t.Fatalf("index %s definition = %q, want fragment %q", name, def, fragment)
+		}
+	}
+
+	assertPlanUsesIndex(t, db,
+		`SELECT * FROM audit_log
+		 WHERE user_id = '00000000-0000-0000-0000-000000000001'::uuid
+		 ORDER BY created_at DESC
+		 LIMIT 50`,
+		"audit_log_user_created_idx",
+	)
+	assertPlanUsesIndex(t, db,
+		`SELECT * FROM audit_log
+		 WHERE event_type = 'auth.login'
+		 ORDER BY created_at DESC
+		 LIMIT 50`,
+		"audit_log_event_created_idx",
+	)
+}
+
 func TestAuditDeviceCodeIssued(t *testing.T) {
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
@@ -148,6 +213,43 @@ func TestAuditDeviceCodeIssued(t *testing.T) {
 	}
 	if _, ok := metadata["user_code"]; ok {
 		t.Fatalf("metadata must not include user_code: %#v", metadata)
+	}
+}
+
+func assertPlanUsesIndex(t *testing.T, db *sql.DB, query, indexName string) {
+	t.Helper()
+
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin explain tx: %v", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(context.Background(), `SET LOCAL enable_seqscan = off`); err != nil {
+		t.Fatalf("disable seqscan: %v", err)
+	}
+
+	rows, err := tx.QueryContext(context.Background(), "EXPLAIN (ANALYZE, COSTS OFF) "+query)
+	if err != nil {
+		t.Fatalf("explain query: %v", err)
+	}
+	defer rows.Close()
+
+	var plan []string
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan explain: %v", err)
+		}
+		plan = append(plan, line)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate explain: %v", err)
+	}
+
+	joined := strings.Join(plan, "\n")
+	if !strings.Contains(joined, indexName) {
+		t.Fatalf("plan did not use %s:\n%s", indexName, joined)
 	}
 }
 

--- a/migrations/004_audit_log_indexes.down.sql
+++ b/migrations/004_audit_log_indexes.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS audit_log_created_brin_idx;
+DROP INDEX IF EXISTS audit_log_event_created_idx;
+DROP INDEX IF EXISTS audit_log_user_created_idx;

--- a/migrations/004_audit_log_indexes.up.sql
+++ b/migrations/004_audit_log_indexes.up.sql
@@ -1,0 +1,11 @@
+-- #213: audit_log is long-lived and queried by user timeline, event timeline,
+-- and retention cutoff. Add narrow indexes for the hot lookup paths without
+-- indexing metadata or other high-cardinality payload fields.
+CREATE INDEX audit_log_user_created_idx
+    ON audit_log (user_id, created_at DESC);
+
+CREATE INDEX audit_log_event_created_idx
+    ON audit_log (event_type, created_at DESC);
+
+CREATE INDEX audit_log_created_brin_idx
+    ON audit_log USING BRIN (created_at);


### PR DESCRIPTION
## Summary
- add audit_log lookup indexes for user timelines and event timelines
- add a BRIN index for created_at retention cutoff scans
- verify migration output and EXPLAIN ANALYZE index usage in storage integration tests
- align operations SQL examples with the indexed query shape

Closes #213

## Verification
- go test ./...
- go vet ./...
- go test -tags integration ./internal/storage -run TestAuditLogIndexes -count=1
- go test -tags integration ./internal/storage -count=1
- go run golang.org/x/vuln/cmd/govulncheck@latest ./...

## Notes
- Not tested against a production-size populated audit_log table.