### PR TITLE
fix(observability): expose security audit metrics

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -96,6 +96,7 @@ func main() {
 	httpMetrics := observability.NewHTTPMetrics()
 	auditMetrics := observability.NewAuditMetrics(httpMetrics.Registry())
 	store.SetAuditFailureRecorder(auditMetrics)
+	store.SetAuditEventRecorder(auditMetrics)
 	registerRoutes(mux, cfg, db, store, provider, loginHandler, deviceHandler, accountHandler, mcpLoginHandler, consoleHandler, httpMetrics, &isShuttingDown)
 
 	trustedProxies, err := clientinfo.ParseTrustedProxies(cfg.TrustedProxies)
@@ -114,7 +115,7 @@ func main() {
 	var inflightRequests int64
 	srv, addr := buildHTTPServer(cfg, requestIDHandler, httpMetrics, &inflightRequests)
 
-	cleanupCancel := startCleanupService(db, clk, cfg.AuditLogPIIRetention)
+	cleanupCancel := startCleanupService(db, clk, cfg.AuditLogPIIRetention, auditMetrics)
 	defer cleanupCancel()
 	installGracefulShutdown(srv, cfg, &inflightRequests, cleanupCancel, &isShuttingDown)
 
@@ -462,10 +463,11 @@ func buildHTTPServer(cfg *config.Config, mux http.Handler, httpMetrics *observab
 	}, addr
 }
 
-func startCleanupService(db *sql.DB, clk clock.Clock, auditLogPIIRetention time.Duration) context.CancelFunc {
+func startCleanupService(db *sql.DB, clk clock.Clock, auditLogPIIRetention time.Duration, metrics *observability.AuditMetrics) context.CancelFunc {
 	cleanupRunner := storage.NewCleanupRunner(db)
 	cleanupSvc := service.NewCleanupService(cleanupRunner, clk, 10*time.Minute)
 	cleanupSvc.SetAuditLogPIIRetention(auditLogPIIRetention)
+	cleanupSvc.SetMetricsRecorder(metrics)
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
 	go cleanupSvc.Start(cleanupCtx)
 	return cleanupCancel

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -346,10 +346,39 @@ SELECT * FROM audit_log WHERE event_type = 'auth.inactive_user' ORDER BY created
 |--------|--------|------|
 | `authgate_audit_log_write_failures_total` | `stage="marshal"` | `json.Marshal(metadata)` 실패 — 호출자 입력 형상 버그 |
 | `authgate_audit_log_write_failures_total` | `stage="insert"` | `audit_log INSERT` 실패 — DB outage / 권한 / 디스크 |
+| `authgate_audit_events_total` | `event_type`, `channel` | 성공적으로 저장된 audit event 수. channel이 없는 이벤트는 `channel="unknown"` |
+| `authgate_cleanup_runs_total` | `result="success"` / `result="failure"` | cleanup run 성공/실패 수 |
 
 PrometheusRule 예시:
 
 ```yaml
+- alert: AuthgateRefreshReuseBurst
+  expr: sum(increase(authgate_audit_events_total{event_type="auth.refresh_reuse_detected"}[5m])) > 3
+  for: 1m
+  labels:
+    severity: critical
+  annotations:
+    summary: "refresh token reuse detected repeatedly"
+    description: "5분 내 refresh token reuse가 반복 탐지됨. 계정 탈취 또는 토큰 유출 가능성 조사."
+
+- alert: AuthgateChannelMismatchBurst
+  expr: sum by (channel) (increase(authgate_audit_events_total{event_type="auth.channel_mismatch"}[5m])) > 10
+  for: 2m
+  labels:
+    severity: warning
+  annotations:
+    summary: "auth channel mismatch burst (channel={{ $labels.channel }})"
+    description: "브라우저/MCP/device 채널 정책 위반이 급증. 잘못된 client 설정 또는 공격성 흐름 확인."
+
+- alert: AuthgateCleanupStale
+  expr: increase(authgate_cleanup_runs_total{result="success"}[30m]) == 0
+  for: 10m
+  labels:
+    severity: warning
+  annotations:
+    summary: "authgate cleanup has not completed recently"
+    description: "최근 30분 동안 cleanup 성공 run이 없음. pending deletion, 만료 세션, audit PII 정리가 지연될 수 있음."
+
 - alert: AuthgateAuditWriteFailures
   expr: increase(authgate_audit_log_write_failures_total[5m]) > 0
   for: 1m

--- a/internal/observability/audit_metrics.go
+++ b/internal/observability/audit_metrics.go
@@ -4,11 +4,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// AuditMetrics owns Prometheus counters for audit-log write outcomes.
+// AuditMetrics owns Prometheus counters for security-relevant audit and
+// cleanup outcomes.
 // It registers into the shared HTTPMetrics registry so a single /metrics
 // scrape target exposes both groups.
 type AuditMetrics struct {
+	events        *prometheus.CounterVec
 	writeFailures *prometheus.CounterVec
+	cleanupRuns   *prometheus.CounterVec
 }
 
 // NewAuditMetrics registers audit-log counters into reg and returns a recorder.
@@ -17,20 +20,53 @@ type AuditMetrics struct {
 // rules distinguish input-shape bugs from DB outages so an oncall responder
 // can route the page correctly.
 func NewAuditMetrics(reg *prometheus.Registry) *AuditMetrics {
-	cv := prometheus.NewCounterVec(
+	events := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "authgate_audit_events_total",
+			Help: "Total number of successfully persisted audit events, partitioned by event_type and channel.",
+		},
+		[]string{"event_type", "channel"},
+	)
+
+	writeFailures := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "authgate_audit_log_write_failures_total",
 			Help: "Total number of audit log write failures, partitioned by stage (marshal|insert).",
 		},
 		[]string{"stage"},
 	)
-	reg.MustRegister(cv)
+
+	cleanupRuns := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "authgate_cleanup_runs_total",
+			Help: "Total number of cleanup service runs, partitioned by result (success|failure).",
+		},
+		[]string{"result"},
+	)
+
+	reg.MustRegister(events, writeFailures, cleanupRuns)
 	// Pre-create the known label series so increase()/rate() see a baseline
 	// of 0 from the first scrape — otherwise the alert in
 	// docs/spec/009-operations.md would miss the very first failure.
-	cv.WithLabelValues("marshal")
-	cv.WithLabelValues("insert")
-	return &AuditMetrics{writeFailures: cv}
+	writeFailures.WithLabelValues("marshal")
+	writeFailures.WithLabelValues("insert")
+	cleanupRuns.WithLabelValues("success")
+	cleanupRuns.WithLabelValues("failure")
+	return &AuditMetrics{
+		events:        events,
+		writeFailures: writeFailures,
+		cleanupRuns:   cleanupRuns,
+	}
+}
+
+// RecordEvent increments the audit-event counter after the audit row is
+// successfully persisted. Nil receivers are tolerated so tests can omit the
+// recorder entirely.
+func (m *AuditMetrics) RecordEvent(eventType, channel string) {
+	if m == nil {
+		return
+	}
+	m.events.WithLabelValues(eventType, channel).Inc()
 }
 
 // RecordWriteFailure increments the failure counter for the given stage.
@@ -42,4 +78,14 @@ func (m *AuditMetrics) RecordWriteFailure(stage string) {
 		return
 	}
 	m.writeFailures.WithLabelValues(stage).Inc()
+}
+
+// RecordCleanupRun increments the cleanup run counter for "success" or
+// "failure". Other result labels are accepted but will not match the stock
+// alert examples.
+func (m *AuditMetrics) RecordCleanupRun(result string) {
+	if m == nil {
+		return
+	}
+	m.cleanupRuns.WithLabelValues(result).Inc()
 }

--- a/internal/observability/audit_metrics_test.go
+++ b/internal/observability/audit_metrics_test.go
@@ -1,0 +1,67 @@
+package observability
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestAuditMetrics_RecordSecurityCounters(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewAuditMetrics(reg)
+
+	m.RecordEvent("auth.inactive_user", "browser")
+	m.RecordWriteFailure("insert")
+	m.RecordCleanupRun("success")
+
+	assertCounterValue(t, reg, "authgate_audit_events_total", map[string]string{
+		"event_type": "auth.inactive_user",
+		"channel":    "browser",
+	}, 1)
+	assertCounterValue(t, reg, "authgate_audit_log_write_failures_total", map[string]string{
+		"stage": "insert",
+	}, 1)
+	assertCounterValue(t, reg, "authgate_cleanup_runs_total", map[string]string{
+		"result": "success",
+	}, 1)
+}
+
+func assertCounterValue(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string, want float64) {
+	t.Helper()
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if !metricHasLabels(metric.GetLabel(), labels) {
+				continue
+			}
+			if got := metric.GetCounter().GetValue(); got != want {
+				t.Fatalf("%s labels %v = %v, want %v", name, labels, got, want)
+			}
+			return
+		}
+	}
+
+	t.Fatalf("missing %s labels %v", name, labels)
+}
+
+func metricHasLabels(gotLabels []*dto.LabelPair, want map[string]string) bool {
+	got := make(map[string]string, len(gotLabels))
+	for _, label := range gotLabels {
+		got[label.GetName()] = label.GetValue()
+	}
+	for key, value := range want {
+		if got[key] != value {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/observability/http_metrics.go
+++ b/internal/observability/http_metrics.go
@@ -12,8 +12,6 @@ import (
 	"github.com/kangheeyong/authgate/internal/middleware"
 )
 
-
-
 type HTTPMetrics struct {
 	registry       *prometheus.Registry
 	requestsTotal  *prometheus.CounterVec

--- a/internal/service/cleanup.go
+++ b/internal/service/cleanup.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -20,12 +21,23 @@ type cleanupRunner interface {
 	DeleteUser(ctx context.Context, userID string, now time.Time, hook func(ctx context.Context, userID string) error) error
 }
 
+// CleanupMetricsRecorder receives a signal when a cleanup run completes or
+// fails before completion. main.go wires observability.AuditMetrics.
+type CleanupMetricsRecorder interface {
+	RecordCleanupRun(result string)
+}
+
+type noopCleanupMetricsRecorder struct{}
+
+func (noopCleanupMetricsRecorder) RecordCleanupRun(string) {}
+
 type CleanupService struct {
 	runner            cleanupRunner
 	clock             clock.Clock
 	interval          time.Duration
 	auditPIIRetention time.Duration
 	deleteUserHook    func(ctx context.Context, userID string) error
+	metrics           CleanupMetricsRecorder
 }
 
 func NewCleanupService(runner cleanupRunner, clk clock.Clock, interval time.Duration) *CleanupService {
@@ -34,6 +46,7 @@ func NewCleanupService(runner cleanupRunner, clk clock.Clock, interval time.Dura
 		clock:             clk,
 		interval:          interval,
 		auditPIIRetention: 3 * 365 * 24 * time.Hour,
+		metrics:           noopCleanupMetricsRecorder{},
 	}
 }
 
@@ -41,6 +54,14 @@ func (c *CleanupService) SetAuditLogPIIRetention(retention time.Duration) {
 	if retention > 0 {
 		c.auditPIIRetention = retention
 	}
+}
+
+func (c *CleanupService) SetMetricsRecorder(r CleanupMetricsRecorder) {
+	if r == nil {
+		c.metrics = noopCleanupMetricsRecorder{}
+		return
+	}
+	c.metrics = r
 }
 
 // Start runs cleanup jobs periodically until ctx is cancelled.
@@ -65,6 +86,7 @@ func (c *CleanupService) Start(ctx context.Context) {
 func (c *CleanupService) runAll(ctx context.Context) {
 	acquired, err := c.runner.WithExclusiveLock(ctx, c.runAllLocked)
 	if err != nil {
+		c.metrics.RecordCleanupRun("failure")
 		slog.Error("cleanup run failed", "error", err)
 		return
 	}
@@ -72,19 +94,23 @@ func (c *CleanupService) runAll(ctx context.Context) {
 		slog.Info("cleanup skipped: advisory lock not acquired")
 		return
 	}
+	c.metrics.RecordCleanupRun("success")
 }
 
 func (c *CleanupService) runAllLocked(ctx context.Context) error {
 	now := c.clock.Now()
+	var runErr error
 
 	// 1. Token cleanup: revoked/expired refresh_tokens after 30 days
 	if n, err := c.runner.DeleteRevokedRefreshTokensBefore(ctx, now.Add(-30*24*time.Hour)); err != nil {
+		runErr = errors.Join(runErr, err)
 		slog.Error("token cleanup (revoked)", "error", err)
 	} else if n > 0 {
 		slog.Info("token cleanup (revoked)", "deleted", n)
 	}
 
 	if n, err := c.runner.DeleteExpiredRefreshTokensBefore(ctx, now.Add(-30*24*time.Hour)); err != nil {
+		runErr = errors.Join(runErr, err)
 		slog.Error("token cleanup (expired)", "error", err)
 	} else if n > 0 {
 		slog.Info("token cleanup (expired)", "deleted", n)
@@ -92,6 +118,7 @@ func (c *CleanupService) runAllLocked(ctx context.Context) error {
 
 	// 2. Session cleanup: expired or revoked sessions
 	if n, err := c.runner.DeleteExpiredOrRevokedSessions(ctx, now); err != nil {
+		runErr = errors.Join(runErr, err)
 		slog.Error("session cleanup", "error", err)
 	} else if n > 0 {
 		slog.Info("session cleanup", "deleted", n)
@@ -99,6 +126,7 @@ func (c *CleanupService) runAllLocked(ctx context.Context) error {
 
 	// 3. Temp data cleanup: auth_requests expired > 1 hour
 	if n, err := c.runner.DeleteExpiredAuthRequestsBefore(ctx, now.Add(-1*time.Hour)); err != nil {
+		runErr = errors.Join(runErr, err)
 		slog.Error("auth_requests cleanup", "error", err)
 	} else if n > 0 {
 		slog.Info("auth_requests cleanup", "deleted", n)
@@ -106,6 +134,7 @@ func (c *CleanupService) runAllLocked(ctx context.Context) error {
 
 	// 4. Temp data cleanup: device_codes expired > 1 hour
 	if n, err := c.runner.DeleteExpiredDeviceCodesBefore(ctx, now.Add(-1*time.Hour)); err != nil {
+		runErr = errors.Join(runErr, err)
 		slog.Error("device_codes cleanup", "error", err)
 	} else if n > 0 {
 		slog.Info("device_codes cleanup", "deleted", n)
@@ -114,10 +143,12 @@ func (c *CleanupService) runAllLocked(ctx context.Context) error {
 	// 5. Deletion cleanup: pending_deletion users past scheduled date → PII scrub
 	userIDs, err := c.runner.ListPendingDeletionUserIDsBefore(ctx, now)
 	if err != nil {
+		runErr = errors.Join(runErr, err)
 		slog.Error("deletion cleanup query", "error", err)
 	} else {
 		for _, userID := range userIDs {
 			if err := c.deleteUser(ctx, userID, now); err != nil {
+				runErr = errors.Join(runErr, err)
 				slog.Error("deletion cleanup", "user_id", userID, "error", err)
 			} else {
 				slog.Info("deletion cleanup", "user_id", userID)
@@ -127,11 +158,12 @@ func (c *CleanupService) runAllLocked(ctx context.Context) error {
 
 	// 6. Audit log PII anonymization: user_id/IP/User-Agent NULL after the configured retention.
 	if n, err := c.runner.AnonymizeAuditLogBefore(ctx, now.Add(-c.auditPIIRetention)); err != nil {
+		runErr = errors.Join(runErr, err)
 		slog.Error("audit_log anonymization", "error", err)
 	} else if n > 0 {
 		slog.Info("audit_log anonymization", "anonymized", n)
 	}
-	return nil
+	return runErr
 }
 
 // deleteUser performs Spec 006 stage 3: explicit DELETE of child records + PII scrub.

--- a/internal/service/cleanup_unit_test.go
+++ b/internal/service/cleanup_unit_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 type cleanupRunnerStub struct {
 	lockAcquired    bool
 	lockErr         error
+	revokedErr      error
 	lockCalls       int
 	cleanupCallHits int
 }
@@ -28,7 +30,7 @@ func (s *cleanupRunnerStub) WithExclusiveLock(ctx context.Context, fn func(conte
 
 func (s *cleanupRunnerStub) DeleteRevokedRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
 	s.cleanupCallHits++
-	return 0, nil
+	return 0, s.revokedErr
 }
 
 func (s *cleanupRunnerStub) DeleteExpiredRefreshTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -92,4 +94,38 @@ func TestCleanupRunAll_ReleasesLockAfterRun(t *testing.T) {
 	if runner.cleanupCallHits == 0 {
 		t.Fatal("cleanup calls = 0, want > 0 when lock acquired")
 	}
+}
+
+func TestCleanupRunAll_RecordsSuccessMetric(t *testing.T) {
+	runner := &cleanupRunnerStub{lockAcquired: true}
+	rec := &cleanupMetricsRecorderStub{}
+	svc := NewCleanupService(runner, &clock.FixedClock{T: time.Now()}, time.Minute)
+	svc.SetMetricsRecorder(rec)
+
+	svc.RunOnce(context.Background())
+
+	if got := rec.results; len(got) != 1 || got[0] != "success" {
+		t.Fatalf("cleanup metric results = %v, want [success]", got)
+	}
+}
+
+func TestCleanupRunAll_RecordsFailureMetric(t *testing.T) {
+	runner := &cleanupRunnerStub{lockAcquired: true, revokedErr: errors.New("cleanup failed")}
+	rec := &cleanupMetricsRecorderStub{}
+	svc := NewCleanupService(runner, &clock.FixedClock{T: time.Now()}, time.Minute)
+	svc.SetMetricsRecorder(rec)
+
+	svc.RunOnce(context.Background())
+
+	if got := rec.results; len(got) != 1 || got[0] != "failure" {
+		t.Fatalf("cleanup metric results = %v, want [failure]", got)
+	}
+}
+
+type cleanupMetricsRecorderStub struct {
+	results []string
+}
+
+func (s *cleanupMetricsRecorderStub) RecordCleanupRun(result string) {
+	s.results = append(s.results, result)
 }

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -251,7 +251,9 @@ func (s *Storage) AuditLog(ctx context.Context, userID *string, eventType, ipAdd
 			"user_id", userIDLogValue(userID),
 			"error", err,
 		)
+		return
 	}
+	s.auditEventRec.RecordEvent(eventType, auditMetricChannel(metadata))
 }
 
 func sanitizeAuditMetadata(ctx context.Context, eventType string, metadata map[string]any) map[string]any {
@@ -287,6 +289,28 @@ func sanitizeAuditMetadata(ctx context.Context, eventType string, metadata map[s
 		return nil
 	}
 	return sanitized
+}
+
+func auditMetricChannel(metadata map[string]any) string {
+	if channel, ok := stringMetadataValue(metadata, "channel"); ok {
+		return channel
+	}
+	if channel, ok := stringMetadataValue(metadata, "actual_channel"); ok {
+		return channel
+	}
+	return "unknown"
+}
+
+func stringMetadataValue(metadata map[string]any, key string) (string, bool) {
+	value, ok := metadata[key]
+	if !ok {
+		return "", false
+	}
+	text, ok := value.(string)
+	if !ok || text == "" {
+		return "", false
+	}
+	return text, true
 }
 
 func userIDLogValue(userID *string) string {

--- a/internal/storage/audit_test.go
+++ b/internal/storage/audit_test.go
@@ -101,6 +101,29 @@ func TestAuditLog_AppendOnlyGuardAllowsPIIRedactionOnly(t *testing.T) {
 	}
 }
 
+func TestAuditLog_SuccessIncrementsEventRecorder(t *testing.T) {
+	db := testutil.SetupPostgres(t)
+	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
+	store := New(db, clk, idgen.CryptoGenerator{}, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
+	rec := &fakeAuditEventRecorder{}
+	store.SetAuditEventRecorder(rec)
+	ctx := context.Background()
+
+	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "audit-metric@test.com", EmailVerified: true, Name: "Audit Metric", AvatarURL: "", Provider: "google", ProviderUserID: "audit-metric-sub", ProviderEmail: "audit-metric@test.com"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	store.AuditLog(ctx, &user.ID, "auth.inactive_user", "198.51.100.10", "metric-agent", map[string]any{"status": "disabled", "channel": "browser"})
+
+	if len(rec.events) != 1 {
+		t.Fatalf("recorded events = %d, want 1", len(rec.events))
+	}
+	if got := rec.events[0]; got != (auditEventRecord{eventType: "auth.inactive_user", channel: "browser"}) {
+		t.Fatalf("recorded event = %+v", got)
+	}
+}
+
 func TestAuditLogIndexes(t *testing.T) {
 	db := testutil.SetupPostgres(t)
 	ctx := context.Background()
@@ -272,4 +295,17 @@ func requireStorageAuditEvent(t *testing.T, db *sql.DB, userID, eventType string
 		}
 	}
 	return metadata
+}
+
+type auditEventRecord struct {
+	eventType string
+	channel   string
+}
+
+type fakeAuditEventRecorder struct {
+	events []auditEventRecord
+}
+
+func (f *fakeAuditEventRecorder) RecordEvent(eventType, channel string) {
+	f.events = append(f.events, auditEventRecord{eventType: eventType, channel: channel})
 }

--- a/internal/storage/audit_unit_test.go
+++ b/internal/storage/audit_unit_test.go
@@ -77,3 +77,25 @@ func TestSanitizeAuditMetadata_EmptyResultReturnsNil(t *testing.T) {
 		t.Fatalf("disallowed-only metadata = %#v, want nil", got)
 	}
 }
+
+func TestAuditMetricChannel(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]any
+		want     string
+	}{
+		{name: "channel", metadata: map[string]any{"channel": "browser"}, want: "browser"},
+		{name: "actual channel fallback", metadata: map[string]any{"actual_channel": "mcp"}, want: "mcp"},
+		{name: "missing", metadata: map[string]any{"family_id": "fam-1"}, want: "unknown"},
+		{name: "non string", metadata: map[string]any{"channel": 42}, want: "unknown"},
+		{name: "nil", metadata: nil, want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := auditMetricChannel(tt.metadata); got != tt.want {
+				t.Fatalf("auditMetricChannel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -58,9 +58,20 @@ type AuditFailureRecorder interface {
 	RecordWriteFailure(stage string)
 }
 
+// AuditEventRecorder receives an event after an audit-log row is successfully
+// persisted. main.go wires observability.AuditMetrics so security-sensitive
+// event bursts are visible from /metrics.
+type AuditEventRecorder interface {
+	RecordEvent(eventType, channel string)
+}
+
 type noopAuditFailureRecorder struct{}
 
 func (noopAuditFailureRecorder) RecordWriteFailure(string) {}
+
+type noopAuditEventRecorder struct{}
+
+func (noopAuditEventRecorder) RecordEvent(string, string) {}
 
 type Storage struct {
 	db              *sql.DB
@@ -90,6 +101,9 @@ type Storage struct {
 	// or insert. Defaults to a no-op in New() so call sites never need a nil
 	// guard; main.go installs observability.AuditMetrics at startup.
 	auditFailureRec AuditFailureRecorder
+	// auditEventRec receives a signal after a successful AuditLog insert.
+	// Defaults to a no-op for tests that construct Storage directly.
+	auditEventRec AuditEventRecorder
 }
 
 func New(db *sql.DB, clk clock.Clock, gen idgen.IDGenerator, checker StateChecker, accessTTL, refreshTTL time.Duration) *Storage {
@@ -102,6 +116,7 @@ func New(db *sql.DB, clk clock.Clock, gen idgen.IDGenerator, checker StateChecke
 		refreshTokenTTL:    refreshTTL,
 		devicePollInterval: 5 * time.Second,
 		auditFailureRec:    noopAuditFailureRecorder{},
+		auditEventRec:      noopAuditEventRecorder{},
 	}
 	s.clientPolicy = NewCoreClientResolutionPolicy(s)
 	s.resourcePolicy = NewCoreResourceBindingPolicy()
@@ -125,6 +140,16 @@ func (s *Storage) SetAuditFailureRecorder(r AuditFailureRecorder) {
 		return
 	}
 	s.auditFailureRec = r
+}
+
+// SetAuditEventRecorder installs a metric recorder that AuditLog invokes after
+// a successful row insert. Passing nil resets to the no-op recorder.
+func (s *Storage) SetAuditEventRecorder(r AuditEventRecorder) {
+	if r == nil {
+		s.auditEventRec = noopAuditEventRecorder{}
+		return
+	}
+	s.auditEventRec = r
 }
 
 // SetSigningKey sets the current RSA signing key used for JWT issuance.


### PR DESCRIPTION
## Summary
- Add `authgate_audit_events_total{event_type,channel}` for successfully persisted audit rows.
- Add `authgate_cleanup_runs_total{result}` for cleanup success/failure visibility.
- Wire the new counters into the existing `/metrics` registry and document alert examples for reuse bursts, channel mismatches, cleanup stale runs, and audit write failures.

Closes #207

## Verification
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `go test -tags integration ./internal/storage -run TestAuditLog_SuccessIncrementsEventRecorder -count=1`
- `go test -tags integration ./internal/service -run TestCleanup -count=1`