### PR TITLE
feat(monitoring): load authgate alert rules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
       - "9092:9090"
     volumes:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/prometheus/rules:/etc/prometheus/rules:ro
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -349,7 +349,7 @@ Grafana dashboard는 llmgate 운영 화면과 같은 방식으로 용도별로 �
 
 | Dashboard | 용도 |
 |-----------|------|
-| `Authgate Operations Overview` | 장애 대응 첫 화면. HTTP RED, DB USE, local pressure를 함께 본다. |
+| `Authgate Operations Overview` | 장애 대응 첫 화면. HTTP RED와 DB USE를 함께 본다. |
 | `Authgate Runtime Resources` | Go/process runtime, DB pool pressure, file descriptor 사용률을 본다. |
 | `Authgate Security and Audit Evidence` | audit event, audit write failure, cleanup, token introspection 증적을 본다. |
 
@@ -397,45 +397,27 @@ pattern이 없는 요청은 raw path를 label로 쓰지 않고 `route="unmatched
 | `authgate_audit_events_total` | `event_type`, `channel` | 성공적으로 저장된 audit event 수. channel이 없는 이벤트는 `channel="unknown"` |
 | `authgate_cleanup_runs_total` | `result="success"` / `result="failure"` | cleanup run 성공/실패 수 |
 
-PrometheusRule 예시:
+로컬 compose 스택은 `monitoring/prometheus/rules/authgate-alerts.yml`을 로드한다.
+룰은 실제 metric 이름과 bounded label만 사용한다.
 
 ```yaml
-- alert: AuthgateRefreshReuseBurst
-  expr: sum(increase(authgate_audit_events_total{event_type="auth.refresh_reuse_detected"}[5m])) > 3
-  for: 1m
-  labels:
-    severity: critical
-  annotations:
-    summary: "refresh token reuse detected repeatedly"
-    description: "5분 내 refresh token reuse가 반복 탐지됨. 계정 탈취 또는 토큰 유출 가능성 조사."
-
-- alert: AuthgateChannelMismatchBurst
-  expr: sum by (channel) (increase(authgate_audit_events_total{event_type="auth.channel_mismatch"}[5m])) > 10
-  for: 2m
-  labels:
-    severity: warning
-  annotations:
-    summary: "auth channel mismatch burst (channel={{ $labels.channel }})"
-    description: "브라우저/MCP/device 채널 정책 위반이 급증. 잘못된 client 설정 또는 공격성 흐름 확인."
-
-- alert: AuthgateCleanupStale
-  expr: increase(authgate_cleanup_runs_total{result="success"}[30m]) == 0
-  for: 10m
-  labels:
-    severity: warning
-  annotations:
-    summary: "authgate cleanup has not completed recently"
-    description: "최근 30분 동안 cleanup 성공 run이 없음. pending deletion, 만료 세션, audit PII 정리가 지연될 수 있음."
-
-- alert: AuthgateAuditWriteFailures
-  expr: increase(authgate_audit_log_write_failures_total[5m]) > 0
-  for: 1m
-  labels:
-    severity: critical
-  annotations:
-    summary: "authgate audit log writes are failing (stage={{ $labels.stage }})"
-    description: "감사 로그 쓰기가 silent하게 실패 중. 침해 탐지 인프라가 broken — 즉시 점검."
+rule_files:
+  - /etc/prometheus/rules/*.yml
 ```
+
+기본 alert 세트:
+
+| Alert | Signal | 기준 |
+|-------|--------|------|
+| `AuthgateMetricsTargetDown` | `up{job="authgate"}` | 2분간 scrape 실패 |
+| `AuthgateHighHTTP5xxRate` | HTTP RED | 5분간 5xx 비율 5% 초과 |
+| `AuthgateRouteP95LatencyHigh` | route별 p95 latency | sustained traffic route에서 5분간 1s 초과 |
+| `AuthgateDBConnectionWaits` | DB USE | 10분간 connection wait > 0.5/s |
+| `AuthgateAuditWriteFailures` | audit evidence | 5분 내 write failure 증가 |
+| `AuthgateRefreshReuseBurst` | token theft signal | 5분 내 refresh reuse 3회 초과 |
+| `AuthgateChannelMismatchBurst` | channel policy signal | 5분 내 channel mismatch 10회 초과 |
+| `AuthgateCleanupFailures` | lifecycle job failure | 15분 내 cleanup failure 발생 |
+| `AuthgateCleanupStale` | lifecycle job liveness | 30분 동안 cleanup success 없음 |
 
 ## 백업/복구
 

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -2,6 +2,9 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
 scrape_configs:
   - job_name: prometheus
     static_configs:

--- a/monitoring/prometheus/rules/authgate-alerts.yml
+++ b/monitoring/prometheus/rules/authgate-alerts.yml
@@ -1,0 +1,101 @@
+groups:
+  - name: authgate.availability
+    rules:
+      - alert: AuthgateMetricsTargetDown
+        expr: up{job="authgate"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "authgate metrics target is down"
+          description: "Prometheus has not been able to scrape authgate for 2 minutes."
+
+  - name: authgate.http
+    rules:
+      - alert: AuthgateHighHTTP5xxRate
+        expr: |
+          (
+            sum(rate(authgate_http_requests_total{status=~"5.."}[5m]))
+            / clamp_min(sum(rate(authgate_http_requests_total[5m])), 0.001)
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "authgate HTTP 5xx rate is high"
+          description: "More than 5% of authgate HTTP requests have returned 5xx for 5 minutes."
+
+      - alert: AuthgateRouteP95LatencyHigh
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (route, le) (
+              rate(authgate_http_request_duration_seconds_bucket{status!~"5.."}[5m])
+            )
+          ) > 1
+          and on (route)
+          sum by (route) (rate(authgate_http_requests_total[5m])) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "authgate route p95 latency is high (route={{ $labels.route }})"
+          description: "Route p95 latency has been above 1s for 5 minutes while receiving sustained traffic."
+
+  - name: authgate.db
+    rules:
+      - alert: AuthgateDBConnectionWaits
+        expr: sum(rate(authgate_db_wait_count_total[5m])) > 0.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "authgate DB pool is waiting for connections"
+          description: "DB connection waits are above 0.5/s for 10 minutes. Check pool sizing and query latency."
+
+  - name: authgate.security
+    rules:
+      - alert: AuthgateAuditWriteFailures
+        expr: sum by (stage) (increase(authgate_audit_log_write_failures_total[5m])) > 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "authgate audit log writes are failing (stage={{ $labels.stage }})"
+          description: "Audit log writes are failing. Incident detection evidence may be incomplete."
+
+      - alert: AuthgateRefreshReuseBurst
+        expr: sum(increase(authgate_audit_events_total{event_type="auth.refresh_reuse_detected"}[5m])) > 3
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "authgate refresh token reuse detected repeatedly"
+          description: "Refresh token reuse was detected more than 3 times in 5 minutes."
+
+      - alert: AuthgateChannelMismatchBurst
+        expr: sum by (channel) (increase(authgate_audit_events_total{event_type="auth.channel_mismatch"}[5m])) > 10
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "authgate channel mismatch burst (channel={{ $labels.channel }})"
+          description: "Channel policy mismatches are increasing. Check client configuration and suspicious flows."
+
+      - alert: AuthgateCleanupFailures
+        expr: sum(increase(authgate_cleanup_runs_total{result="failure"}[15m])) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "authgate cleanup runs are failing"
+          description: "At least one cleanup run failed in the last 15 minutes."
+
+      - alert: AuthgateCleanupStale
+        expr: sum(increase(authgate_cleanup_runs_total{result="success"}[30m])) == 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "authgate cleanup has not completed recently"
+          description: "No successful cleanup run was observed in the last 30 minutes."


### PR DESCRIPTION
## Summary

- Load Prometheus alert rules from `monitoring/prometheus/rules/*.yml` in the compose stack.
- Add 9 authgate alert rules covering target health, HTTP RED, DB waits, audit write failures, refresh reuse/channel mismatch, and cleanup failure/stale signals.
- Update operations docs to point at the loaded rule file instead of stale inline examples.

## Checklist

- [ ] Tests added or updated for changed behavior
- [x] **Doc sync** (per CLAUDE.md):
  - [ ] Env var change -> `docs/spec/009-operations.md` updated
  - [ ] Endpoint change -> relevant `docs/spec/00N-*.md` updated
  - [ ] Test added -> `docs/tests/README.md` updated
  - [ ] Package structure change -> `docs/architecture/*.md` updated
- [x] No secrets committed (`.env`, keys, credentials)
- [x] `go test ./...` passes locally

Doc sync note: no Go behavior, env var, endpoint, test, or package-structure changes. `docs/spec/009-operations.md` was updated for the Prometheus rule loading contract.

## Verification

- `docker run --rm --entrypoint promtool -v "$PWD/monitoring/prometheus:/etc/prometheus:ro" prom/prometheus:v3.8.0 check config /etc/prometheus/prometheus.yml`
- `docker run --rm --entrypoint promtool -v "$PWD/monitoring/prometheus:/etc/prometheus:ro" prom/prometheus:v3.8.0 check rules /etc/prometheus/rules/authgate-alerts.yml`
- `docker compose config --quiet`
- `docker compose up -d --build db mock-idp authgate prometheus`
- Prometheus `/api/v1/rules` showed 4 authgate groups and 9 rules
- Prometheus query `up{job="authgate"}` returned `1`
- `go test ./...`
- `docker compose down`