### PR TITLE
Revert "refactor(telemetry): cap unmatched route labels"

### DIFF
--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -382,10 +382,6 @@ Grafana dashboard는 llmgate 운영 화면과 같은 방식으로 용도별로 �
 | `authgate_http_requests_total` | `method="POST", route="/oauth/introspect", status` | introspection 요청 수와 결과 상태 |
 | `authgate_http_request_duration_seconds` | `method="POST", route="/oauth/introspect", status` | introspection 지연 시간 |
 
-HTTP metric의 `route`는 `http.ServeMux`의 route pattern만 사용한다. 매칭된
-pattern이 없는 요청은 raw path를 label로 쓰지 않고 `route="unmatched"`로
-묶어 봇 스캔/404 경로가 time series를 늘리지 않게 한다.
-
 ### audit_log 쓰기 실패 모니터링 (#208)
 
 `Storage.AuditLog`는 best-effort write이므로 marshal/insert 실패가 비즈니스 트랜잭션을 차단하지 않는다. 그러나 감사 로그가 silent하게 누락되면 침해 탐지 능력 자체가 무력화되므로 Prometheus counter로 노출되어 alert으로 감지한다.

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -42,7 +42,6 @@
 코드 = internal/*_test.go
 
 - config/clock/idgen 일부는 일반 unit test로 바로 실행 가능
-- telemetry unit test는 Prometheus metric 이름/label cardinality 같은 운영 evidence 계약을 고정
 - service/storage/integration 테스트 다수는 `//go:build integration`
 - integration 테스트는 testcontainers-go를 사용하므로 Docker 접근 권한이 필요
 ```

--- a/internal/telemetry/http.go
+++ b/internal/telemetry/http.go
@@ -11,8 +11,6 @@ import (
 	"github.com/kangheeyong/authgate/internal/middleware"
 )
 
-const unmatchedRouteLabel = "unmatched"
-
 type HTTPRecorder struct {
 	requestsTotal  *prometheus.CounterVec
 	requestLatency *prometheus.HistogramVec
@@ -69,7 +67,10 @@ func (rec *HTTPRecorder) Middleware(next http.Handler) http.Handler {
 		next.ServeHTTP(sw, r)
 
 		status := strconv.Itoa(sw.status)
-		route := routeLabel(r)
+		route := r.Pattern
+		if route == "" {
+			route = r.URL.Path
+		}
 
 		durationSec := time.Since(start).Seconds()
 		rec.requestsTotal.WithLabelValues(r.Method, route, status).Inc()
@@ -85,13 +86,6 @@ func (rec *HTTPRecorder) Middleware(next http.Handler) http.Handler {
 			"duration_ms", int64(durationSec*1000),
 		)
 	})
-}
-
-func routeLabel(r *http.Request) string {
-	if r.Pattern != "" {
-		return r.Pattern
-	}
-	return unmatchedRouteLabel
 }
 
 type statusWriter struct {

--- a/internal/telemetry/http_test.go
+++ b/internal/telemetry/http_test.go
@@ -120,21 +120,3 @@ func TestMiddleware_RecordsOAuthIntrospectionRouteEvidence(t *testing.T) {
 
 	t.Fatal("authgate_http_requests_total did not include POST /oauth/introspect 200 evidence")
 }
-
-func TestMiddleware_UsesFixedRouteLabelWhenPatternIsMissing(t *testing.T) {
-	reg := prometheus.NewRegistry()
-	m := NewHTTPRecorder(reg)
-	h := wrapWithRequestID(m.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	})))
-
-	req := httptest.NewRequest(http.MethodGet, "/wp-login.php", nil)
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-
-	assertCounterValue(t, reg, "authgate_http_requests_total", map[string]string{
-		"method": http.MethodGet,
-		"route":  unmatchedRouteLabel,
-		"status": "404",
-	}, 1)
-}

--- a/internal/telemetry/security.go
+++ b/internal/telemetry/security.go
@@ -12,6 +12,10 @@ type SecurityRecorder struct {
 	cleanupRuns   *prometheus.CounterVec
 }
 
+// AuditRecorder is kept as a compatibility alias for storage/service recorder
+// wiring that still describes the audit-specific side of this collector.
+type AuditRecorder = SecurityRecorder
+
 // NewSecurityRecorder registers audit/security counters into reg and returns a
 // recorder.
 // Stages: "marshal" (json.Marshal of metadata failed before any DB call) and
@@ -56,6 +60,10 @@ func NewSecurityRecorder(reg *prometheus.Registry) *SecurityRecorder {
 		writeFailures: writeFailures,
 		cleanupRuns:   cleanupRuns,
 	}
+}
+
+func NewAuditRecorder(reg *prometheus.Registry) *AuditRecorder {
+	return NewSecurityRecorder(reg)
 }
 
 // RecordEvent increments the audit-event counter after the audit row is


### PR DESCRIPTION
## Summary
- Reverts 05c2fa0 ("refactor(telemetry): cap unmatched route labels")
- Restores the previous telemetry route-labeling behavior and the `AuditRecorder` compatibility shim

## Test plan
- [ ] `make build`
- [ ] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)