### PR TITLE
chore(ci): add CI quality gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+# Keep routine dependency churn batched. Major bumps stay separate because
+# Go, GitHub Actions, and security-sensitive auth libraries need review.
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      go-deps:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      gh-actions:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ on:
       - "migrations/**"
       - "internal/db/queries/**"
       - "sqlc.yaml"
-      - ".github/workflows/ci.yml"
+      - "Makefile"
+      - ".golangci.yml"
+      - ".github/dependabot.yml"
+      - ".github/workflows/**"
   push:
     branches: [main]
     paths:
@@ -21,7 +24,10 @@ on:
       - "migrations/**"
       - "internal/db/queries/**"
       - "sqlc.yaml"
-      - ".github/workflows/ci.yml"
+      - "Makefile"
+      - ".golangci.yml"
+      - ".github/dependabot.yml"
+      - ".github/workflows/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,6 +42,25 @@ permissions:
   pull-requests: write
 
 jobs:
+  fmt:
+    name: Go Format
+    runs-on: arc-runner-set-authgate
+    container: catthehacker/ubuntu:act-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: gofmt -l
+        run: |
+          out=$(gofmt -l .)
+          if [ -n "$out" ]; then
+            echo "$out"
+            echo "::error::gofmt found unformatted files; run 'gofmt -w .'"
+            exit 1
+          fi
+
   sqlc:
     name: SQLC
     runs-on: arc-runner-set-authgate
@@ -98,6 +123,19 @@ jobs:
           name: code-coverage
           path: coverage.out
 
+  race:
+    name: Race
+    runs-on: arc-runner-set-authgate
+    container: catthehacker/ubuntu:act-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests with race detector
+        run: go test -race ./...
+
   coverage-report:
     name: Coverage Report
     needs: test
@@ -134,6 +172,25 @@ jobs:
           go-version-file: go.mod
       - run: go vet ./...
 
+  lint:
+    name: GolangCI-Lint
+    runs-on: arc-runner-set-authgate
+    container: catthehacker/ubuntu:act-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install golangci-lint
+        run: |
+          GOTOOLCHAIN=go$(awk '/^go / {print $2; exit}' go.mod) \
+            go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+
+      - name: Run golangci-lint
+        run: |
+          $(go env GOPATH)/bin/golangci-lint run ./...
+
   vuln:
     name: Vulnerability Check
     runs-on: arc-runner-set-authgate
@@ -144,8 +201,13 @@ jobs:
         with:
           go-version-file: go.mod
       - run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          # Build govulncheck with the setup-go toolchain. Without this,
+          # the tool's own toolchain directive can downgrade to Go 1.25 and
+          # fail to load this Go 1.26 module.
+          GOTOOLCHAIN=local go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
           # integration/test utility packages pull docker/testcontainers only for tests.
           # Vulnerability checks here focus on runtime packages used in production code paths.
-          PKGS=$(go list ./... | grep -v '/internal/testutil' | grep -v '/internal/integration')
-          govulncheck ${PKGS}
+          go list ./... \
+            | grep -v '/internal/testutil' \
+            | grep -v '/internal/integration' \
+            | xargs govulncheck

--- a/.github/workflows/vuln-full-scan.yml
+++ b/.github/workflows/vuln-full-scan.yml
@@ -21,7 +21,11 @@ jobs:
           go-version-file: go.mod
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: |
+          # Build govulncheck with the setup-go toolchain. Without this,
+          # the tool's own toolchain directive can downgrade to Go 1.25 and
+          # fail to load this Go 1.26 module.
+          GOTOOLCHAIN=local go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
       - name: Run full govulncheck (non-blocking)
         id: vulnscan

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,8 @@
-run:
-  go: "1.24"  # golangci-lint is built with go1.24; override until go1.25 support lands
-
+version: "2"
 linters:
+  default: none
   enable:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
@@ -12,17 +10,33 @@ linters:
     - gosec
     - bodyclose
     - noctx
-
-linters-settings:
-  gosec:
-    excludes:
-      - G115  # integer overflow conversion — not relevant for this codebase
-
-issues:
-  exclude-rules:
-    # Test files: allow hardcoded credentials and unhandled errors
-    - path: "_test\\.go"
-      linters: [gosec, errcheck]
-    # Example code: allow hardcoded values
-    - path: "examples/"
-      linters: [gosec]
+  settings:
+    gosec:
+      excludes:
+        - G115 # integer overflow conversion; not relevant for this codebase
+  exclusions:
+    rules:
+      # Test files: allow hardcoded credentials and unhandled errors.
+      - path: _test\.go
+        linters:
+          - gosec
+          - errcheck
+          - noctx
+      # Example code: allow hardcoded values.
+      - path: examples/
+        linters:
+          - gosec
+      # Integration/test utility packages are not production request paths.
+      - path: internal/integration/
+        linters:
+          - errcheck
+          - gosec
+          - noctx
+      - path: internal/testutil/
+        linters:
+          - errcheck
+          - gosec
+          - noctx
+      - path: internal/storage/audit.go
+        linters:
+          - gosec

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: infra infra-down dev dev-authgate dev-sample-app stop sqlc-generate
+.PHONY: infra infra-down dev dev-authgate dev-sample-app stop sqlc-generate lint
+
+GO_VERSION := $(shell awk '/^go / {print $$2; exit}' go.mod)
+GOLANGCI_LINT_VERSION := v2.12.2
+GOLANGCI_LINT := $(shell go env GOPATH)/bin/golangci-lint
 
 # Start infrastructure (DB + mock IdP)
 infra:
@@ -60,3 +64,8 @@ stop:
 # Generate sqlc query code (Docker-based, no local sqlc install needed)
 sqlc-generate:
 	docker run --rm -v $(CURDIR):/src -w /src sqlc/sqlc:1.31.1 generate
+
+# Static analysis. Forces golangci-lint to build with this module's Go version.
+lint:
+	GOTOOLCHAIN=go$(GO_VERSION) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	$(GOLANGCI_LINT) run ./...

--- a/internal/adapter/mcp/cimd.go
+++ b/internal/adapter/mcp/cimd.go
@@ -313,7 +313,7 @@ func (f *HTTPCIMDFetcher) fetchAndValidate(ctx context.Context, clientID string)
 	if err != nil {
 		return nil, 0, fmt.Errorf("cimd: fetch failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, 0, fmt.Errorf("cimd: HTTP %d from %s", resp.StatusCode, clientID)

--- a/internal/adapter/mcp/policy.go
+++ b/internal/adapter/mcp/policy.go
@@ -33,10 +33,10 @@ type resourceBindingPolicy struct {
 // ValidateAuthorizeRequest enforces the channel × resource matrix per
 // RFC 8707 §2.2 AS-side policy and authgate spec 004:
 //   - login_channel='mcp'     ⇒ resource is REQUIRED (the token would
-//                                otherwise have no audience to bind to)
+//     otherwise have no audience to bind to)
 //   - login_channel='browser' ⇒ resource MUST NOT be present (a browser
-//                                client minting an MCP-audience token is a
-//                                boundary-confusion attack — issue #184)
+//     client minting an MCP-audience token is a
+//     boundary-confusion attack — issue #184)
 //
 // Once /authorize rejects browser+resource here, the core policy's
 // existing "unexpected resource" check at /oauth/token covers the
@@ -97,4 +97,3 @@ func NewClientResolutionPolicy(base storage.ClientResolutionPolicy, fetcher stor
 func NewResourceBindingPolicy(base storage.ResourceBindingPolicy, resolver storage.ClientResolutionPolicy) storage.ResourceBindingPolicy {
 	return &resourceBindingPolicy{base: base, resolver: resolver}
 }
-

--- a/internal/adapter/mcp/policy_test.go
+++ b/internal/adapter/mcp/policy_test.go
@@ -181,4 +181,3 @@ func TestResourceBindingPolicy_TokenDelegatesToBase(t *testing.T) {
 		t.Fatalf("base token calls = %d, want 1", base.tokenCalls)
 	}
 }
-

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -28,7 +28,7 @@ const devicePollInterval = 5 * time.Second
 func Run() {
 	cfg := mustLoadConfig()
 	db := mustOpenDB(cfg)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	if err := migrator.Run(db, cfg.MigrationsPath); err != nil {
 		log.Fatalf("migrations: %v", err)

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"database/sql"
 	"log"
 
@@ -28,7 +29,7 @@ func mustOpenDB(cfg *config.Config) *sql.DB {
 	db.SetConnMaxLifetime(cfg.DBConnMaxLifetime)
 	db.SetConnMaxIdleTime(cfg.DBConnMaxIdleTime)
 
-	if err := db.Ping(); err != nil {
+	if err := db.PingContext(context.Background()); err != nil {
 		log.Fatalf("db ping: %v", err)
 	}
 	return db

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -52,7 +52,7 @@ func startMetricsServer(cfg *config.Config) context.CancelFunc {
 	if cfg.MetricsAddr == "" {
 		return func() {}
 	}
-	ln, err := net.Listen("tcp", cfg.MetricsAddr)
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", cfg.MetricsAddr)
 	if err != nil {
 		log.Fatalf("metrics listen: %v", err)
 	}

--- a/internal/clientinfo/clientinfo.go
+++ b/internal/clientinfo/clientinfo.go
@@ -169,4 +169,3 @@ func FromContext(ctx context.Context) Info {
 	info, _ := ctx.Value(ctxKey{}).(Info)
 	return info
 }
-

--- a/internal/clientinfo/clientinfo_test.go
+++ b/internal/clientinfo/clientinfo_test.go
@@ -332,8 +332,8 @@ func TestParseTrustedProxies_WhitespaceOnly_Skipped(t *testing.T) {
 func TestParseTrustedProxies_Invalid_Error(t *testing.T) {
 	cases := []string{
 		"not-a-cidr",
-		"10.0.0.0",     // bare IP, no /mask — must be rejected
-		"10.0.0.0/40",  // mask out of range
+		"10.0.0.0",    // bare IP, no /mask — must be rejected
+		"10.0.0.0/40", // mask out of range
 		"::/-1",
 	}
 	for _, in := range cases {
@@ -378,7 +378,7 @@ func TestFromContext_Absent_ReturnsZeroInfo(t *testing.T) {
 			t.Fatalf("FromContext(nil) panicked: %v", r)
 		}
 	}()
-	if got := FromContext(nil); got != (Info{}) {
+	if got := FromContext(nil); got != (Info{}) { //nolint:staticcheck // FromContext intentionally accepts nil defensively.
 		t.Fatalf("FromContext(nil) = %#v, want zero", got)
 	}
 }

--- a/internal/handler/account.go
+++ b/internal/handler/account.go
@@ -30,7 +30,7 @@ func (h *AccountHandler) HandleDeleteAccount(w http.ResponseWriter, r *http.Requ
 	origin := r.Header.Get("Origin")
 	if origin == "" || origin != h.publicURL {
 		w.WriteHeader(http.StatusForbidden)
-		json.NewEncoder(w).Encode(map[string]string{"error": "origin mismatch"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "origin mismatch"})
 		return
 	}
 
@@ -42,12 +42,12 @@ func (h *AccountHandler) HandleDeleteAccount(w http.ResponseWriter, r *http.Requ
 	w.Header().Set("Content-Type", "application/json")
 	if result.Success {
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]string{
+		_ = json.NewEncoder(w).Encode(map[string]string{
 			"status":  "pending_deletion",
 			"message": result.Message,
 		})
 	} else {
 		w.WriteHeader(result.ErrorCode)
-		json.NewEncoder(w).Encode(map[string]string{"error": result.Message})
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": result.Message})
 	}
 }

--- a/internal/handler/device.go
+++ b/internal/handler/device.go
@@ -35,7 +35,7 @@ func (h *DeviceHandler) HandleDevicePage(w http.ResponseWriter, r *http.Request)
 	switch result.Action {
 	case service.DeviceShowEntry:
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		pages.RenderDeviceEntry(w, pages.DeviceEntryData{
+		_ = pages.RenderDeviceEntry(w, pages.DeviceEntryData{
 			BrandName: h.brandName,
 			UserCode:  userCode,
 			Error:     result.Error,
@@ -46,9 +46,10 @@ func (h *DeviceHandler) HandleDevicePage(w http.ResponseWriter, r *http.Request)
 		if err != nil {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.WriteHeader(http.StatusInternalServerError)
-			pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: http.StatusInternalServerError, Message: "internal error"})
+			_ = pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: http.StatusInternalServerError, Message: "internal error"})
 			return
 		}
+		//nolint:gosec // Secure=false is allowed only in explicit DEV_MODE for localhost device flow.
 		http.SetCookie(w, &http.Cookie{
 			Name:     "csrf_token",
 			Value:    csrfToken,
@@ -58,19 +59,20 @@ func (h *DeviceHandler) HandleDevicePage(w http.ResponseWriter, r *http.Request)
 			Secure:   !h.devMode,
 		})
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		pages.RenderDeviceApprove(w, pages.DeviceApproveData{
+		_ = pages.RenderDeviceApprove(w, pages.DeviceApproveData{
 			BrandName: h.brandName,
 			UserCode:  result.UserCode,
 			CSRFToken: csrfToken,
 		})
 
 	case service.DeviceRedirectIdP:
+		//nolint:gosec // Redirect target is the upstream IdP authorization URL built by DeviceService.
 		http.Redirect(w, r, result.UserCode, http.StatusFound) // UserCode holds the auth URL
 
 	case service.DeviceError:
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(result.ErrorCode)
-		pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: result.ErrorCode, Message: result.Error})
+		_ = pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: result.ErrorCode, Message: result.Error})
 	}
 }
 
@@ -87,12 +89,13 @@ func (h *DeviceHandler) HandleDeviceCallback(w http.ResponseWriter, r *http.Requ
 		if result.SessionID != "" {
 			setSessionCookie(w, result.SessionID, h.devMode)
 		}
+		//nolint:gosec // Internal redirect to the fixed device endpoint with a service-issued user code.
 		http.Redirect(w, r, "/device?user_code="+result.UserCode, http.StatusFound)
 
 	case service.DeviceError:
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(result.ErrorCode)
-		pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: result.ErrorCode, Message: result.Error})
+		_ = pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: result.ErrorCode, Message: result.Error})
 	}
 }
 
@@ -104,7 +107,7 @@ func (h *DeviceHandler) HandleDeviceApprove(w http.ResponseWriter, r *http.Reque
 	}
 	if err := r.ParseForm(); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: 400, Message: "invalid form"})
+		_ = pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: 400, Message: "invalid form"})
 		return
 	}
 
@@ -116,7 +119,7 @@ func (h *DeviceHandler) HandleDeviceApprove(w http.ResponseWriter, r *http.Reque
 	}
 	if formToken == "" || subtle.ConstantTimeCompare([]byte(formToken), []byte(cookieToken)) != 1 {
 		w.WriteHeader(http.StatusForbidden)
-		pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: 403, Message: "CSRF validation failed"})
+		_ = pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: 403, Message: "CSRF validation failed"})
 		return
 	}
 
@@ -131,7 +134,7 @@ func (h *DeviceHandler) HandleDeviceApprove(w http.ResponseWriter, r *http.Reque
 	if !result.Success && result.ErrorCode != 0 {
 		w.WriteHeader(result.ErrorCode)
 	}
-	pages.RenderResult(w, pages.ResultData{
+	_ = pages.RenderResult(w, pages.ResultData{
 		BrandName: h.brandName,
 		Success:   result.Success,
 		Message:   result.Message,

--- a/internal/handler/login.go
+++ b/internal/handler/login.go
@@ -32,10 +32,12 @@ func (h *LoginHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 
 	switch result.Action {
 	case service.ActionRedirectToIdP:
+		//nolint:gosec // Redirect target is the upstream IdP authorization URL built by LoginService.
 		http.Redirect(w, r, result.RedirectURL, http.StatusFound)
 
 	case service.ActionAutoApprove:
 		// Redirect back to zitadel's authorize callback
+		//nolint:gosec // Internal redirect to the fixed OIDC callback with a service-issued auth request ID.
 		http.Redirect(w, r, "/authorize/callback?id="+result.AuthRequestID, http.StatusFound)
 
 	case service.ActionError:
@@ -56,6 +58,7 @@ func (h *LoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		if result.SessionID != "" {
 			setSessionCookie(w, result.SessionID, h.devMode)
 		}
+		//nolint:gosec // Internal redirect to the fixed OIDC callback with a service-issued auth request ID.
 		http.Redirect(w, r, "/authorize/callback?id="+result.AuthRequestID, http.StatusFound)
 
 	case service.ActionError:
@@ -66,5 +69,5 @@ func (h *LoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 func (h *LoginHandler) renderError(w http.ResponseWriter, code int, message string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(code)
-	pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: code, Message: message})
+	_ = pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: code, Message: message})
 }

--- a/internal/handler/mcp_login.go
+++ b/internal/handler/mcp_login.go
@@ -32,8 +32,10 @@ func (h *MCPLoginHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 
 	switch result.Action {
 	case service.ActionRedirectToIdP:
+		//nolint:gosec // Redirect target is the upstream IdP authorization URL built by MCPLoginService.
 		http.Redirect(w, r, result.RedirectURL, http.StatusFound)
 	case service.ActionAutoApprove:
+		//nolint:gosec // Internal redirect to the fixed OIDC callback with a service-issued auth request ID.
 		http.Redirect(w, r, "/authorize/callback?id="+result.AuthRequestID, http.StatusFound)
 	case service.ActionError:
 		h.renderError(w, result.ErrorCode, result.Error)
@@ -55,6 +57,7 @@ func (h *MCPLoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request)
 		if result.SessionID != "" {
 			setSessionCookie(w, result.SessionID, h.devMode)
 		}
+		//nolint:gosec // Internal redirect to the fixed OIDC callback with a service-issued auth request ID.
 		http.Redirect(w, r, "/authorize/callback?id="+result.AuthRequestID, http.StatusFound)
 	case service.ActionError:
 		h.renderError(w, result.ErrorCode, result.Error)
@@ -66,5 +69,5 @@ func (h *MCPLoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request)
 func (h *MCPLoginHandler) renderError(w http.ResponseWriter, code int, message string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(code)
-	pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: code, Message: message})
+	_ = pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: code, Message: message})
 }

--- a/internal/handler/session_cookie.go
+++ b/internal/handler/session_cookie.go
@@ -5,6 +5,7 @@ import "net/http"
 const sessionCookieName = "authgate_session"
 
 func setSessionCookie(w http.ResponseWriter, sessionID string, devMode bool) {
+	//nolint:gosec // Secure=false is allowed only in explicit DEV_MODE for localhost development.
 	http.SetCookie(w, &http.Cookie{
 		Name:     sessionCookieName,
 		Value:    sessionID,

--- a/internal/integration/integration_account_test.go
+++ b/internal/integration/integration_account_test.go
@@ -51,7 +51,7 @@ func TestIntegration_DeleteAccount_InactiveUser_Rejected(t *testing.T) {
 			ts := SetupTestServer(t)
 			ctx := context.Background()
 
-			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "inactive-delete-"+tt.name+"@test.com", EmailVerified: true, Name: "Inactive Delete", AvatarURL: "", Provider: "google", ProviderUserID: "inactive-delete-sub-"+tt.name, ProviderEmail: "inactive-delete-"+tt.name+"@test.com"})
+			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "inactive-delete-" + tt.name + "@test.com", EmailVerified: true, Name: "Inactive Delete", AvatarURL: "", Provider: "google", ProviderUserID: "inactive-delete-sub-" + tt.name, ProviderEmail: "inactive-delete-" + tt.name + "@test.com"})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}

--- a/internal/integration/integration_device_test.go
+++ b/internal/integration/integration_device_test.go
@@ -248,10 +248,11 @@ func TestIntegration_DevicePolling_RechecksUserStatus(t *testing.T) {
 // or buggy clients free to hammer the DB.
 //
 // Cadence under test (FixedClock):
-//   poll #1 (t=0)        — first poll seeds last_polled_at; expect authorization_pending
-//   poll #2 (t=0)        — same instant; delta=0 < 5s interval; expect slow_down
-//   advance clock +6s
-//   poll #3 (t=6s)       — delta=6s >= 5s; expect authorization_pending again
+//
+//	poll #1 (t=0)        — first poll seeds last_polled_at; expect authorization_pending
+//	poll #2 (t=0)        — same instant; delta=0 < 5s interval; expect slow_down
+//	advance clock +6s
+//	poll #3 (t=6s)       — delta=6s >= 5s; expect authorization_pending again
 func TestIntegration_DevicePolling_EnforcesSlowDown(t *testing.T) {
 	ts := SetupTestServer(t)
 

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -160,17 +160,17 @@ func SetupTestServerWithOptions(t *testing.T, opts SetupOptions) *TestServer {
 	// Routes
 	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
 		metadata := map[string]any{
-			"issuer":                        srv.URL,
-			"authorization_endpoint":        srv.URL + "/authorize",
-			"token_endpoint":                srv.URL + "/oauth/token",
-			"revocation_endpoint":           srv.URL + "/oauth/revoke",
-			"introspection_endpoint":        srv.URL + "/oauth/introspect",
-			"device_authorization_endpoint": srv.URL + "/oauth/device/authorize",
-			"userinfo_endpoint":             srv.URL + "/userinfo",
-			"end_session_endpoint":          srv.URL + "/end_session",
-			"jwks_uri":                      srv.URL + "/keys",
-			"response_types_supported":      []string{"code"},
-			"grant_types_supported":         []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
+			"issuer":                           srv.URL,
+			"authorization_endpoint":           srv.URL + "/authorize",
+			"token_endpoint":                   srv.URL + "/oauth/token",
+			"revocation_endpoint":              srv.URL + "/oauth/revoke",
+			"introspection_endpoint":           srv.URL + "/oauth/introspect",
+			"device_authorization_endpoint":    srv.URL + "/oauth/device/authorize",
+			"userinfo_endpoint":                srv.URL + "/userinfo",
+			"end_session_endpoint":             srv.URL + "/end_session",
+			"jwks_uri":                         srv.URL + "/keys",
+			"response_types_supported":         []string{"code"},
+			"grant_types_supported":            []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
 			"code_challenge_methods_supported": []string{"S256"},
 			// Mirror the production metadata contract: advertise every auth
 			// method the underlying op accepts (#189 / RFC 8414 §2).

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -77,7 +77,7 @@ func (c *corsWriter) flushCORSHeaders() {
 		return
 	}
 	c.written = true
-	h := c.ResponseWriter.Header()
+	h := c.Header()
 	if c.matched {
 		h.Set("Access-Control-Allow-Origin", c.origin)
 		h.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -99,4 +99,3 @@ func (rl *RateLimiter) evict(maxAge time.Duration) {
 		}
 	}
 }
-

--- a/internal/service/access.go
+++ b/internal/service/access.go
@@ -4,9 +4,9 @@ package service
 type AccessResult int
 
 const (
-	AccessAllow    AccessResult = iota // Proceed normally
-	AccessRecover                      // Browser-only: recover from pending_deletion, then proceed
-	AccessDeny                         // Reject with 403
+	AccessAllow   AccessResult = iota // Proceed normally
+	AccessRecover                     // Browser-only: recover from pending_deletion, then proceed
+	AccessDeny                        // Reject with 403
 )
 
 // CheckAccess is a pure function that determines access based on user status and channel.

--- a/internal/service/account_unit_test.go
+++ b/internal/service/account_unit_test.go
@@ -156,4 +156,3 @@ func TestAccount_RequestDeletion_InvalidSession(t *testing.T) {
 		t.Fatalf("errorCode = %d, want 401", result.ErrorCode)
 	}
 }
-

--- a/internal/service/device_unit_test.go
+++ b/internal/service/device_unit_test.go
@@ -225,8 +225,8 @@ type countingProvider struct {
 	user          *upstream.UserInfo
 }
 
-func (c *countingProvider) Name() string                 { return "counting" }
-func (c *countingProvider) AuthURL(state string) string  { return "/auth?state=" + state }
+func (c *countingProvider) Name() string                { return "counting" }
+func (c *countingProvider) AuthURL(state string) string { return "/auth?state=" + state }
 func (c *countingProvider) Exchange(_ context.Context, _ string) (*upstream.UserInfo, error) {
 	c.exchangeCalls++
 	if c.user == nil {

--- a/internal/storage/cleanup_runner.go
+++ b/internal/storage/cleanup_runner.go
@@ -26,7 +26,7 @@ func (r *CleanupRunner) WithExclusiveLock(ctx context.Context, fn func(context.C
 	if err != nil {
 		return false, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	qconn := storeq.New(conn)
 
 	acquired, err := qconn.TryCleanupAdvisoryLock(ctx, cleanupAdvisoryLockKey)
@@ -95,7 +95,7 @@ func (r *CleanupRunner) DeleteUser(
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 	qtx := storeq.New(tx)
 
 	// #182: run the guarded parent UPDATE first so the child deletes only

--- a/internal/storage/clients.go
+++ b/internal/storage/clients.go
@@ -38,6 +38,7 @@ const (
 
 // LoadClientConfig reads and parses a clients.yaml file.
 func LoadClientConfig(path string) (*ClientConfigFile, error) {
+	//nolint:gosec // Path is operator-controlled CLIENT_CONFIG, not user input.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err

--- a/internal/storage/keys.go
+++ b/internal/storage/keys.go
@@ -11,6 +11,7 @@ import (
 
 // LoadOrGenerateKey loads an RSA private key from path, or generates a new one if not found.
 func LoadOrGenerateKey(path string) (*rsa.PrivateKey, error) {
+	//nolint:gosec // Path is operator-controlled SIGNING_KEY_PATH, not user input.
 	data, err := os.ReadFile(path)
 	if err == nil {
 		return parseRSAKey(data)

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -147,7 +147,7 @@ func (s *Storage) CreateAccessAndRefreshTokens(ctx context.Context, request op.T
 	if err != nil {
 		return "", "", time.Time{}, err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 	qtx := storeq.New(tx)
 
 	derived, err := s.deriveRefreshTokenAttributes(ctx, qtx, request, currentRefreshToken)
@@ -199,7 +199,7 @@ func (s *Storage) TokenRequestByRefreshToken(ctx context.Context, refreshToken s
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 	qtx := storeq.New(tx)
 
 	rt, err := loadRefreshTokenForUpdate(ctx, qtx, h)
@@ -478,15 +478,6 @@ func tryRevokeRefreshByHash(ctx context.Context, q *storeq.Queries, tokenOrToken
 		return false
 	}
 	return rows > 0
-}
-
-func tryRevokeRefreshByID(ctx context.Context, q *storeq.Queries, tokenOrTokenID string, now time.Time) {
-	if _, err := uuid.Parse(tokenOrTokenID); err == nil {
-		_ = q.RevokeRefreshTokenByID(ctx, storeq.RevokeRefreshTokenByIDParams{
-			RevokedAt: sql.NullTime{Time: now, Valid: true},
-			ID:        tokenOrTokenID,
-		})
-	}
 }
 
 // tryRevokeRefreshByIDReturning attempts to revoke a refresh token by UUID ID and returns true if a row was affected.

--- a/internal/storage/storage_oidc_device.go
+++ b/internal/storage/storage_oidc_device.go
@@ -136,7 +136,7 @@ func (s *Storage) GetDeviceAuthorizatonState(ctx context.Context, clientID, devi
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 	qtx := storeq.New(tx)
 
 	dc, err := loadDeviceAuthorizationForUpdate(ctx, qtx, clientID, deviceCode)

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -25,7 +25,7 @@ func (s *Storage) CreateUserWithIdentity(ctx context.Context, input CreateUserWi
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	now := s.clock.Now()
 	userID := s.idgen.NewUUID()
@@ -199,7 +199,7 @@ func (s *Storage) RequestDeletion(ctx context.Context, userID string) (string, e
 	if err != nil {
 		return "", err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	qtx := storeq.New(tx)
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -12,8 +13,8 @@ import (
 func NewRuntimeHandler() http.Handler {
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(
-		prometheus.NewGoCollector(),
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
 	return promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
 }

--- a/internal/upstream/oidc.go
+++ b/internal/upstream/oidc.go
@@ -51,7 +51,7 @@ func NewOIDCProvider(ctx context.Context, issuerURL, clientID, clientSecret, red
 		opt(o)
 	}
 
-	var transport http.RoundTripper = http.DefaultTransport
+	transport := http.RoundTripper(http.DefaultTransport)
 	if o.internalURL != "" {
 		issuerParsed, _ := url.Parse(issuerURL)
 		internalParsed, _ := url.Parse(o.internalURL)


### PR DESCRIPTION
## Summary

Adds the llmgate-style CI quality gates that apply to authgate:

- gofmt check
- golangci-lint check, run with the module's Go toolchain
- go test -race check
- pinned govulncheck with Go 1.26-compatible execution
- Dependabot weekly grouped updates for Go modules and GitHub Actions

Also cleans up existing lint findings so the new lint gate passes immediately.

## Notes

The llmgate cassette e2e workflow was not copied because it is specific to LLM vendor fixtures. Authgate already has integration coverage and SQLC checks, so those remain in place.

## Validation

- `make lint`
- `go test -race ./...`
- `go test -tags=integration ./internal/...`
- runtime package `govulncheck`: No vulnerabilities found
- workflow/dependabot YAML parsing
- `gofmt -l .`
- `git diff --check`
