### PR TITLE
chore(gitignore): ignore .tmp/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ go.work.sum
 .idea/
 .vscode/
 .omc/
+.tmp/
 signing_key.pem
 
 # Local screenshots / capture artifacts at the repo root.


### PR DESCRIPTION
## Summary
- `.tmp/`는 로컬 분석/스크래치 산출물 디렉토리라 git에 포함될 이유가 없음
- `.gitignore`의 Editor/IDE 섹션에 `.omc/` 옆에 한 줄 추가

## Test plan
- [x] `git status --ignored` 로 `.tmp/`가 ignored 항목에 들어가는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)