### PR TITLE
docs(architecture): sync observability metrics structure

### DIFF
--- a/docs/architecture/001-component-boundaries.md
+++ b/docs/architecture/001-component-boundaries.md
@@ -352,6 +352,10 @@ internal/
   pages/                    # HTML 템플릿 렌더링
     templates/
   observability/            # metrics / tracing 보조
+    metrics.go              # Prometheus registry 소유 + /metrics handler
+    http_metrics.go         # HTTP RED metrics (rate/error/duration/inflight)
+    audit_metrics.go        # security/audit/cleanup metrics
+    db_metrics.go           # DB pool USE metrics
   clock/                    # 시간 추상화
   idgen/                    # ID/토큰 생성
 


### PR DESCRIPTION
## Summary

- Update the architecture package map for `internal/observability`.
- Document the shared Prometheus registry owner and the HTTP, security, and DB metric collector files introduced by the metrics refactor.

## Checklist

- [x] Tests added or updated for changed behavior
- [x] **Doc sync** (per CLAUDE.md):
  - [x] Env var change → N/A
  - [x] Endpoint change → N/A
  - [x] Test added → N/A
  - [x] Package structure change → `docs/architecture/001-component-boundaries.md` updated
- [x] No secrets committed (`.env`, keys, credentials)
- [x] `go test ./...` passes locally

## Verification

- `git diff --check`
- `go test ./...`