### PR TITLE
fix(audit): enrich deletion lifecycle metadata

### DIFF
--- a/docs/security/001-audit-evidence-matrix.md
+++ b/docs/security/001-audit-evidence-matrix.md
@@ -99,9 +99,9 @@ audit_log
 | `auth.device_code_issued` | Device code 발급 | user_id(NULL), IP, UA, created_at | `client_id`, `client_name` | `internal/storage/storage_oidc_device.go` | `internal/storage/audit_test.go` | DONE |
 | `auth.device_approved` | Device code 승인 | user_id, IP, UA, created_at | `client_id`, `client_name` | `internal/service/device.go` | `internal/service/audit_test.go` | DONE |
 | `auth.device_denied` | Device code 거부 | user_id, IP, UA, created_at | `client_id`, `client_name` | `internal/service/device.go` | `internal/service/audit_test.go` | DONE |
-| `auth.deletion_requested` | `DELETE /account` 성공 | user_id, IP, UA, created_at | 없음 | `internal/service/account.go` | `internal/service/audit_test.go` | DONE |
-| `auth.deletion_cancelled` | pending_deletion 유저 브라우저 재로그인 복구 | user_id, IP, UA, created_at | 없음 | `internal/service/login.go` | `internal/service/audit_test.go` | DONE |
-| `auth.deletion_completed` | cleanup PII scrub 완료 | user_id, created_at | 없음 | `internal/storage/cleanup_runner.go` | `internal/service/cleanup_test.go` | DONE |
+| `auth.deletion_requested` | `DELETE /account` 성공 | user_id, IP, UA, created_at | `channel`, `session_id`, `client_id`, `client_name` | `internal/service/account.go` | `internal/service/audit_test.go` | DONE |
+| `auth.deletion_cancelled` | pending_deletion 유저 브라우저 재로그인 복구 | user_id, IP, UA, created_at | `channel`, `session_id`, `client_id`, `client_name` | `internal/service/login.go` | `internal/service/audit_test.go` | DONE |
+| `auth.deletion_completed` | cleanup PII scrub 완료 | user_id, created_at | `reason` | `internal/storage/cleanup_runner.go` | `internal/service/cleanup_test.go` | DONE |
 | `auth.token_refreshed` | refresh token rotation 성공 | user_id, IP, UA, created_at | `client_id`, `client_name`, `family_id` | `internal/storage/storage_auth_tokens.go` | `internal/integration/integration_audit_test.go` | DONE |
 | `auth.logout` | RP-Initiated Logout | user_id, IP, UA, created_at | `client_id`, `client_name` | `internal/storage/storage_auth_tokens.go` | `internal/storage/storage_integration_test.go` | DONE |
 | `auth.token_revoked` | RFC 7009 revoke에서 refresh token 매칭 | user_id, IP, UA, created_at | `client_id`, `client_name` | `internal/storage/storage_auth_tokens.go` | `internal/integration/integration_audit_test.go` | DONE |

--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -243,9 +243,9 @@ MCP
 | `auth.signup` | 가입 | `{channel, client_id, client_name}` |
 | `auth.login` | 로그인 | `{channel, session_id, client_id, client_name, reused_session, signup}` |
 | `auth.channel_mismatch` | auth_request 채널 불일치 | `{expected_channel, actual_channel, client_id, client_name}` |
-| `auth.deletion_requested` | 탈퇴 요청 | — |
-| `auth.deletion_cancelled` | 탈퇴 취소 (로그인 복구) | — |
-| `auth.deletion_completed` | PII 스크러빙 완료 | TX 커밋 이후 best-effort 기록 |
+| `auth.deletion_requested` | 탈퇴 요청 | `{channel, session_id, client_id, client_name}` |
+| `auth.deletion_cancelled` | 탈퇴 취소 (로그인 복구) | `{channel, session_id, client_id, client_name}` |
+| `auth.deletion_completed` | PII 스크러빙 완료 | `{reason}` |
 | `auth.device_code_issued` | 디바이스 코드 발급 | `{client_id, client_name}` |
 | `auth.device_approved` | 디바이스 승인 | `{client_id, client_name}` |
 | `auth.device_denied` | 디바이스 거부 | `{client_id, client_name}` |

--- a/docs/tests/004-audit-events.md
+++ b/docs/tests/004-audit-events.md
@@ -21,9 +21,9 @@
 | `audit-002` | Browser/MCP/Device 로그인 성공 | `auth.login` | `metadata.channel`이 `browser/device/mcp` 중 하나로 기록 |
 | `audit-003` | Device 승인 | `auth.device_approved` | 승인 시 1회 기록, `metadata.client_id` + `metadata.client_name` 포함 (#205) |
 | `audit-004` | Device 거부 | `auth.device_denied` | 거부 시 1회 기록, `metadata.client_id` + `metadata.client_name` 포함 (#205) |
-| `audit-005` | DELETE /account | `auth.deletion_requested` | 삭제 요청 시 즉시 기록 |
-| `audit-006` | pending_deletion Browser 복구 | `auth.deletion_cancelled` | 자동 복구 시 기록 |
-| `audit-007` | deletion cleanup 완료 | `auth.deletion_completed` | PII 스크러빙 완료 시 기록 |
+| `audit-005` | DELETE /account | `auth.deletion_requested` | 삭제 요청 시 즉시 기록. `metadata.channel`, `session_id`, `client_id`, `client_name` 포함 (#211) |
+| `audit-006` | pending_deletion Browser 복구 | `auth.deletion_cancelled` | 자동 복구 시 기록. `metadata.channel`, `session_id`, `client_id`, `client_name` 포함 (#211) |
+| `audit-007` | deletion cleanup 완료 | `auth.deletion_completed` | PII 스크러빙 완료 시 기록. `metadata.reason=pending_deletion_expired` 포함 (#211) |
 | `audit-008` | pending_deletion/disabled/deleted 로그인 시도 | `auth.inactive_user` | `metadata.status` 포함 |
 | `audit-009` | refresh token 재사용 탐지 | `auth.refresh_reuse_detected` | `metadata.family_id` 기록 |
 | `audit-010` | family 전체 revoke | `auth.refresh_family_revoked` | `metadata.family_id` 기록 |

--- a/internal/db/queries/audit_log.sql
+++ b/internal/db/queries/audit_log.sql
@@ -8,3 +8,14 @@ VALUES (
   sqlc.arg(metadata)::jsonb,
   sqlc.arg(created_at)
 );
+
+-- name: GetAuditClientContextBySessionID :one
+SELECT
+  COALESCE(metadata->>'client_id', '')::text AS client_id,
+  COALESCE(metadata->>'client_name', '')::text AS client_name
+FROM audit_log
+WHERE user_id = NULLIF(sqlc.arg(user_id)::text, '')::uuid
+  AND event_type = 'auth.login'
+  AND metadata->>'session_id' = sqlc.arg(session_id)::text
+ORDER BY created_at DESC
+LIMIT 1;

--- a/internal/db/queries/cleanup.sql
+++ b/internal/db/queries/cleanup.sql
@@ -53,8 +53,13 @@ UPDATE users SET
 WHERE id = sqlc.arg(user_id) AND status = 'pending_deletion' AND deletion_scheduled_at < sqlc.arg(deleted_at);
 
 -- name: InsertDeletionCompletedAudit :exec
-INSERT INTO audit_log (user_id, event_type, created_at)
-VALUES (NULLIF(sqlc.arg(user_id)::text, '')::uuid, 'auth.deletion_completed', sqlc.arg(created_at));
+INSERT INTO audit_log (user_id, event_type, metadata, created_at)
+VALUES (
+  NULLIF(sqlc.arg(user_id)::text, '')::uuid,
+  'auth.deletion_completed',
+  jsonb_build_object('reason', sqlc.arg(reason)::text),
+  sqlc.arg(created_at)
+);
 
 -- name: RedactAuditLogPIIByUserID :execrows
 UPDATE audit_log

--- a/internal/db/storeq/audit_log.sql.go
+++ b/internal/db/storeq/audit_log.sql.go
@@ -11,6 +11,35 @@ import (
 	"time"
 )
 
+const getAuditClientContextBySessionID = `-- name: GetAuditClientContextBySessionID :one
+SELECT
+  COALESCE(metadata->>'client_id', '')::text AS client_id,
+  COALESCE(metadata->>'client_name', '')::text AS client_name
+FROM audit_log
+WHERE user_id = NULLIF($1::text, '')::uuid
+  AND event_type = 'auth.login'
+  AND metadata->>'session_id' = $2::text
+ORDER BY created_at DESC
+LIMIT 1
+`
+
+type GetAuditClientContextBySessionIDParams struct {
+	UserID    string
+	SessionID string
+}
+
+type GetAuditClientContextBySessionIDRow struct {
+	ClientID   string
+	ClientName string
+}
+
+func (q *Queries) GetAuditClientContextBySessionID(ctx context.Context, arg GetAuditClientContextBySessionIDParams) (GetAuditClientContextBySessionIDRow, error) {
+	row := q.db.QueryRowContext(ctx, getAuditClientContextBySessionID, arg.UserID, arg.SessionID)
+	var i GetAuditClientContextBySessionIDRow
+	err := row.Scan(&i.ClientID, &i.ClientName)
+	return i, err
+}
+
 const insertAuditLog = `-- name: InsertAuditLog :exec
 INSERT INTO audit_log (user_id, event_type, ip_address, user_agent, metadata, created_at)
 VALUES (

--- a/internal/db/storeq/cleanup.sql.go
+++ b/internal/db/storeq/cleanup.sql.go
@@ -124,17 +124,23 @@ func (q *Queries) DeleteUserIdentitiesByUserID(ctx context.Context, userID strin
 }
 
 const insertDeletionCompletedAudit = `-- name: InsertDeletionCompletedAudit :exec
-INSERT INTO audit_log (user_id, event_type, created_at)
-VALUES (NULLIF($1::text, '')::uuid, 'auth.deletion_completed', $2)
+INSERT INTO audit_log (user_id, event_type, metadata, created_at)
+VALUES (
+  NULLIF($1::text, '')::uuid,
+  'auth.deletion_completed',
+  jsonb_build_object('reason', $2::text),
+  $3
+)
 `
 
 type InsertDeletionCompletedAuditParams struct {
 	UserID    string
+	Reason    string
 	CreatedAt time.Time
 }
 
 func (q *Queries) InsertDeletionCompletedAudit(ctx context.Context, arg InsertDeletionCompletedAuditParams) error {
-	_, err := q.db.ExecContext(ctx, insertDeletionCompletedAudit, arg.UserID, arg.CreatedAt)
+	_, err := q.db.ExecContext(ctx, insertDeletionCompletedAudit, arg.UserID, arg.Reason, arg.CreatedAt)
 	return err
 }
 

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -27,6 +27,7 @@ type Querier interface {
 	DenyDeviceCodeByUserCode(ctx context.Context, userCode string) error
 	GetActiveConnectionsByUserID(ctx context.Context, arg GetActiveConnectionsByUserIDParams) ([]GetActiveConnectionsByUserIDRow, error)
 	GetActiveSessionsByUserID(ctx context.Context, arg GetActiveSessionsByUserIDParams) ([]GetActiveSessionsByUserIDRow, error)
+	GetAuditClientContextBySessionID(ctx context.Context, arg GetAuditClientContextBySessionIDParams) (GetAuditClientContextBySessionIDRow, error)
 	GetAuditLogByUserID(ctx context.Context, arg GetAuditLogByUserIDParams) ([]GetAuditLogByUserIDRow, error)
 	GetAuthRequestByCode(ctx context.Context, code sql.NullString) (GetAuthRequestByCodeRow, error)
 	GetAuthRequestByID(ctx context.Context, id string) (GetAuthRequestByIDRow, error)

--- a/internal/service/account.go
+++ b/internal/service/account.go
@@ -22,6 +22,10 @@ type AccountStore interface {
 	AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any)
 }
 
+type auditSessionClientContextStore interface {
+	GetAuditClientContextBySessionID(ctx context.Context, userID, sessionID string) (storage.AuditClientContext, error)
+}
+
 func NewAccountService(store AccountStore) *AccountService {
 	return &AccountService{store: store}
 }
@@ -72,7 +76,19 @@ func (s *AccountService) RequestDeletion(ctx context.Context, sessionID, ipAddre
 		return &AccountResult{Success: false, Message: "internal_error", ErrorCode: http.StatusInternalServerError}
 	}
 
-	s.store.AuditLog(ctx, &user.ID, "auth.deletion_requested", ipAddress, userAgent, nil)
+	s.store.AuditLog(ctx, &user.ID, storage.EventAuthDeletionRequested, ipAddress, userAgent, s.deletionRequestedMetadata(ctx, user.ID, sessionID))
 
 	return &AccountResult{Success: true, Message: "Account scheduled for deletion in 30 days. Login to cancel."}
+}
+
+func (s *AccountService) deletionRequestedMetadata(ctx context.Context, userID, sessionID string) map[string]any {
+	clientID := ""
+	clientName := ""
+	if resolver, ok := s.store.(auditSessionClientContextStore); ok {
+		if clientCtx, err := resolver.GetAuditClientContextBySessionID(ctx, userID, sessionID); err == nil {
+			clientID = clientCtx.ClientID
+			clientName = clientCtx.ClientName
+		}
+	}
+	return lifecycleAuditMetadata("browser", sessionID, clientID, clientName)
 }

--- a/internal/service/audit_helper.go
+++ b/internal/service/audit_helper.go
@@ -35,3 +35,12 @@ func resolveClientName(ctx context.Context, store clientResolver, clientID strin
 	}
 	return c.Name
 }
+
+func lifecycleAuditMetadata(channel, sessionID, clientID, clientName string) map[string]any {
+	return map[string]any{
+		"channel":     channel,
+		"session_id":  sessionID,
+		"client_id":   clientID,
+		"client_name": clientName,
+	}
+}

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -285,24 +285,42 @@ func TestAudit005_DeviceDenied(t *testing.T) {
 }
 
 func TestAudit006_DeletionRequested(t *testing.T) {
-	svc, store := setupAccountExtTest(t)
+	loginSvc, store := setupLoginService(t)
+	svc := NewAccountService(store)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-delete@test.com", EmailVerified: true, Name: "Delete", AvatarURL: "", Provider: "google", ProviderUserID: "audit-delete-sub", ProviderEmail: "audit-delete@test.com"})
+	arID, err := store.CreateTestAuthRequest(ctx, "audit-delete")
 	if err != nil {
-		t.Fatalf("create user: %v", err)
+		t.Fatalf("create auth request: %v", err)
 	}
-	sessionID, err := store.CreateSession(ctx, user.ID, 24*time.Hour)
-	if err != nil {
-		t.Fatalf("create session: %v", err)
+	loginResult := loginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "login-agent")
+	if loginResult.Action != ActionAutoApprove {
+		t.Fatalf("login action = %v, want AutoApprove", loginResult.Action)
 	}
 
-	result := svc.RequestDeletion(ctx, sessionID, "127.0.0.1", "delete-agent")
+	user, err := store.GetUserByProviderIdentity(ctx, "google", "google-sub-123")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+
+	result := svc.RequestDeletion(ctx, loginResult.SessionID, "127.0.0.1", "delete-agent")
 	if !result.Success {
 		t.Fatalf("request deletion failed: %s", result.Message)
 	}
 
-	requireSingleAuditEvent(t, store.DB(), user.ID, "auth.deletion_requested")
+	event := requireSingleAuditEvent(t, store.DB(), user.ID, storage.EventAuthDeletionRequested)
+	if event.Metadata["channel"] != "browser" {
+		t.Fatalf("channel = %v, want browser", event.Metadata["channel"])
+	}
+	if event.Metadata["session_id"] != loginResult.SessionID {
+		t.Fatalf("session_id = %v, want %s", event.Metadata["session_id"], loginResult.SessionID)
+	}
+	if event.Metadata["client_id"] != "test-app" {
+		t.Fatalf("client_id = %v, want test-app", event.Metadata["client_id"])
+	}
+	if event.Metadata["client_name"] != "Test App" {
+		t.Fatalf("client_name = %v, want Test App", event.Metadata["client_name"])
+	}
 }
 
 func TestAudit007_DeletionCancelled(t *testing.T) {
@@ -323,7 +341,19 @@ func TestAudit007_DeletionCancelled(t *testing.T) {
 		t.Fatalf("action = %v, want AutoApprove", result.Action)
 	}
 
-	requireSingleAuditEvent(t, store.DB(), user.ID, "auth.deletion_cancelled")
+	event := requireSingleAuditEvent(t, store.DB(), user.ID, storage.EventAuthDeletionCancelled)
+	if event.Metadata["channel"] != "browser" {
+		t.Fatalf("channel = %v, want browser", event.Metadata["channel"])
+	}
+	if event.Metadata["session_id"] != result.SessionID {
+		t.Fatalf("session_id = %v, want %s", event.Metadata["session_id"], result.SessionID)
+	}
+	if event.Metadata["client_id"] != "test-app" {
+		t.Fatalf("client_id = %v, want test-app", event.Metadata["client_id"])
+	}
+	if event.Metadata["client_name"] != "Test App" {
+		t.Fatalf("client_name = %v, want Test App", event.Metadata["client_name"])
+	}
 }
 
 func TestAudit009_InactiveUser(t *testing.T) {

--- a/internal/service/cleanup_test.go
+++ b/internal/service/cleanup_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -122,11 +123,17 @@ func TestCleanup_DeletionPIIScrub(t *testing.T) {
 		t.Errorf("expected 0 sessions, got %d", sessionCount)
 	}
 
-	// Audit event should exist
-	var auditCount int
-	db.QueryRowContext(ctx, `SELECT count(*) FROM audit_log WHERE user_id = $1 AND event_type = 'auth.deletion_completed'`, user.ID).Scan(&auditCount)
-	if auditCount != 1 {
-		t.Errorf("expected 1 deletion_completed audit, got %d", auditCount)
+	// Audit event should exist with a machine-readable cleanup reason.
+	var rawMetadata []byte
+	if err := db.QueryRowContext(ctx, `SELECT metadata FROM audit_log WHERE user_id = $1 AND event_type = 'auth.deletion_completed'`, user.ID).Scan(&rawMetadata); err != nil {
+		t.Fatalf("query deletion_completed audit metadata: %v", err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(rawMetadata, &metadata); err != nil {
+		t.Fatalf("decode deletion_completed metadata: %v", err)
+	}
+	if metadata["reason"] != "pending_deletion_expired" {
+		t.Errorf("deletion_completed reason = %v, want pending_deletion_expired", metadata["reason"])
 	}
 }
 

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -113,15 +113,17 @@ func (s *LoginService) handleSessionLogin(ctx context.Context, authRequestID, se
 }
 
 func (s *LoginService) handleExistingSession(ctx context.Context, user *storage.User, authRequestID, sessionID, ipAddress, userAgent string) *LoginResult {
+	recovered := false
 	switch CheckAccess(user.Status, "browser") {
 	case AccessDeny:
 		s.auditInactiveUser(ctx, user.ID, user.Status, ipAddress, userAgent)
 		return &LoginResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
 
 	case AccessRecover:
-		if err := s.recoverUser(ctx, user.ID, ipAddress, userAgent); err != nil {
+		if err := s.recoverUser(ctx, user.ID); err != nil {
 			return &LoginResult{Action: ActionError, Error: "failed to recover account", ErrorCode: http.StatusInternalServerError}
 		}
+		recovered = true
 	}
 
 	authReq, err := s.store.GetAuthRequestModel(ctx, authRequestID)
@@ -134,6 +136,9 @@ func (s *LoginService) handleExistingSession(ctx context.Context, user *storage.
 
 	if errMsg, code := verifyAuthRequestChannel(ctx, s.store, authReq, "browser", ipAddress, userAgent, &user.ID); errMsg != "" {
 		return &LoginResult{Action: ActionError, Error: errMsg, ErrorCode: code}
+	}
+	if recovered {
+		s.auditDeletionCancelled(ctx, user.ID, sessionID, authReq, ipAddress, userAgent)
 	}
 
 	if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
@@ -187,7 +192,7 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 		return &CallbackResult{Action: ActionError, Error: "upstream_error", ErrorCode: http.StatusInternalServerError}
 	}
 
-	user, signedUp, result := s.prepareBrowserCallbackUser(ctx, userInfo, authReq, ipAddress, userAgent)
+	user, signedUp, recovered, result := s.prepareBrowserCallbackUser(ctx, userInfo, authReq, ipAddress, userAgent)
 	if result != nil {
 		return result
 	}
@@ -195,6 +200,9 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 	sessionID, err := s.store.CreateSession(ctx, user.ID, s.sessionTTL)
 	if err != nil {
 		return &CallbackResult{Action: ActionError, Error: "session creation failed", ErrorCode: http.StatusInternalServerError}
+	}
+	if recovered {
+		s.auditDeletionCancelled(ctx, user.ID, sessionID, authReq, ipAddress, userAgent)
 	}
 
 	if err := s.store.CompleteAuthRequest(ctx, authRequestID, user.ID); err != nil {
@@ -217,22 +225,22 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 // request context — duplicate getCallbackAuthRequest calls would otherwise
 // race against expiration/cleanup between fetch and audit (Codex review NIT
 // on PR #218).
-func (s *LoginService) prepareBrowserCallbackUser(ctx context.Context, userInfo *upstream.UserInfo, authReq *storage.AuthRequestModel, ipAddress, userAgent string) (*storage.User, bool, *CallbackResult) {
+func (s *LoginService) prepareBrowserCallbackUser(ctx context.Context, userInfo *upstream.UserInfo, authReq *storage.AuthRequestModel, ipAddress, userAgent string) (*storage.User, bool, bool, *CallbackResult) {
 	providerName := s.browserProvider.Name()
 	user, err := s.store.GetUserByProviderIdentity(ctx, providerName, userInfo.Sub)
 	if errors.Is(err, storage.ErrNotFound) {
 		user, result := s.signupBrowserUser(ctx, providerName, userInfo, authReq, ipAddress, userAgent)
-		return user, true, result
+		return user, true, false, result
 	}
 	if err != nil {
-		return nil, false, &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
+		return nil, false, false, &CallbackResult{Action: ActionError, Error: "internal_error", ErrorCode: http.StatusInternalServerError}
 	}
 
-	user, result := s.ensureBrowserAccess(ctx, user, ipAddress, userAgent)
+	user, recovered, result := s.ensureBrowserAccess(ctx, user, ipAddress, userAgent)
 	if result != nil {
-		return nil, false, result
+		return nil, false, false, result
 	}
-	return user, false, nil
+	return user, false, recovered, nil
 }
 
 func (s *LoginService) getCallbackAuthRequest(ctx context.Context, authRequestID string) (*storage.AuthRequestModel, *CallbackResult) {
@@ -250,12 +258,8 @@ func (s *LoginService) redirectToProvider(authRequestID string) *LoginResult {
 	return &LoginResult{Action: ActionRedirectToIdP, RedirectURL: s.browserProvider.AuthURL(authRequestID)}
 }
 
-func (s *LoginService) recoverUser(ctx context.Context, userID, ipAddress, userAgent string) error {
-	if err := s.store.RecoverUser(ctx, userID); err != nil {
-		return err
-	}
-	s.store.AuditLog(ctx, &userID, "auth.deletion_cancelled", ipAddress, userAgent, nil)
-	return nil
+func (s *LoginService) recoverUser(ctx context.Context, userID string) error {
+	return s.store.RecoverUser(ctx, userID)
 }
 
 func (s *LoginService) signupBrowserUser(ctx context.Context, providerName string, userInfo *upstream.UserInfo, authReq *storage.AuthRequestModel, ipAddress, userAgent string) (*storage.User, *CallbackResult) {
@@ -285,24 +289,33 @@ func (s *LoginService) signupBrowserUser(ctx context.Context, providerName strin
 	return user, nil
 }
 
-func (s *LoginService) ensureBrowserAccess(ctx context.Context, user *storage.User, ipAddress, userAgent string) (*storage.User, *CallbackResult) {
+func (s *LoginService) ensureBrowserAccess(ctx context.Context, user *storage.User, ipAddress, userAgent string) (*storage.User, bool, *CallbackResult) {
 	switch CheckAccess(user.Status, "browser") {
 	case AccessDeny:
 		s.auditInactiveUser(ctx, user.ID, user.Status, ipAddress, userAgent)
-		return nil, &CallbackResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
+		return nil, false, &CallbackResult{Action: ActionError, Error: "account_inactive", ErrorCode: http.StatusForbidden}
 	case AccessRecover:
-		if err := s.recoverUser(ctx, user.ID, ipAddress, userAgent); err != nil {
-			return nil, &CallbackResult{Action: ActionError, Error: "recovery failed", ErrorCode: http.StatusInternalServerError}
+		if err := s.recoverUser(ctx, user.ID); err != nil {
+			return nil, false, &CallbackResult{Action: ActionError, Error: "recovery failed", ErrorCode: http.StatusInternalServerError}
 		}
 
 		recoveredUser, err := s.store.GetUserByID(ctx, user.ID)
 		if err != nil {
-			return nil, &CallbackResult{Action: ActionError, Error: "failed to read user after recovery", ErrorCode: http.StatusInternalServerError}
+			return nil, false, &CallbackResult{Action: ActionError, Error: "failed to read user after recovery", ErrorCode: http.StatusInternalServerError}
 		}
-		return recoveredUser, nil
+		return recoveredUser, true, nil
 	default:
-		return user, nil
+		return user, false, nil
 	}
+}
+
+func (s *LoginService) auditDeletionCancelled(ctx context.Context, userID, sessionID string, authReq *storage.AuthRequestModel, ipAddress, userAgent string) {
+	s.store.AuditLog(ctx, &userID, storage.EventAuthDeletionCancelled, ipAddress, userAgent, lifecycleAuditMetadata(
+		"browser",
+		sessionID,
+		authReq.ClientID,
+		resolveClientName(ctx, s.store, authReq.ClientID),
+	))
 }
 
 func (s *LoginService) auditInactiveUser(ctx context.Context, userID, status, ipAddress, userAgent string) {

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -2,7 +2,9 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net"
 	"net/netip"
@@ -33,6 +35,8 @@ const (
 	EventAuthRefreshReuseDetected = "auth.refresh_reuse_detected"
 	EventAuthRefreshFamilyRevoked = "auth.refresh_family_revoked"
 	EventAuthTokenRefreshed       = "auth.token_refreshed"
+	EventAuthDeletionRequested    = "auth.deletion_requested"
+	EventAuthDeletionCancelled    = "auth.deletion_cancelled"
 	EventAuthDeletionCompleted    = "auth.deletion_completed"
 	EventAuthLogout               = "auth.logout"
 	EventAuthTokenRevoked         = "auth.token_revoked"
@@ -73,6 +77,21 @@ var auditMetadataAllowlist = map[string]map[string]struct{}{
 		"status":  {},
 		"channel": {},
 		"phase":   {},
+	},
+	EventAuthDeletionRequested: {
+		"channel":     {},
+		"client_id":   {},
+		"client_name": {},
+		"session_id":  {},
+	},
+	EventAuthDeletionCancelled: {
+		"channel":     {},
+		"client_id":   {},
+		"client_name": {},
+		"session_id":  {},
+	},
+	EventAuthDeletionCompleted: {
+		"reason": {},
 	},
 	"auth.device_denied": {
 		"client_id":   {},
@@ -174,6 +193,25 @@ func (s *Storage) auditClientName(ctx context.Context, clientID string) string {
 		return ""
 	}
 	return c.Name
+}
+
+type AuditClientContext struct {
+	ClientID   string
+	ClientName string
+}
+
+func (s *Storage) GetAuditClientContextBySessionID(ctx context.Context, userID, sessionID string) (AuditClientContext, error) {
+	row, err := storeq.New(s.db).GetAuditClientContextBySessionID(ctx, storeq.GetAuditClientContextBySessionIDParams{
+		UserID:    userID,
+		SessionID: sessionID,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return AuditClientContext{}, ErrNotFound
+	}
+	if err != nil {
+		return AuditClientContext{}, err
+	}
+	return AuditClientContext{ClientID: row.ClientID, ClientName: row.ClientName}, nil
 }
 
 // AuditLog records a security/audit event on a best-effort basis. Failures are

--- a/internal/storage/cleanup_runner.go
+++ b/internal/storage/cleanup_runner.go
@@ -145,6 +145,7 @@ func (r *CleanupRunner) DeleteUser(
 
 	if err := storeq.New(r.db).InsertDeletionCompletedAudit(ctx, storeq.InsertDeletionCompletedAuditParams{
 		UserID:    userID,
+		Reason:    "pending_deletion_expired",
 		CreatedAt: now,
 	}); err != nil {
 		slog.ErrorContext(ctx, "audit log: insert deletion_completed",


### PR DESCRIPTION
## Summary
- Add session/client metadata to deletion requested and cancelled audit rows.
- Record `reason: pending_deletion_expired` on deletion completed audit rows.
- Cover the new deletion lifecycle audit metadata in service integration tests and existing audit docs.

Closes #211

## Verification
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `docker run --rm -v /Users/kangheeyong/project/authgate:/src -w /src sqlc/sqlc:1.28.0 vet`
- `go test -tags integration ./internal/service -run 'TestAudit006|TestAudit007|TestCleanup_DeletionPIIScrub' -count=1`