### PR TITLE
fix(audit): normalize token audit event names

### DIFF
--- a/docs/security/001-audit-evidence-matrix.md
+++ b/docs/security/001-audit-evidence-matrix.md
@@ -102,7 +102,7 @@ audit_log
 | `auth.deletion_requested` | `DELETE /account` 성공 | user_id, IP, UA, created_at | 없음 | `internal/service/account.go` | `internal/service/audit_test.go` | DONE |
 | `auth.deletion_cancelled` | pending_deletion 유저 브라우저 재로그인 복구 | user_id, IP, UA, created_at | 없음 | `internal/service/login.go` | `internal/service/audit_test.go` | DONE |
 | `auth.deletion_completed` | cleanup PII scrub 완료 | user_id, created_at | 없음 | `internal/storage/cleanup_runner.go` | `internal/service/cleanup_test.go` | DONE |
-| `token.refresh` | refresh token rotation 성공 | user_id, IP, UA, created_at | `client_id`, `client_name`, `family_id` | `internal/storage/storage_auth_tokens.go` | `internal/integration/integration_audit_test.go` | DONE |
+| `auth.token_refreshed` | refresh token rotation 성공 | user_id, IP, UA, created_at | `client_id`, `client_name`, `family_id` | `internal/storage/storage_auth_tokens.go` | `internal/integration/integration_audit_test.go` | DONE |
 | `auth.logout` | RP-Initiated Logout | user_id, IP, UA, created_at | `client_id`, `client_name` | `internal/storage/storage_auth_tokens.go` | `internal/storage/storage_integration_test.go` | DONE |
 | `auth.token_revoked` | RFC 7009 revoke에서 refresh token 매칭 | user_id, IP, UA, created_at | `client_id`, `client_name` | `internal/storage/storage_auth_tokens.go` | `internal/integration/integration_audit_test.go` | DONE |
 | `auth.refresh_reuse_detected` | 폐기 refresh token 재사용 | user_id, IP, UA, created_at | `family_id` | `internal/storage/storage_auth_tokens.go` | `internal/storage/audit_test.go` | DONE |
@@ -124,7 +124,7 @@ audit_log
 | `GET /login/callback` | 인증 완료/가입 | `auth.signup`, `auth.login`, `auth.inactive_user` | auth limiter | DONE |
 | `GET /mcp/login` | MCP 인증 시작 | `auth.inactive_user`, `auth.login` 일부 경로 | auth limiter | DONE |
 | `GET /mcp/callback` | MCP 인증 완료 | `auth.login`, `auth.inactive_user` | auth limiter | DONE |
-| `POST /oauth/token` | 토큰 발급/갱신 | `token.refresh`, reuse events | token limiter | DONE |
+| `POST /oauth/token` | 토큰 발급/갱신 | `auth.token_refreshed`, reuse events | token limiter | DONE |
 | `POST /oauth/revoke` | 토큰 폐기 | `auth.token_revoked` when matching refresh token | token limiter | DONE |
 | `POST /oauth/introspect` | 토큰 상태 검증 | `authgate_http_requests_total{method="POST",route="/oauth/introspect",status}` metric | token limiter | DONE |
 | `POST /oauth/device/authorize` | Device code 발급 | `auth.device_code_issued` | token limiter | DONE |

--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -150,7 +150,7 @@ erDiagram
 | `auth.deletion_requested` | 계정 삭제 요청 | 계정 삭제 API |
 | `auth.deletion_cancelled` | 삭제 예정 계정 복구 (재로그인) | 브라우저 로그인 |
 | `auth.deletion_completed` | PII 스크러빙 완료 | cleanup 배치 |
-| `token.refresh` | refresh token rotation 성공 | 토큰 갱신 |
+| `auth.token_refreshed` | refresh token rotation 성공 | 토큰 갱신 |
 | `auth.logout` | RP-Initiated Logout | OIDC end_session |
 | `auth.token_revoked` | refresh token 폐기 | RFC 7009 revoke |
 | `auth.refresh_reuse_detected` | refresh token 재사용 감지 | 토큰 갱신 |
@@ -249,7 +249,7 @@ MCP
 | `auth.device_code_issued` | 디바이스 코드 발급 | `{client_id, client_name}` |
 | `auth.device_approved` | 디바이스 승인 | `{client_id, client_name}` |
 | `auth.device_denied` | 디바이스 거부 | `{client_id, client_name}` |
-| `token.refresh` | refresh token rotation 성공 | `{client_id, client_name, family_id}` |
+| `auth.token_refreshed` | refresh token rotation 성공 | `{client_id, client_name, family_id}` |
 | `auth.logout` | RP-Initiated Logout | `{client_id, client_name}` |
 | `auth.token_revoked` | refresh token revoke | `{client_id, client_name}` |
 | `auth.refresh_reuse_detected` | 폐기된 refresh_token 재사용 탐지 | `{family_id}` |

--- a/docs/tests/004-audit-events.md
+++ b/docs/tests/004-audit-events.md
@@ -35,6 +35,7 @@
 | `audit-016` | Console audit log 조회 | `console.audit_log_viewed` | 성공 응답 후 `metadata.page`, `metadata.limit`, `metadata.result_count` 기록 |
 | `audit-017` | Console 401/403 접근 거부 | `console.access_denied` | 401은 `user_id=NULL`, 403은 식별된 `user_id` + `metadata.user_status` 기록. `metadata.operation`, `status_code`, `reason` 포함 |
 | `audit-018` | Device code 발급 | `auth.device_code_issued` | 승인 전 단계라 `user_id=NULL`. `metadata.client_id` + `metadata.client_name`만 기록하고 `device_code`/`user_code`는 저장하지 않음 |
+| `audit-019` | refresh token rotation 성공 | `auth.token_refreshed` | `metadata.client_id`, `metadata.client_name`, `metadata.family_id` 기록 |
 
 ## 채널별 auth.login 검증
 

--- a/internal/integration/integration_audit_test.go
+++ b/internal/integration/integration_audit_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-// TestAuditEvents verifies that token.refresh, token.revoked, and auth.token_revoked events
+// TestAuditEvents verifies that auth.token_refreshed and auth.token_revoked events
 // are recorded in audit_log after the corresponding operations.
 func TestAuditEvents(t *testing.T) {
 	ts := SetupTestServer(t)
@@ -30,7 +30,7 @@ func TestAuditEvents(t *testing.T) {
 		t.Fatalf("get user: %v", err)
 	}
 
-	t.Run("token.refresh recorded after refresh grant", func(t *testing.T) {
+	t.Run("auth.token_refreshed recorded after refresh grant", func(t *testing.T) {
 		client := NewOAuthClient(t, ts.BaseURL)
 		refreshed := client.RefreshToken(tokens.RefreshToken)
 		if refreshed.StatusCode != 200 {
@@ -39,14 +39,14 @@ func TestAuditEvents(t *testing.T) {
 
 		var count int
 		err := ts.DB.QueryRowContext(ctx,
-			`SELECT COUNT(*) FROM audit_log WHERE user_id = $1::uuid AND event_type = 'token.refresh'`,
+			`SELECT COUNT(*) FROM audit_log WHERE user_id = $1::uuid AND event_type = 'auth.token_refreshed'`,
 			user.ID,
 		).Scan(&count)
 		if err != nil {
-			t.Fatalf("query audit_log for token.refresh: %v", err)
+			t.Fatalf("query audit_log for auth.token_refreshed: %v", err)
 		}
 		if count == 0 {
-			t.Error("expected at least one token.refresh audit_log row, got 0")
+			t.Error("expected at least one auth.token_refreshed audit_log row, got 0")
 		}
 	})
 

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -32,6 +32,7 @@ import (
 const (
 	EventAuthRefreshReuseDetected = "auth.refresh_reuse_detected"
 	EventAuthRefreshFamilyRevoked = "auth.refresh_family_revoked"
+	EventAuthTokenRefreshed       = "auth.token_refreshed"
 	EventAuthDeletionCompleted    = "auth.deletion_completed"
 	EventAuthLogout               = "auth.logout"
 	EventAuthTokenRevoked         = "auth.token_revoked"
@@ -46,11 +47,6 @@ const (
 	EventConsoleSessionsListed    = "console.sessions_listed"
 	EventConsoleAuditLogViewed    = "console.audit_log_viewed"
 	EventConsoleAccessDenied      = "console.access_denied"
-
-	EventTokenRefresh   = "token.refresh"
-	EventTokenRevoked   = "token.revoked"
-	EventSessionRevoked = "session.revoked"
-	EventAccountDeleted = "account.deleted"
 )
 
 var auditMetadataAllowlist = map[string]map[string]struct{}{
@@ -100,7 +96,7 @@ var auditMetadataAllowlist = map[string]map[string]struct{}{
 	EventAuthOtherSessionsRevoked: {
 		"current_session_id": {},
 	},
-	EventTokenRefresh: {
+	EventAuthTokenRefreshed: {
 		"client_id":   {},
 		"client_name": {},
 		"family_id":   {},

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -178,10 +178,10 @@ func (s *Storage) CreateAccessAndRefreshTokens(ctx context.Context, request op.T
 		return "", "", time.Time{}, err
 	}
 
-	// Audit token.refresh only when this is a refresh-token grant (not the initial code exchange).
+	// Audit token refresh only when this is a refresh-token grant (not the initial code exchange).
 	if currentRefreshToken != "" {
 		info := clientinfo.FromContext(ctx)
-		s.AuditLog(ctx, &derived.userID, EventTokenRefresh, info.IP, info.UserAgent, map[string]any{
+		s.AuditLog(ctx, &derived.userID, EventAuthTokenRefreshed, info.IP, info.UserAgent, map[string]any{
 			"client_id":   derived.clientID,
 			"client_name": s.auditClientName(ctx, derived.clientID),
 			"family_id":   derived.familyID,
@@ -441,8 +441,8 @@ func revokeRefreshFamilyOnReuse(ctx context.Context, qtx *storeq.Queries, family
 
 func (s *Storage) auditRefreshReuseDetection(ctx context.Context, userID, familyID string) {
 	info := clientinfo.FromContext(ctx)
-	s.AuditLog(ctx, &userID, "auth.refresh_reuse_detected", info.IP, info.UserAgent, map[string]any{"family_id": familyID})
-	s.AuditLog(ctx, &userID, "auth.refresh_family_revoked", info.IP, info.UserAgent, map[string]any{"family_id": familyID})
+	s.AuditLog(ctx, &userID, EventAuthRefreshReuseDetected, info.IP, info.UserAgent, map[string]any{"family_id": familyID})
+	s.AuditLog(ctx, &userID, EventAuthRefreshFamilyRevoked, info.IP, info.UserAgent, map[string]any{"family_id": familyID})
 }
 
 func (s *Storage) validateRefreshTokenRequest(ctx context.Context, tx *sql.Tx, rt *RefreshTokenModel, now time.Time) error {


### PR DESCRIPTION
## Summary
- replace the refresh-token rotation audit event with canonical `auth.token_refreshed`
- remove stale legacy Event* constants for `token.revoked`, `session.revoked`, and `account.deleted`
- use existing constants for refresh reuse/family revoke audit emission
- update integration assertions and audit docs to use the single canonical event name

Closes #210

## Verification
- go test ./...
- go test -tags integration ./internal/integration -run TestAuditEvents -count=1
- go test -tags integration ./internal/storage -run 'TestAudit010And011|TestAuditLog' -count=1\n- go vet ./...\n- go run golang.org/x/vuln/cmd/govulncheck@latest ./...\n- rg legacy event names\n\n## Notes\n- This changes newly emitted refresh rotation audit rows from `token.refresh` to `auth.token_refreshed`.\n- Historical `audit_log` rows with `token.refresh` are not migrated in this PR.