### PR TITLE
refactor(observability): centralize metrics registry

### DIFF
--- a/cmd/authgate/main.go
+++ b/cmd/authgate/main.go
@@ -93,11 +93,10 @@ func main() {
 
 	var isShuttingDown atomic.Bool
 	mux := http.NewServeMux()
-	httpMetrics := observability.NewHTTPMetrics()
-	auditMetrics := observability.NewAuditMetrics(httpMetrics.Registry())
-	store.SetAuditFailureRecorder(auditMetrics)
-	store.SetAuditEventRecorder(auditMetrics)
-	registerRoutes(mux, cfg, db, store, provider, loginHandler, deviceHandler, accountHandler, mcpLoginHandler, consoleHandler, httpMetrics, &isShuttingDown)
+	metrics := observability.NewMetrics(db)
+	store.SetAuditFailureRecorder(metrics.Security)
+	store.SetAuditEventRecorder(metrics.Security)
+	registerRoutes(mux, cfg, db, store, provider, loginHandler, deviceHandler, accountHandler, mcpLoginHandler, consoleHandler, metrics, &isShuttingDown)
 
 	trustedProxies, err := clientinfo.ParseTrustedProxies(cfg.TrustedProxies)
 	if err != nil {
@@ -113,9 +112,9 @@ func main() {
 	requestIDHandler := middleware.RequestIDMiddleware(corsHandler)
 
 	var inflightRequests int64
-	srv, addr := buildHTTPServer(cfg, requestIDHandler, httpMetrics, &inflightRequests)
+	srv, addr := buildHTTPServer(cfg, requestIDHandler, metrics.HTTP, &inflightRequests)
 
-	cleanupCancel := startCleanupService(db, clk, cfg.AuditLogPIIRetention, auditMetrics)
+	cleanupCancel := startCleanupService(db, clk, cfg.AuditLogPIIRetention, metrics.Security)
 	defer cleanupCancel()
 	installGracefulShutdown(srv, cfg, &inflightRequests, cleanupCancel, &isShuttingDown)
 
@@ -295,13 +294,13 @@ func registerRoutes(
 	accountHandler *handler.AccountHandler,
 	mcpLoginHandler *handler.MCPLoginHandler,
 	consoleHandler *handler.ConsoleHandler,
-	httpMetrics *observability.HTTPMetrics,
+	metrics *observability.Metrics,
 	isShuttingDown *atomic.Bool,
 ) {
 	registerOAuthMetadataRoute(mux, cfg)
 	registerProviderRoutes(mux, cfg, store, provider)
 	registerAuthgateRoutes(mux, cfg, loginHandler, deviceHandler, accountHandler, mcpLoginHandler, consoleHandler)
-	registerHealthRoutes(mux, db, isShuttingDown, httpMetrics)
+	registerHealthRoutes(mux, db, isShuttingDown, metrics)
 }
 
 func registerOAuthMetadataRoute(mux *http.ServeMux, cfg *config.Config) {
@@ -420,7 +419,7 @@ func registerAuthgateRoutes(
 	mux.Handle("/console/me/audit-log", authLimiter(http.HandlerFunc(consoleHandler.HandleGetAuditLog)))
 }
 
-func registerHealthRoutes(mux *http.ServeMux, db *sql.DB, isShuttingDown *atomic.Bool, httpMetrics *observability.HTTPMetrics) {
+func registerHealthRoutes(mux *http.ServeMux, db *sql.DB, isShuttingDown *atomic.Bool, metrics *observability.Metrics) {
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -441,7 +440,7 @@ func registerHealthRoutes(mux *http.ServeMux, db *sql.DB, isShuttingDown *atomic
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"status":"ready"}`))
 	})
-	mux.Handle("/metrics", httpMetrics.MetricsHandler())
+	mux.Handle("/metrics", metrics.Handler())
 }
 
 func buildHTTPServer(cfg *config.Config, mux http.Handler, httpMetrics *observability.HTTPMetrics, inflightRequests *int64) (*http.Server, string) {
@@ -463,7 +462,7 @@ func buildHTTPServer(cfg *config.Config, mux http.Handler, httpMetrics *observab
 	}, addr
 }
 
-func startCleanupService(db *sql.DB, clk clock.Clock, auditLogPIIRetention time.Duration, metrics *observability.AuditMetrics) context.CancelFunc {
+func startCleanupService(db *sql.DB, clk clock.Clock, auditLogPIIRetention time.Duration, metrics service.CleanupMetricsRecorder) context.CancelFunc {
 	cleanupRunner := storage.NewCleanupRunner(db)
 	cleanupSvc := service.NewCleanupService(cleanupRunner, clk, 10*time.Minute)
 	cleanupSvc.SetAuditLogPIIRetention(auditLogPIIRetention)

--- a/internal/observability/audit_metrics.go
+++ b/internal/observability/audit_metrics.go
@@ -4,22 +4,25 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// AuditMetrics owns Prometheus counters for security-relevant audit and
+// SecurityMetrics owns Prometheus counters for security-relevant audit and
 // cleanup outcomes.
-// It registers into the shared HTTPMetrics registry so a single /metrics
-// scrape target exposes both groups.
-type AuditMetrics struct {
+type SecurityMetrics struct {
 	events        *prometheus.CounterVec
 	writeFailures *prometheus.CounterVec
 	cleanupRuns   *prometheus.CounterVec
 }
 
-// NewAuditMetrics registers audit-log counters into reg and returns a recorder.
+// AuditMetrics is kept as a compatibility alias for storage/service recorder
+// wiring that still describes the audit-specific side of this collector.
+type AuditMetrics = SecurityMetrics
+
+// NewSecurityMetrics registers audit/security counters into reg and returns a
+// recorder.
 // Stages: "marshal" (json.Marshal of metadata failed before any DB call) and
 // "insert" (audit_log INSERT failed). Tracking the two separately lets alert
 // rules distinguish input-shape bugs from DB outages so an oncall responder
 // can route the page correctly.
-func NewAuditMetrics(reg *prometheus.Registry) *AuditMetrics {
+func NewSecurityMetrics(reg *prometheus.Registry) *SecurityMetrics {
 	events := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "authgate_audit_events_total",
@@ -52,17 +55,21 @@ func NewAuditMetrics(reg *prometheus.Registry) *AuditMetrics {
 	writeFailures.WithLabelValues("insert")
 	cleanupRuns.WithLabelValues("success")
 	cleanupRuns.WithLabelValues("failure")
-	return &AuditMetrics{
+	return &SecurityMetrics{
 		events:        events,
 		writeFailures: writeFailures,
 		cleanupRuns:   cleanupRuns,
 	}
 }
 
+func NewAuditMetrics(reg *prometheus.Registry) *AuditMetrics {
+	return NewSecurityMetrics(reg)
+}
+
 // RecordEvent increments the audit-event counter after the audit row is
 // successfully persisted. Nil receivers are tolerated so tests can omit the
 // recorder entirely.
-func (m *AuditMetrics) RecordEvent(eventType, channel string) {
+func (m *SecurityMetrics) RecordEvent(eventType, channel string) {
 	if m == nil {
 		return
 	}
@@ -73,7 +80,7 @@ func (m *AuditMetrics) RecordEvent(eventType, channel string) {
 // Callers pass either "marshal" or "insert"; other labels are accepted but
 // will not match the alert rules in docs/spec/009-operations.md.
 // Nil receivers are tolerated so test wiring can omit the recorder entirely.
-func (m *AuditMetrics) RecordWriteFailure(stage string) {
+func (m *SecurityMetrics) RecordWriteFailure(stage string) {
 	if m == nil {
 		return
 	}
@@ -83,7 +90,7 @@ func (m *AuditMetrics) RecordWriteFailure(stage string) {
 // RecordCleanupRun increments the cleanup run counter for "success" or
 // "failure". Other result labels are accepted but will not match the stock
 // alert examples.
-func (m *AuditMetrics) RecordCleanupRun(result string) {
+func (m *SecurityMetrics) RecordCleanupRun(result string) {
 	if m == nil {
 		return
 	}

--- a/internal/observability/audit_metrics_test.go
+++ b/internal/observability/audit_metrics_test.go
@@ -7,9 +7,9 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
-func TestAuditMetrics_RecordSecurityCounters(t *testing.T) {
+func TestSecurityMetrics_RecordSecurityCounters(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	m := NewAuditMetrics(reg)
+	m := NewSecurityMetrics(reg)
 
 	m.RecordEvent("auth.inactive_user", "browser")
 	m.RecordWriteFailure("insert")
@@ -44,6 +44,32 @@ func assertCounterValue(t *testing.T, reg *prometheus.Registry, name string, lab
 				continue
 			}
 			if got := metric.GetCounter().GetValue(); got != want {
+				t.Fatalf("%s labels %v = %v, want %v", name, labels, got, want)
+			}
+			return
+		}
+	}
+
+	t.Fatalf("missing %s labels %v", name, labels)
+}
+
+func assertGaugeValue(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string, want float64) {
+	t.Helper()
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if !metricHasLabels(metric.GetLabel(), labels) {
+				continue
+			}
+			if got := metric.GetGauge().GetValue(); got != want {
 				t.Fatalf("%s labels %v = %v, want %v", name, labels, got, want)
 			}
 			return

--- a/internal/observability/db_metrics.go
+++ b/internal/observability/db_metrics.go
@@ -1,0 +1,59 @@
+package observability
+
+import (
+	"database/sql"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// DBMetrics registers sql.DB pool gauges/counters into the shared /metrics
+// registry. Values are sampled from db.Stats() at scrape time.
+type DBMetrics struct{}
+
+func NewDBMetrics(reg *prometheus.Registry, db *sql.DB) *DBMetrics {
+	reg.MustRegister(
+		prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Name: "authgate_db_connections_open",
+				Help: "Current number of open database connections.",
+			},
+			func() float64 { return float64(db.Stats().OpenConnections) },
+		),
+		prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Name: "authgate_db_connections_in_use",
+				Help: "Current number of in-use database connections.",
+			},
+			func() float64 { return float64(db.Stats().InUse) },
+		),
+		prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Name: "authgate_db_connections_idle",
+				Help: "Current number of idle database connections.",
+			},
+			func() float64 { return float64(db.Stats().Idle) },
+		),
+		prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Name: "authgate_db_connections_max_open",
+				Help: "Configured maximum number of open database connections. Zero means unlimited.",
+			},
+			func() float64 { return float64(db.Stats().MaxOpenConnections) },
+		),
+		prometheus.NewCounterFunc(
+			prometheus.CounterOpts{
+				Name: "authgate_db_wait_count_total",
+				Help: "Total number of times a database query waited for a connection.",
+			},
+			func() float64 { return float64(db.Stats().WaitCount) },
+		),
+		prometheus.NewCounterFunc(
+			prometheus.CounterOpts{
+				Name: "authgate_db_wait_duration_seconds_total",
+				Help: "Total time spent waiting for database connections in seconds.",
+			},
+			func() float64 { return db.Stats().WaitDuration.Seconds() },
+		),
+	)
+	return &DBMetrics{}
+}

--- a/internal/observability/http_metrics.go
+++ b/internal/observability/http_metrics.go
@@ -7,21 +7,17 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/kangheeyong/authgate/internal/middleware"
 )
 
 type HTTPMetrics struct {
-	registry       *prometheus.Registry
 	requestsTotal  *prometheus.CounterVec
 	requestLatency *prometheus.HistogramVec
 	inflight       prometheus.Gauge
 }
 
-func NewHTTPMetrics() *HTTPMetrics {
-	reg := prometheus.NewRegistry()
-
+func NewHTTPMetrics(reg *prometheus.Registry) *HTTPMetrics {
 	requestsTotal := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "authgate_http_requests_total",
@@ -50,27 +46,13 @@ func NewHTTPMetrics() *HTTPMetrics {
 		requestsTotal,
 		requestLatency,
 		inflight,
-		prometheus.NewGoCollector(),
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
 	)
 
 	return &HTTPMetrics{
-		registry:       reg,
 		requestsTotal:  requestsTotal,
 		requestLatency: requestLatency,
 		inflight:       inflight,
 	}
-}
-
-func (m *HTTPMetrics) MetricsHandler() http.Handler {
-	return promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{})
-}
-
-// Registry exposes the shared Prometheus registry so adjacent metric groups
-// (e.g., observability.AuditMetrics) can register into the same /metrics
-// scrape target without spinning up a second endpoint.
-func (m *HTTPMetrics) Registry() *prometheus.Registry {
-	return m.registry
 }
 
 func (m *HTTPMetrics) Middleware(next http.Handler) http.Handler {

--- a/internal/observability/http_metrics_test.go
+++ b/internal/observability/http_metrics_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/kangheeyong/authgate/internal/middleware"
 )
 
@@ -15,7 +17,8 @@ func wrapWithRequestID(h http.Handler) http.Handler {
 }
 
 func TestMiddleware_SetsRequestIDAndRecordsMetrics(t *testing.T) {
-	m := NewHTTPMetrics()
+	reg := prometheus.NewRegistry()
+	m := NewHTTPMetrics(reg)
 	inner := m.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 		_, _ = w.Write([]byte("ok"))
@@ -30,7 +33,7 @@ func TestMiddleware_SetsRequestIDAndRecordsMetrics(t *testing.T) {
 		t.Fatal("missing X-Request-ID header")
 	}
 
-	metrics, err := m.registry.Gather()
+	metrics, err := reg.Gather()
 	if err != nil {
 		t.Fatalf("gather metrics: %v", err)
 	}
@@ -65,7 +68,7 @@ func TestMiddleware_SetsRequestIDAndRecordsMetrics(t *testing.T) {
 }
 
 func TestMiddleware_UsesInboundRequestID(t *testing.T) {
-	m := NewHTTPMetrics()
+	m := NewHTTPMetrics(prometheus.NewRegistry())
 	inner := m.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -83,7 +86,8 @@ func TestMiddleware_UsesInboundRequestID(t *testing.T) {
 }
 
 func TestMiddleware_RecordsOAuthIntrospectionRouteEvidence(t *testing.T) {
-	m := NewHTTPMetrics()
+	reg := prometheus.NewRegistry()
+	m := NewHTTPMetrics(reg)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/oauth/introspect", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -94,7 +98,7 @@ func TestMiddleware_RecordsOAuthIntrospectionRouteEvidence(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
-	metrics, err := m.registry.Gather()
+	metrics, err := reg.Gather()
 	if err != nil {
 		t.Fatalf("gather metrics: %v", err)
 	}

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -1,0 +1,45 @@
+package observability
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Metrics owns the Prometheus registry exposed by /metrics and groups the
+// collectors registered into it.
+type Metrics struct {
+	registry *prometheus.Registry
+
+	HTTP     *HTTPMetrics
+	Security *SecurityMetrics
+	DB       *DBMetrics
+}
+
+func NewMetrics(db *sql.DB) *Metrics {
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(
+		prometheus.NewGoCollector(),
+		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+	)
+
+	metrics := &Metrics{
+		registry: reg,
+	}
+	metrics.HTTP = NewHTTPMetrics(reg)
+	metrics.Security = NewSecurityMetrics(reg)
+	if db != nil {
+		metrics.DB = NewDBMetrics(reg, db)
+	}
+	return metrics
+}
+
+func (m *Metrics) Handler() http.Handler {
+	return promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{})
+}
+
+func (m *Metrics) Registry() *prometheus.Registry {
+	return m.registry
+}

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -1,0 +1,26 @@
+package observability
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+func TestNewMetrics_RegistersSharedCollectors(t *testing.T) {
+	db, err := sql.Open("pgx", "postgres://localhost:1/authgate")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(7)
+
+	m := NewMetrics(db)
+	m.Security.RecordEvent("auth.inactive_user", "browser")
+
+	assertCounterValue(t, m.Registry(), "authgate_audit_events_total", map[string]string{
+		"event_type": "auth.inactive_user",
+		"channel":    "browser",
+	}, 1)
+	assertGaugeValue(t, m.Registry(), "authgate_db_connections_max_open", nil, 7)
+}

--- a/internal/service/cleanup.go
+++ b/internal/service/cleanup.go
@@ -22,7 +22,7 @@ type cleanupRunner interface {
 }
 
 // CleanupMetricsRecorder receives a signal when a cleanup run completes or
-// fails before completion. main.go wires observability.AuditMetrics.
+// fails before completion. main.go wires observability.SecurityMetrics.
 type CleanupMetricsRecorder interface {
 	RecordCleanupRun(result string)
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -52,14 +52,14 @@ type ResourceBindingPolicy interface {
 
 // AuditFailureRecorder receives an event whenever an audit-log write fails so
 // the silent best-effort policy in AuditLog (#208) is still observable via
-// metrics/alerts. main.go wires observability.AuditMetrics; tests can plug a
+// metrics/alerts. main.go wires observability.SecurityMetrics; tests can plug a
 // fake recorder. Stages: "marshal" or "insert".
 type AuditFailureRecorder interface {
 	RecordWriteFailure(stage string)
 }
 
 // AuditEventRecorder receives an event after an audit-log row is successfully
-// persisted. main.go wires observability.AuditMetrics so security-sensitive
+// persisted. main.go wires observability.SecurityMetrics so security-sensitive
 // event bursts are visible from /metrics.
 type AuditEventRecorder interface {
 	RecordEvent(eventType, channel string)
@@ -99,7 +99,7 @@ type Storage struct {
 	issuer string
 	// auditFailureRec receives a signal whenever AuditLog fails to marshal
 	// or insert. Defaults to a no-op in New() so call sites never need a nil
-	// guard; main.go installs observability.AuditMetrics at startup.
+	// guard; main.go installs observability.SecurityMetrics at startup.
 	auditFailureRec AuditFailureRecorder
 	// auditEventRec receives a signal after a successful AuditLog insert.
 	// Defaults to a no-op for tests that construct Storage directly.
@@ -132,7 +132,7 @@ func (s *Storage) SetDevicePollInterval(d time.Duration) {
 }
 
 // SetAuditFailureRecorder installs a metric recorder that AuditLog invokes
-// when a write fails. main.go wires observability.AuditMetrics. Passing nil
+// when a write fails. main.go wires observability.SecurityMetrics. Passing nil
 // resets to the no-op recorder so the call site contract holds either way.
 func (s *Storage) SetAuditFailureRecorder(r AuditFailureRecorder) {
 	if r == nil {


### PR DESCRIPTION
## Summary
- Introduce `observability.Metrics` as the single owner of the Prometheus registry exposed by `/metrics`.
- Move HTTP metrics to register into a caller-owned registry instead of owning the registry themselves.
- Rename the audit/cleanup collector surface to `SecurityMetrics` while keeping the audit recorder alias.
- Promote DB pool USE metrics into the shared registry so DB saturation metrics are collected with HTTP/security metrics.

## Verification
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `go test -tags integration ./internal/service -run TestCleanup -count=1`