### PR TITLE
fix(test): remove stray blank line failing gofmt

### DIFF
--- a/internal/storage/storage_integration_test.go
+++ b/internal/storage/storage_integration_test.go
@@ -232,7 +232,6 @@ func TestSession_StatusFilter(t *testing.T) {
 	}
 }
 
-
 // #183: RequestDeletion must NOT overwrite a closed-account status. The
 // browser-channel recovery path treats `pending_deletion` as recoverable, so
 // if `disabled` (operator suspension) silently became `pending_deletion`


### PR DESCRIPTION
## Summary
- Removes a leftover double blank line in `storage_integration_test.go` left by the console test removal in #258, which failed the **Go Format** CI gate on main.

All other gates (SQLC, Test, Race, Go Vet, GolangCI-Lint, Vulnerability Check) passed on the #258 merge; this restores green.

## Test plan
- [x] `gofmt -l internal cmd` reports clean