### PR TITLE
refactor: remove avatar URL persistence

### DIFF
--- a/docs/spec/001-signup.md
+++ b/docs/spec/001-signup.md
@@ -58,7 +58,7 @@ sequenceDiagram
     AG->>IdP: token exchange (authorization code)
     IdP-->>AG: access_token + id_token
     AG->>IdP: GET /userinfo (또는 id_token 디코딩)
-    IdP-->>AG: {sub, email, email_verified, name, picture}
+    IdP-->>AG: {sub, email, email_verified, name}
 
     Note over U,DB: 2. 신규/기존 판별
     AG->>DB: SELECT FROM user_identities WHERE provider='google' AND provider_user_id=$sub
@@ -103,7 +103,6 @@ users:
   email:           IdP 이메일 (표시용)
   email_verified:  IdP 검증 결과
   name:            IdP 프로필 이름
-  avatar_url:      IdP picture (프로필 이미지 URL)
   status:          'active'
 
 user_identities:

--- a/docs/spec/006-account-lifecycle.md
+++ b/docs/spec/006-account-lifecycle.md
@@ -111,7 +111,6 @@ BEGIN;
 UPDATE users SET
   email = 'deleted-' || id::text || '@deleted.invalid',
   name = NULL,
-  avatar_url = NULL,
   status = 'deleted',
   deleted_at = NOW(),
   deletion_requested_at = NULL,

--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -18,7 +18,6 @@ erDiagram
         text email UK "NOT NULL"
         boolean email_verified "NOT NULL, DEFAULT false"
         text name "nullable"
-        text avatar_url "nullable"
         text status "NOT NULL, DEFAULT 'active', CHECK (active/disabled/pending_deletion/deleted)"
         timestamptz deletion_requested_at "nullable"
         timestamptz deletion_scheduled_at "nullable"
@@ -233,7 +232,7 @@ MCP
 | refresh_token은 SHA-256 해시로 저장 | `token_hash` 컬럼 |
 | client_secret은 bcrypt 해시로 저장 | `clients.yaml`의 `client_secret_hash` 필드 |
 | access_token(JWT)은 DB에 저장하지 않음 | stateless |
-| PII 스크러빙 시 email, name, avatar_url 제거 | `deleted` 상태 전이 시 |
+| PII 스크러빙 시 email, name 제거 | `deleted` 상태 전이 시 |
 | audit_log는 보존기간 후 user_id/IP/User-Agent 익명화 | cleanup job + `AUDIT_LOG_PII_RETENTION_DAYS` |
 
 ## 감사 이벤트 (audit_log.event_type)

--- a/docs/tests/005-upstream-provider.md
+++ b/docs/tests/005-upstream-provider.md
@@ -105,7 +105,7 @@ rp 라이브러리가 ID token을 검증하므로, fake IdP는:
 
 | ID | 시나리오 | 입력 | 기대 결과 | 검증 포인트 |
 |----|----------|------|----------|-------------|
-| `oidc-exchange-001` | 정상 교환 | 유효한 code | `UserInfo` 반환 | sub, email, name, picture 올바르게 매핑 |
+| `oidc-exchange-001` | 정상 교환 | 유효한 code | `UserInfo` 반환 | sub, email, name 올바르게 매핑 |
 | `oidc-exchange-002` | 토큰 엔드포인트 에러 | 401 응답 | 에러 반환 | rp 라이브러리 에러 전파 |
 | `oidc-exchange-003` | UserInfo 엔드포인트 에러 | 토큰 성공 + userinfo 401 | 에러 반환 | 2단계 에러 전파 |
 
@@ -113,11 +113,10 @@ rp 라이브러리가 ID token을 검증하므로, fake IdP는:
 
 | ID | 시나리오 | 입력 | 기대 결과 | 검증 포인트 |
 |----|----------|------|----------|-------------|
-| `oidc-map-001` | 전체 필드 매핑 | 모든 필드 포함 UserInfo | 모든 필드 올바르게 매핑 | sub, email, email_verified, name, picture |
+| `oidc-map-001` | 전체 필드 매핑 | 필수/표시 필드 포함 UserInfo | 필드 올바르게 매핑 | sub, email, email_verified, name |
 | `oidc-map-002` | email_verified=true | `"email_verified": true` | `UserInfo.EmailVerified == true` | **email_verified 버그 수정 회귀 테스트 (핵심)** |
 | `oidc-map-003` | email_verified=false | `"email_verified": false` | `UserInfo.EmailVerified == false` | false도 정상 매핑 |
 | `oidc-map-004` | email_verified 누락 | 필드 없음 | `UserInfo.EmailVerified == false` | 기본값 처리 |
-| `oidc-map-005` | picture 포함 | `"picture": "https://..."` | `UserInfo.Picture` 설정 | avatar_url 저장 연계 |
 
 ### 전체 통합
 

--- a/internal/db/queries/cleanup.sql
+++ b/internal/db/queries/cleanup.sql
@@ -45,7 +45,6 @@ WHERE user_id = $1;
 UPDATE users SET
   email = 'deleted-' || id::text || '@deleted.invalid',
   name = NULL,
-  avatar_url = NULL,
   status = 'deleted',
   deleted_at = sqlc.arg(deleted_at),
   deletion_requested_at = NULL,

--- a/internal/db/queries/sessions.sql
+++ b/internal/db/queries/sessions.sql
@@ -3,7 +3,7 @@ INSERT INTO sessions (id, user_id, expires_at, created_at)
 VALUES ($1, $2, $3, $4);
 
 -- name: GetValidSessionUser :one
-SELECT u.id, u.email, u.email_verified, u.name, u.avatar_url, u.status,
+SELECT u.id, u.email, u.email_verified, u.name, u.status,
        u.created_at, u.updated_at
 FROM sessions s
 JOIN users u ON s.user_id = u.id

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -1,20 +1,20 @@
 -- name: InsertUser :exec
-INSERT INTO users (id, email, email_verified, name, avatar_url, status, created_at, updated_at)
-VALUES ($1, $2, $3, $4, $5, 'active', $6, $6);
+INSERT INTO users (id, email, email_verified, name, status, created_at, updated_at)
+VALUES ($1, $2, $3, $4, 'active', $5, $5);
 
 -- name: InsertUserIdentity :exec
 INSERT INTO user_identities (id, user_id, provider, provider_user_id, provider_email, created_at)
 VALUES ($1, $2, $3, $4, $5, $6);
 
 -- name: GetUserByProviderIdentity :one
-SELECT u.id, u.email, u.email_verified, u.name, u.avatar_url, u.status,
+SELECT u.id, u.email, u.email_verified, u.name, u.status,
        u.created_at, u.updated_at
 FROM users u
 JOIN user_identities ui ON u.id = ui.user_id
 WHERE ui.provider = $1 AND ui.provider_user_id = $2;
 
 -- name: GetUserByID :one
-SELECT id, email, email_verified, name, avatar_url, status,
+SELECT id, email, email_verified, name, status,
        created_at, updated_at
 FROM users
 WHERE id = $1;

--- a/internal/db/storeq/cleanup.sql.go
+++ b/internal/db/storeq/cleanup.sql.go
@@ -177,7 +177,6 @@ const markUserDeletedByID = `-- name: MarkUserDeletedByID :execrows
 UPDATE users SET
   email = 'deleted-' || id::text || '@deleted.invalid',
   name = NULL,
-  avatar_url = NULL,
   status = 'deleted',
   deleted_at = $1,
   deletion_requested_at = NULL,

--- a/internal/db/storeq/models.go
+++ b/internal/db/storeq/models.go
@@ -81,7 +81,6 @@ type User struct {
 	Email               string
 	EmailVerified       bool
 	Name                sql.NullString
-	AvatarUrl           sql.NullString
 	Status              string
 	DeletionRequestedAt sql.NullTime
 	DeletionScheduledAt sql.NullTime

--- a/internal/db/storeq/sessions.sql.go
+++ b/internal/db/storeq/sessions.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getValidSessionUser = `-- name: GetValidSessionUser :one
-SELECT u.id, u.email, u.email_verified, u.name, u.avatar_url, u.status,
+SELECT u.id, u.email, u.email_verified, u.name, u.status,
        u.created_at, u.updated_at
 FROM sessions s
 JOIN users u ON s.user_id = u.id
@@ -29,7 +29,6 @@ type GetValidSessionUserRow struct {
 	Email         string
 	EmailVerified bool
 	Name          sql.NullString
-	AvatarUrl     sql.NullString
 	Status        string
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
@@ -43,7 +42,6 @@ func (q *Queries) GetValidSessionUser(ctx context.Context, arg GetValidSessionUs
 		&i.Email,
 		&i.EmailVerified,
 		&i.Name,
-		&i.AvatarUrl,
 		&i.Status,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/internal/db/storeq/users.sql.go
+++ b/internal/db/storeq/users.sql.go
@@ -32,7 +32,7 @@ func (q *Queries) CompleteAuthRequestByID(ctx context.Context, arg CompleteAuthR
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, email, email_verified, name, avatar_url, status,
+SELECT id, email, email_verified, name, status,
        created_at, updated_at
 FROM users
 WHERE id = $1
@@ -43,7 +43,6 @@ type GetUserByIDRow struct {
 	Email         string
 	EmailVerified bool
 	Name          sql.NullString
-	AvatarUrl     sql.NullString
 	Status        string
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
@@ -57,7 +56,6 @@ func (q *Queries) GetUserByID(ctx context.Context, id string) (GetUserByIDRow, e
 		&i.Email,
 		&i.EmailVerified,
 		&i.Name,
-		&i.AvatarUrl,
 		&i.Status,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -66,7 +64,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id string) (GetUserByIDRow, e
 }
 
 const getUserByProviderIdentity = `-- name: GetUserByProviderIdentity :one
-SELECT u.id, u.email, u.email_verified, u.name, u.avatar_url, u.status,
+SELECT u.id, u.email, u.email_verified, u.name, u.status,
        u.created_at, u.updated_at
 FROM users u
 JOIN user_identities ui ON u.id = ui.user_id
@@ -83,7 +81,6 @@ type GetUserByProviderIdentityRow struct {
 	Email         string
 	EmailVerified bool
 	Name          sql.NullString
-	AvatarUrl     sql.NullString
 	Status        string
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
@@ -97,7 +94,6 @@ func (q *Queries) GetUserByProviderIdentity(ctx context.Context, arg GetUserByPr
 		&i.Email,
 		&i.EmailVerified,
 		&i.Name,
-		&i.AvatarUrl,
 		&i.Status,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -250,8 +246,8 @@ func (q *Queries) InsertTestAuthRequestWithResource(ctx context.Context, arg Ins
 }
 
 const insertUser = `-- name: InsertUser :exec
-INSERT INTO users (id, email, email_verified, name, avatar_url, status, created_at, updated_at)
-VALUES ($1, $2, $3, $4, $5, 'active', $6, $6)
+INSERT INTO users (id, email, email_verified, name, status, created_at, updated_at)
+VALUES ($1, $2, $3, $4, 'active', $5, $5)
 `
 
 type InsertUserParams struct {
@@ -259,7 +255,6 @@ type InsertUserParams struct {
 	Email         string
 	EmailVerified bool
 	Name          sql.NullString
-	AvatarUrl     sql.NullString
 	CreatedAt     time.Time
 }
 
@@ -269,7 +264,6 @@ func (q *Queries) InsertUser(ctx context.Context, arg InsertUserParams) error {
 		arg.Email,
 		arg.EmailVerified,
 		arg.Name,
-		arg.AvatarUrl,
 		arg.CreatedAt,
 	)
 	return err

--- a/internal/integration/integration_account_test.go
+++ b/internal/integration/integration_account_test.go
@@ -18,7 +18,7 @@ func TestIntegration_DeleteAccount_WrongOrigin_Rejected(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user + get session
-	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "origin-test@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "o@test.com"})
+	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "origin-test@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "o@test.com"})
 	sessionID, _ := ts.Store.CreateSession(ctx, user.ID, 24*3600*1e9)
 
 	req, _ := http.NewRequest("DELETE", ts.BaseURL+"/account", nil)
@@ -51,7 +51,7 @@ func TestIntegration_DeleteAccount_InactiveUser_Rejected(t *testing.T) {
 			ts := SetupTestServer(t)
 			ctx := context.Background()
 
-			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "inactive-delete-" + tt.name + "@test.com", EmailVerified: true, Name: "Inactive Delete", AvatarURL: "", Provider: "google", ProviderUserID: "inactive-delete-sub-" + tt.name, ProviderEmail: "inactive-delete-" + tt.name + "@test.com"})
+			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "inactive-delete-" + tt.name + "@test.com", EmailVerified: true, Name: "Inactive Delete", Provider: "google", ProviderUserID: "inactive-delete-sub-" + tt.name, ProviderEmail: "inactive-delete-" + tt.name + "@test.com"})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}
@@ -95,7 +95,7 @@ func TestIntegration_DeleteAccount_ResponseShape(t *testing.T) {
 	ts := SetupTestServer(t)
 	ctx := context.Background()
 
-	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "shape@test.com", EmailVerified: true, Name: "Shape", AvatarURL: "", Provider: "google", ProviderUserID: "shape-sub", ProviderEmail: "shape@test.com"})
+	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "shape@test.com", EmailVerified: true, Name: "Shape", Provider: "google", ProviderUserID: "shape-sub", ProviderEmail: "shape@test.com"})
 	sessionID, _ := ts.Store.CreateSession(ctx, user.ID, 24*3600*1e9)
 
 	req, _ := http.NewRequest(http.MethodDelete, ts.BaseURL+"/account", nil)

--- a/internal/integration/integration_at_jwt_test.go
+++ b/internal/integration/integration_at_jwt_test.go
@@ -25,7 +25,7 @@ func TestAccessToken_TypIsAtJWTAndIDTokenStaysJWT(t *testing.T) {
 
 	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
 		Email: "atjwt@test.com", EmailVerified: true, Name: "AT JWT",
-		AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub",
+		Provider: "google", ProviderUserID: "test-google-sub",
 		ProviderEmail: "atjwt@test.com",
 	}); err != nil {
 		t.Fatalf("create user: %v", err)

--- a/internal/integration/integration_device_test.go
+++ b/internal/integration/integration_device_test.go
@@ -48,7 +48,7 @@ func TestIntegration_DeviceCallback_PendingDeletion_Rejected(t *testing.T) {
 	ts := SetupTestServer(t)
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-pending@test.com", EmailVerified: true, Name: "Device Pending", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-pending@test.com"})
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-pending@test.com", EmailVerified: true, Name: "Device Pending", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-pending@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestIntegration_DeviceConsumed_RePolling(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user and approve device code
-	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-consumed@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-consumed-sub", ProviderEmail: "dc@test.com"})
+	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-consumed@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-consumed-sub", ProviderEmail: "dc@test.com"})
 	_ = user
 
 	// Store a device code and approve it
@@ -115,7 +115,7 @@ func TestIntegration_DeviceFullFlow_TokenIssued(t *testing.T) {
 	ts := SetupTestServer(t)
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-ok@test.com", EmailVerified: true, Name: "Device OK", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-ok@test.com"})
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-ok@test.com", EmailVerified: true, Name: "Device OK", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-ok@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestIntegration_DeviceConcurrentPolling_ExactlyOneSuccess(t *testing.T) {
 	ts := SetupTestServer(t)
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-race@test.com", EmailVerified: true, Name: "Device Race", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-race@test.com"})
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-race@test.com", EmailVerified: true, Name: "Device Race", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-race@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestIntegration_DevicePolling_RechecksUserStatus(t *testing.T) {
 			ctx := context.Background()
 
 			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
-				Email: "device-" + tc.flipStatus + "@test.com", EmailVerified: true, Name: "Flipped Mid-Flow", AvatarURL: "",
+				Email: "device-" + tc.flipStatus + "@test.com", EmailVerified: true, Name: "Flipped Mid-Flow",
 				Provider: "google", ProviderUserID: "test-google-sub-" + tc.flipStatus, ProviderEmail: "device-" + tc.flipStatus + "@test.com",
 			})
 			if err != nil {
@@ -291,7 +291,7 @@ func TestIntegration_DevicePolling_SlowDownThenApprove_Succeeds(t *testing.T) {
 
 	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
 		Email: "device-slow-then-approve@test.com", EmailVerified: true, Name: "Slow Then Approve",
-		AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-slow-then-approve@test.com",
+		Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-slow-then-approve@test.com",
 	})
 	if err != nil {
 		t.Fatalf("create user: %v", err)

--- a/internal/integration/integration_mcp_resource_test.go
+++ b/internal/integration/integration_mcp_resource_test.go
@@ -58,7 +58,7 @@ func TestMCPResourceBinding(t *testing.T) {
 
 		if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
 			Email: "mcp-resource-ok@test.com", EmailVerified: true, Name: "MCP Resource OK",
-			AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub",
+			Provider: "google", ProviderUserID: "test-google-sub",
 			ProviderEmail: "mcp-resource-ok@test.com",
 		}); err != nil {
 			t.Fatalf("create user: %v", err)
@@ -179,7 +179,7 @@ func TestMCPResourceBinding(t *testing.T) {
 
 		if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
 			Email: "mcp-resource-mismatch@test.com", EmailVerified: true, Name: "MCP Resource Mismatch",
-			AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub",
+			Provider: "google", ProviderUserID: "test-google-sub",
 			ProviderEmail: "mcp-resource-mismatch@test.com",
 		}); err != nil {
 			t.Fatalf("create user: %v", err)

--- a/internal/integration/integration_mcp_test.go
+++ b/internal/integration/integration_mcp_test.go
@@ -18,7 +18,7 @@ func TestIntegration_MCPTokenExchange_NoPKCE_Rejected(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-pkce@test.com", EmailVerified: true, Name: "MCP PKCE", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-pkce@test.com"})
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-pkce@test.com", EmailVerified: true, Name: "MCP PKCE", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-pkce@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestIntegration_MCPTokenExchange_MissingResource_Rejected(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-missing-resource@test.com", EmailVerified: true, Name: "MCP Missing Resource", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-missing-resource@test.com"}); err != nil {
+	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-missing-resource@test.com", EmailVerified: true, Name: "MCP Missing Resource", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-missing-resource@test.com"}); err != nil {
 		t.Fatalf("create user: %v", err)
 	}
 
@@ -73,7 +73,7 @@ func TestIntegration_MCPRefresh_MismatchedResource_Rejected(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-refresh-resource@test.com", EmailVerified: true, Name: "MCP Refresh Resource", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-refresh-resource@test.com"}); err != nil {
+	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-refresh-resource@test.com", EmailVerified: true, Name: "MCP Refresh Resource", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-refresh-resource@test.com"}); err != nil {
 		t.Fatalf("create user: %v", err)
 	}
 
@@ -98,7 +98,7 @@ func TestIntegration_MCPAccessToken_AudienceBoundToResource(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-audience@test.com", EmailVerified: true, Name: "MCP Audience", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-audience@test.com"}); err != nil {
+	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-audience@test.com", EmailVerified: true, Name: "MCP Audience", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-audience@test.com"}); err != nil {
 		t.Fatalf("create user: %v", err)
 	}
 
@@ -144,7 +144,7 @@ func TestIntegration_MCPCodeExchange_StateChange_InvalidGrant(t *testing.T) {
 			client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 
 			ctx := context.Background()
-			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-token-state@test.com", EmailVerified: true, Name: "MCP Token", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-token-state@test.com"})
+			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-token-state@test.com", EmailVerified: true, Name: "MCP Token", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-token-state@test.com"})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}
@@ -195,7 +195,7 @@ func TestIntegration_MCPCallback_PendingDeletion_Rejected(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-callback-pending@test.com", EmailVerified: true, Name: "MCP Callback Pending", AvatarURL: "", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-callback-pending@test.com"})
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-callback-pending@test.com", EmailVerified: true, Name: "MCP Callback Pending", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-callback-pending@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}

--- a/internal/service/account_test.go
+++ b/internal/service/account_test.go
@@ -50,7 +50,7 @@ func setupAccountTest(t *testing.T) *accountFixture {
 func createUserWithSession(t *testing.T, store *storage.Storage, email, sub string) (string, string) {
 	t.Helper()
 	ctx := context.Background()
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: sub, ProviderEmail: email})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: sub, ProviderEmail: email})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestAccount004_PendingDeletion_DeviceRejected(t *testing.T) {
 	fx := setupGapTest(t)
 	ctx := context.Background()
 
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pd-device@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "pd@test.com"})
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pd-device@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "pd@test.com"})
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 	insertDeviceCode(t, fx.Store, "PD-CODE", fx.Clock)
 
@@ -230,7 +230,7 @@ func TestAccount004b_PendingDeletion_MCPRejected(t *testing.T) {
 	fx := setupGapTest(t)
 	ctx := context.Background()
 
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pd-mcp@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "pdm@test.com"})
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pd-mcp@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "pdm@test.com"})
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	arID, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "pd-mcp", "http://localhost/mcp")

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -92,7 +92,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		svc, store := setupBrowserExtTest(t)
 		ctx := context.Background()
 
-		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-browser@test.com", EmailVerified: true, Name: "Browser", AvatarURL: "", Provider: "google", ProviderUserID: "browser-ext-sub", ProviderEmail: "audit-browser@test.com"})
+		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-browser@test.com", EmailVerified: true, Name: "Browser", Provider: "google", ProviderUserID: "browser-ext-sub", ProviderEmail: "audit-browser@test.com"})
 		if err != nil {
 			t.Fatalf("create user: %v", err)
 		}
@@ -113,7 +113,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		svc, store, clk := setupDeviceExtTest(t, "audit-device-sub")
 		ctx := context.Background()
 
-		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device@test.com", EmailVerified: true, Name: "Device", AvatarURL: "", Provider: "google", ProviderUserID: "audit-device-sub", ProviderEmail: "audit-device@test.com"})
+		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device@test.com", EmailVerified: true, Name: "Device", Provider: "google", ProviderUserID: "audit-device-sub", ProviderEmail: "audit-device@test.com"})
 		if err != nil {
 			t.Fatalf("create user: %v", err)
 		}
@@ -134,7 +134,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		svc, store := setupMCPExtTest(t, "audit-mcp-sub")
 		ctx := context.Background()
 
-		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp@test.com", EmailVerified: true, Name: "MCP", AvatarURL: "", Provider: "google", ProviderUserID: "audit-mcp-sub", ProviderEmail: "audit-mcp@test.com"})
+		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "audit-mcp-sub", ProviderEmail: "audit-mcp@test.com"})
 		if err != nil {
 			t.Fatalf("create user: %v", err)
 		}
@@ -160,7 +160,7 @@ func TestAudit_ReusedSession_AuthLoginRecorded(t *testing.T) {
 	svc, store := setupBrowserExtTest(t)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-reuse@test.com", EmailVerified: true, Name: "Reuse", AvatarURL: "", Provider: "google", ProviderUserID: "browser-ext-sub", ProviderEmail: "audit-reuse@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-reuse@test.com", EmailVerified: true, Name: "Reuse", Provider: "google", ProviderUserID: "browser-ext-sub", ProviderEmail: "audit-reuse@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestAudit_ReusedSession_MCP_AuthLoginRecorded(t *testing.T) {
 	svc, store := setupMCPExtTest(t, "audit-mcp-reuse-sub")
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp-reuse@test.com", EmailVerified: true, Name: "MCP Reuse", AvatarURL: "", Provider: "google", ProviderUserID: "audit-mcp-reuse-sub", ProviderEmail: "audit-mcp-reuse@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp-reuse@test.com", EmailVerified: true, Name: "MCP Reuse", Provider: "google", ProviderUserID: "audit-mcp-reuse-sub", ProviderEmail: "audit-mcp-reuse@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestAudit004_DeviceApproved(t *testing.T) {
 	svc, store, clk := setupDeviceService(t)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-approve@test.com", EmailVerified: true, Name: "Approve", AvatarURL: "", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "audit-approve@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-approve@test.com", EmailVerified: true, Name: "Approve", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "audit-approve@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestAudit005_DeviceDenied(t *testing.T) {
 	svc, store, clk := setupDeviceService(t)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-deny@test.com", EmailVerified: true, Name: "Deny", AvatarURL: "", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "audit-deny@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-deny@test.com", EmailVerified: true, Name: "Deny", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "audit-deny@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestAudit007_DeletionCancelled(t *testing.T) {
 	svc, store := setupLoginService(t)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-recover@test.com", EmailVerified: true, Name: "Recover", AvatarURL: "", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "audit-recover@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-recover@test.com", EmailVerified: true, Name: "Recover", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "audit-recover@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -370,7 +370,7 @@ func TestAudit009_InactiveUser(t *testing.T) {
 			svc, store := setupLoginService(t)
 			ctx := context.Background()
 
-			user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-inactive-" + tt.name + "@test.com", EmailVerified: true, Name: "Inactive", AvatarURL: "", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "audit-inactive@test.com"})
+			user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-inactive-" + tt.name + "@test.com", EmailVerified: true, Name: "Inactive", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "audit-inactive@test.com"})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}
@@ -399,7 +399,7 @@ func TestAuditSecurity003_DeviceInactiveUser(t *testing.T) {
 	svc, store, clk := setupDeviceExtTest(t, "audit-device-inactive-sub")
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-inactive@test.com", EmailVerified: true, Name: "Inactive Device", AvatarURL: "", Provider: "google", ProviderUserID: "audit-device-inactive-sub", ProviderEmail: "audit-device-inactive@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-inactive@test.com", EmailVerified: true, Name: "Inactive Device", Provider: "google", ProviderUserID: "audit-device-inactive-sub", ProviderEmail: "audit-device-inactive@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -423,7 +423,7 @@ func TestAuditSecurity_DevicePendingDeletionInactiveUser(t *testing.T) {
 	svc, store, clk := setupDeviceExtTest(t, "audit-device-pending-sub")
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-pending@test.com", EmailVerified: true, Name: "Pending Device", AvatarURL: "", Provider: "google", ProviderUserID: "audit-device-pending-sub", ProviderEmail: "audit-device-pending@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-pending@test.com", EmailVerified: true, Name: "Pending Device", Provider: "google", ProviderUserID: "audit-device-pending-sub", ProviderEmail: "audit-device-pending@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -461,7 +461,7 @@ func TestAuditSecurity_MCPInactiveUser_Metadata(t *testing.T) {
 			svc, store := setupMCPExtTest(t, "audit-mcp-"+tt.name+"-sub")
 			ctx := context.Background()
 
-			user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp-" + tt.name + "@test.com", EmailVerified: true, Name: "MCP Inactive", AvatarURL: "", Provider: "google", ProviderUserID: "audit-mcp-" + tt.name + "-sub", ProviderEmail: "audit-mcp-" + tt.name + "@test.com"})
+			user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp-" + tt.name + "@test.com", EmailVerified: true, Name: "MCP Inactive", Provider: "google", ProviderUserID: "audit-mcp-" + tt.name + "-sub", ProviderEmail: "audit-mcp-" + tt.name + "@test.com"})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}

--- a/internal/service/cleanup_test.go
+++ b/internal/service/cleanup_test.go
@@ -31,7 +31,7 @@ func TestCleanup_ExpiredSessions(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user + expired session
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "cleanup-session@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "cleanup-session-sub", ProviderEmail: "c@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "cleanup-session@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "cleanup-session-sub", ProviderEmail: "c@test.com"})
 	db.ExecContext(ctx,
 		`INSERT INTO sessions (id, user_id, expires_at, created_at) VALUES (uuid_generate_v4(), $1, $2, $3)`,
 		user.ID, clk.Now().Add(-1*time.Hour), clk.Now().Add(-25*time.Hour), // expired 1 hour ago
@@ -86,7 +86,7 @@ func TestCleanup_DeletionPIIScrub(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user, then set to pending_deletion with past scheduled date
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "delete-me@test.com", EmailVerified: true, Name: "Delete Me", AvatarURL: "", Provider: "google", ProviderUserID: "delete-sub", ProviderEmail: "d@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "delete-me@test.com", EmailVerified: true, Name: "Delete Me", Provider: "google", ProviderUserID: "delete-sub", ProviderEmail: "d@test.com"})
 	db.ExecContext(ctx,
 		`UPDATE users SET status = 'pending_deletion', deletion_scheduled_at = $1 WHERE id = $2`,
 		clk.Now().Add(-1*time.Hour), user.ID, // scheduled in the past
@@ -143,7 +143,7 @@ func TestE2E8_CleanupRollback(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user set for deletion
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "rollback@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "rollback-sub", ProviderEmail: "rb@test.com"})
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "rollback@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "rollback-sub", ProviderEmail: "rb@test.com"})
 	fx.DB.ExecContext(ctx, `UPDATE users SET status='pending_deletion', deletion_scheduled_at=$1 WHERE id=$2`,
 		fx.Clock.Now().Add(-1*time.Hour), user.ID)
 
@@ -200,7 +200,7 @@ func TestCleanup_DeletionPIIScrub_Idempotent(t *testing.T) {
 	db, store, clk := setupCleanupTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "cleanup-idem@test.com", EmailVerified: true, Name: "Idem", AvatarURL: "", Provider: "google", ProviderUserID: "cleanup-idem-sub", ProviderEmail: "cleanup-idem@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "cleanup-idem@test.com", EmailVerified: true, Name: "Idem", Provider: "google", ProviderUserID: "cleanup-idem-sub", ProviderEmail: "cleanup-idem@test.com"})
 	db.ExecContext(ctx,
 		`UPDATE users SET status = 'pending_deletion', deletion_scheduled_at = $1 WHERE id = $2`,
 		clk.Now().Add(-1*time.Hour), user.ID,

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -82,7 +82,7 @@ func TestDevicePage_ValidCode_WithSession_ShowApprove(t *testing.T) {
 	ctx := context.Background()
 
 	// Create active user and session
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-approve@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-approve-sub", ProviderEmail: "d@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-approve@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-approve-sub", ProviderEmail: "d@test.com"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 
 	insertDeviceCode(t, store, "APPR-CODE", clk)
@@ -98,7 +98,7 @@ func TestDevicePage_InactiveUser_Rejected(t *testing.T) {
 	ctx := context.Background()
 
 	// Create disabled user
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-inactive@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-inactive-sub", ProviderEmail: "di@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-inactive@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-inactive-sub", ProviderEmail: "di@test.com"})
 	store.DisableUser(ctx, user.ID)
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 
@@ -117,7 +117,7 @@ func TestDeviceApprove_Allow(t *testing.T) {
 	svc, store, clk := setupDeviceService(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-allow@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-allow-sub", ProviderEmail: "da@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-allow@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-allow-sub", ProviderEmail: "da@test.com"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 
 	insertDeviceCode(t, store, "ALLW-CODE", clk)
@@ -132,7 +132,7 @@ func TestDeviceApprove_Deny(t *testing.T) {
 	svc, store, clk := setupDeviceService(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-deny@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-deny-sub", ProviderEmail: "dd@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-deny@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-deny-sub", ProviderEmail: "dd@test.com"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 
 	insertDeviceCode(t, store, "DENY-CODE", clk)
@@ -176,7 +176,7 @@ func TestDeviceCallback_ExistingUser_RedirectBack(t *testing.T) {
 	svc, store, clk := setupDeviceService(t)
 	ctx := context.Background()
 
-	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-cb@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "dc@test.com"})
+	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-cb@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "dc@test.com"})
 	insertDeviceCode(t, store, "RDIR-CODE", clk)
 
 	result := svc.HandleDeviceCallback(ctx, "fake-code", "RDIR-CODE", "127.0.0.1", "test")
@@ -196,7 +196,7 @@ func TestDevice005_RecoverableCallback_Rejected(t *testing.T) {
 	svc, store, clk := setupDeviceExtTest(t, "dev-recover-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-recover@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-recover-sub", ProviderEmail: "drc@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-recover@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-recover-sub", ProviderEmail: "drc@test.com"})
 	store.SetUserStatus(ctx, user.ID, "pending_deletion")
 	insertDeviceCode(t, store, "RECV-CODE", clk)
 
@@ -214,7 +214,7 @@ func TestDevice006_InactiveCallback_Rejected(t *testing.T) {
 	svc, store, clk := setupDeviceExtTest(t, "dev-inactive-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-inactive@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-inactive-sub", ProviderEmail: "di@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-inactive@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-inactive-sub", ProviderEmail: "di@test.com"})
 	store.DisableUser(ctx, user.ID)
 	insertDeviceCode(t, store, "INAC-CODE", clk)
 
@@ -232,7 +232,7 @@ func TestDeviceCallback_DeletedUser_Rejected(t *testing.T) {
 	svc, store, clk := setupDeviceExtTest(t, "dev-deleted-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-deleted@test.com", EmailVerified: true, Name: "Deleted", AvatarURL: "", Provider: "google", ProviderUserID: "dev-deleted-sub", ProviderEmail: "dev-deleted@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-deleted@test.com", EmailVerified: true, Name: "Deleted", Provider: "google", ProviderUserID: "dev-deleted-sub", ProviderEmail: "dev-deleted@test.com"})
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
 	insertDeviceCode(t, store, "DELD-CODE", clk)
 
@@ -250,7 +250,7 @@ func TestDevice011_ApproveAfterDisable(t *testing.T) {
 	svc, store, clk := setupDeviceExtTest(t, "dev-approve-dis-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-dis@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-approve-dis-sub", ProviderEmail: "dad@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-dis@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-approve-dis-sub", ProviderEmail: "dad@test.com"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 	insertDeviceCode(t, store, "ADIS-CODE", clk)
 
@@ -281,7 +281,7 @@ func TestDeviceApprove_AfterStatusTransition_Rejected(t *testing.T) {
 			svc, store, clk := setupDeviceExtTest(t, "dev-approve-"+tt.status)
 			ctx := context.Background()
 
-			user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-" + tt.status + "@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "dev-approve-" + tt.status, ProviderEmail: "dev-approve-" + tt.status + "@test.com"})
+			user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-" + tt.status + "@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-approve-" + tt.status, ProviderEmail: "dev-approve-" + tt.status + "@test.com"})
 			sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 			insertDeviceCode(t, store, "ASTA-"+tt.status, clk)
 

--- a/internal/service/e2e_test.go
+++ b/internal/service/e2e_test.go
@@ -155,7 +155,7 @@ func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
 	fx := setupE2ETest(t)
 	ctx := context.Background()
 
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "e2e4-full@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "e2e-sub", ProviderEmail: "e2e4-full@test.com"})
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "e2e4-full@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "e2e-sub", ProviderEmail: "e2e4-full@test.com"})
 	sessionID, _ := fx.Store.CreateSession(ctx, user.ID, 24*time.Hour)
 	refreshToken := createRefreshTokenForUser(t, ctx, fx.Store, user.ID)
 
@@ -223,7 +223,7 @@ func TestE2E5_RecoveryThenAuthRequestRetry(t *testing.T) {
 	fx := setupE2ETest(t)
 	ctx := context.Background()
 
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "e2e5-retry@test.com", EmailVerified: true, Name: "Retry User", AvatarURL: "", Provider: "google", ProviderUserID: "e2e-sub", ProviderEmail: "e2e5-retry@test.com"})
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "e2e5-retry@test.com", EmailVerified: true, Name: "Retry User", Provider: "google", ProviderUserID: "e2e-sub", ProviderEmail: "e2e5-retry@test.com"})
 	sessionID, _ := fx.Store.CreateSession(ctx, user.ID, 24*time.Hour)
 
 	// 1) pending_deletion 전환

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -267,7 +267,6 @@ func (s *LoginService) signupBrowserUser(ctx context.Context, providerName strin
 		Email:          userInfo.Email,
 		EmailVerified:  userInfo.EmailVerified,
 		Name:           userInfo.Name,
-		AvatarURL:      userInfo.Picture,
 		Provider:       providerName,
 		ProviderUserID: userInfo.Sub,
 		ProviderEmail:  userInfo.Email,

--- a/internal/service/login_test.go
+++ b/internal/service/login_test.go
@@ -28,7 +28,6 @@ func setupLoginService(t *testing.T) (*LoginService, *storage.Storage) {
 			Email:         "test@example.com",
 			EmailVerified: true,
 			Name:          "Test User",
-			Picture:       "https://example.com/photo.jpg",
 		},
 	}
 
@@ -86,7 +85,7 @@ func TestHandleCallback_ExistingUser_AutoApprove(t *testing.T) {
 	ctx := context.Background()
 
 	// Pre-create user
-	_, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "existing@example.com", EmailVerified: true, Name: "Existing", AvatarURL: "", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "existing@example.com"})
+	_, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "existing@example.com", EmailVerified: true, Name: "Existing", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "existing@example.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -112,7 +111,7 @@ func TestHandleCallback_PendingDeletion_RecoveryAutoApprove(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user, then set to pending_deletion
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pending@example.com", EmailVerified: true, Name: "Pending", AvatarURL: "", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "pending@example.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pending@example.com", EmailVerified: true, Name: "Pending", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "pending@example.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -139,7 +138,7 @@ func TestHandleCallback_InactiveUser_Error(t *testing.T) {
 	ctx := context.Background()
 
 	// Create disabled user
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "disabled@example.com", EmailVerified: true, Name: "Disabled", AvatarURL: "", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "disabled@example.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "disabled@example.com", EmailVerified: true, Name: "Disabled", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "disabled@example.com"})
 	store.DisableUser(ctx, user.ID)
 	arID, err := store.CreateTestAuthRequest(ctx, "req-disabled")
 	if err != nil {
@@ -187,7 +186,7 @@ func TestBrowser007_RecoveryRetryIdempotent(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user, then set to pending_deletion
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "retry@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "r@test.com"})
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "retry@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "r@test.com"})
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	// First attempt: callback with bogus authRequestID is rejected before

--- a/internal/service/mcp_test.go
+++ b/internal/service/mcp_test.go
@@ -37,7 +37,7 @@ func TestMCP_CompleteUser_AutoApprove(t *testing.T) {
 	svc, store := setupMCPTest(t)
 	ctx := context.Background()
 
-	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-ok@test.com", EmailVerified: true, Name: "MCP", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-sub-123", ProviderEmail: "mcp@test.com"})
+	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-ok@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "mcp-sub-123", ProviderEmail: "mcp@test.com"})
 	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-ok", "http://localhost/mcp")
 
 	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
@@ -66,7 +66,7 @@ func TestMCP_DisabledUser_Rejected(t *testing.T) {
 	svc, store := setupMCPTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-dis@test.com", EmailVerified: true, Name: "MCP", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-sub-123", ProviderEmail: "mcp@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-dis@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "mcp-sub-123", ProviderEmail: "mcp@test.com"})
 	store.DisableUser(ctx, user.ID)
 
 	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-dis", "http://localhost/mcp")
@@ -85,7 +85,7 @@ func TestMCP005_Recoverable_Rejected(t *testing.T) {
 	svc, store := setupMCPExtTest(t, "mcp-005-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-recover@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-005-sub", ProviderEmail: "mrc@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-recover@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "mcp-005-sub", ProviderEmail: "mrc@test.com"})
 	store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-005", "http://localhost/mcp")
@@ -104,7 +104,7 @@ func TestMCPLogin_PendingDeletionSession_Rejected(t *testing.T) {
 	svc, store := setupMCPTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-login-pending@test.com", EmailVerified: true, Name: "MCP Pending", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-login-pending-sub", ProviderEmail: "mcp-login-pending@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-login-pending@test.com", EmailVerified: true, Name: "MCP Pending", Provider: "google", ProviderUserID: "mcp-login-pending-sub", ProviderEmail: "mcp-login-pending@test.com"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 	_ = store.SetUserStatus(ctx, user.ID, "pending_deletion")
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-login-pending")
@@ -129,7 +129,7 @@ func TestMCPLogin_DeletedSession_Rejected(t *testing.T) {
 	svc, store := setupMCPTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-login-deleted@test.com", EmailVerified: true, Name: "MCP Deleted", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-login-deleted-sub", ProviderEmail: "mcp-login-deleted@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-login-deleted@test.com", EmailVerified: true, Name: "MCP Deleted", Provider: "google", ProviderUserID: "mcp-login-deleted-sub", ProviderEmail: "mcp-login-deleted@test.com"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-login-deleted")
@@ -170,7 +170,7 @@ func TestMCP_DeletedUser_Rejected(t *testing.T) {
 	svc, store := setupMCPExtTest(t, "mcp-deleted-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-deleted@test.com", EmailVerified: true, Name: "MCP", AvatarURL: "", Provider: "google", ProviderUserID: "mcp-deleted-sub", ProviderEmail: "mcp-deleted@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-deleted@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "mcp-deleted-sub", ProviderEmail: "mcp-deleted@test.com"})
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
 	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-deleted", "http://localhost/mcp")
 

--- a/internal/storage/audit_test.go
+++ b/internal/storage/audit_test.go
@@ -23,7 +23,7 @@ func TestAudit010And011_RefreshReuseAndFamilyRevoke(t *testing.T) {
 	store := New(db, clk, gen, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "audit-refresh@test.com", EmailVerified: true, Name: "Refresh Audit", AvatarURL: "", Provider: "google", ProviderUserID: "audit-refresh-sub", ProviderEmail: "audit-refresh@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "audit-refresh@test.com", EmailVerified: true, Name: "Refresh Audit", Provider: "google", ProviderUserID: "audit-refresh-sub", ProviderEmail: "audit-refresh@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestAuditLog_AppendOnlyGuardAllowsPIIRedactionOnly(t *testing.T) {
 	store := New(db, clk, idgen.CryptoGenerator{}, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "audit-guard@test.com", EmailVerified: true, Name: "Audit Guard", AvatarURL: "", Provider: "google", ProviderUserID: "audit-guard-sub", ProviderEmail: "audit-guard@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "audit-guard@test.com", EmailVerified: true, Name: "Audit Guard", Provider: "google", ProviderUserID: "audit-guard-sub", ProviderEmail: "audit-guard@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}

--- a/internal/storage/expiry_test.go
+++ b/internal/storage/expiry_test.go
@@ -53,7 +53,7 @@ func TestAuthRequestByCode_Expired_Rejected(t *testing.T) {
 
 	// Create auth request + complete + save code
 	arID, _ := store.CreateTestAuthRequest(ctx, "code-expiry")
-	user, _ := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "code-expiry@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "code-expiry-sub", ProviderEmail: "ce@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "code-expiry@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "code-expiry-sub", ProviderEmail: "ce@test.com"})
 	store.CompleteAuthRequest(ctx, arID, user.ID)
 	store.SaveAuthCode(ctx, arID, "test-code-expiry")
 

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -16,7 +16,6 @@ type User struct {
 	Email         string
 	EmailVerified bool
 	Name          string
-	AvatarURL     *string
 	Status        string
 	CreatedAt     time.Time
 	UpdatedAt     time.Time

--- a/internal/storage/refresh_state_test.go
+++ b/internal/storage/refresh_state_test.go
@@ -23,7 +23,7 @@ func TestRefreshReuseDetection_FamilyRevoke(t *testing.T) {
 	store := New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "reuse@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "reuse-sub", ProviderEmail: "ru@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "reuse@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "reuse-sub", ProviderEmail: "ru@test.com"})
 	_ = user
 
 	// Insert two tokens in the same family
@@ -116,7 +116,7 @@ func TestRefreshStateCheck_AllStates(t *testing.T) {
 			email := fmt.Sprintf("refresh-state-%d@test.com", i)
 			sub := fmt.Sprintf("refresh-state-sub-%d", i)
 
-			user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: sub, ProviderEmail: email})
+			user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: sub, ProviderEmail: email})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}
@@ -204,7 +204,7 @@ func TestAuthCodeStateCheck_AllStates(t *testing.T) {
 			email := fmt.Sprintf("authcode-state-%d@test.com", i)
 			sub := fmt.Sprintf("authcode-state-sub-%d", i)
 
-			user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: sub, ProviderEmail: email})
+			user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: sub, ProviderEmail: email})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}

--- a/internal/storage/storage_integration_test.go
+++ b/internal/storage/storage_integration_test.go
@@ -28,7 +28,7 @@ func TestCreateUserWithIdentity_Atomic(t *testing.T) {
 	s := testStorage(t)
 	ctx := context.Background()
 
-	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "atomic@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "atomic-sub-1", ProviderEmail: "atomic@test.com"})
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "atomic@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "atomic-sub-1", ProviderEmail: "atomic@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestCreateUserWithIdentity_Atomic(t *testing.T) {
 	}
 
 	// Duplicate email should fail
-	_, err = s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "atomic@test.com", EmailVerified: true, Name: "Test2", AvatarURL: "", Provider: "google", ProviderUserID: "atomic-sub-2", ProviderEmail: "dup@test.com"})
+	_, err = s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "atomic@test.com", EmailVerified: true, Name: "Test2", Provider: "google", ProviderUserID: "atomic-sub-2", ProviderEmail: "dup@test.com"})
 	if err == nil {
 		t.Fatal("expected error for duplicate email")
 	}
@@ -67,7 +67,7 @@ func TestRefreshTokenRotation_Atomicity(t *testing.T) {
 	ctx := context.Background()
 
 	// Setup: create user
-	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "refresh@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "refresh-sub", ProviderEmail: "r@test.com"})
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "refresh@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "refresh-sub", ProviderEmail: "r@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestSession_CreateAndValidate(t *testing.T) {
 	s := testStorage(t)
 	ctx := context.Background()
 
-	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "session@test.com", EmailVerified: true, Name: "Test", AvatarURL: "", Provider: "google", ProviderUserID: "session-sub", ProviderEmail: "s@test.com"})
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "session@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "session-sub", ProviderEmail: "s@test.com"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestSession_StatusFilter(t *testing.T) {
 			ctx := context.Background()
 
 			user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
-				Email: tc.name + "@test.com", EmailVerified: true, Name: "Test", AvatarURL: "",
+				Email: tc.name + "@test.com", EmailVerified: true, Name: "Test",
 				Provider: "google", ProviderUserID: "filter-" + tc.name, ProviderEmail: tc.name + "@test.com",
 			})
 			if err != nil {

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -14,7 +14,6 @@ type CreateUserWithIdentityInput struct {
 	Email          string
 	EmailVerified  bool
 	Name           string
-	AvatarURL      string
 	Provider       string
 	ProviderUserID string
 	ProviderEmail  string
@@ -64,7 +63,6 @@ func (s *Storage) insertUserForSignup(ctx context.Context, qtx *storeq.Queries, 
 		Email:         input.Email,
 		EmailVerified: input.EmailVerified,
 		Name:          sql.NullString{String: input.Name, Valid: true},
-		AvatarUrl:     sql.NullString{String: input.AvatarURL, Valid: true},
 		CreatedAt:     now,
 	})
 }
@@ -91,7 +89,7 @@ func (s *Storage) GetUserByProviderIdentity(ctx context.Context, provider, provi
 	if err != nil {
 		return nil, err
 	}
-	return buildFullUser(row.ID, row.Email, row.EmailVerified, row.Name, row.AvatarUrl, row.Status, row.CreatedAt, row.UpdatedAt), nil
+	return buildFullUser(row.ID, row.Email, row.EmailVerified, row.Name, row.Status, row.CreatedAt, row.UpdatedAt), nil
 }
 
 func (s *Storage) getUserByID(ctx context.Context, tx *sql.Tx, userID string) (*User, error) {
@@ -114,7 +112,7 @@ func (s *Storage) GetUserByID(ctx context.Context, userID string) (*User, error)
 	if err != nil {
 		return nil, err
 	}
-	return buildFullUser(row.ID, row.Email, row.EmailVerified, row.Name, row.AvatarUrl, row.Status, row.CreatedAt, row.UpdatedAt), nil
+	return buildFullUser(row.ID, row.Email, row.EmailVerified, row.Name, row.Status, row.CreatedAt, row.UpdatedAt), nil
 }
 
 // RecoverUser recovers a pending_deletion user to active.
@@ -327,7 +325,7 @@ func (s *Storage) GetValidSession(ctx context.Context, sessionID string) (*User,
 	if err != nil {
 		return nil, err
 	}
-	user := buildFullUser(row.ID, row.Email, row.EmailVerified, row.Name, row.AvatarUrl, row.Status, row.CreatedAt, row.UpdatedAt)
+	user := buildFullUser(row.ID, row.Email, row.EmailVerified, row.Name, row.Status, row.CreatedAt, row.UpdatedAt)
 	if err := requireUsableUser(user); err != nil {
 		return user, err
 	}
@@ -360,13 +358,12 @@ func buildCoreUser(id, email string, emailVerified bool, name sql.NullString, st
 	}
 }
 
-func buildFullUser(id, email string, emailVerified bool, name, avatar sql.NullString, status string, createdAt, updatedAt time.Time) *User {
+func buildFullUser(id, email string, emailVerified bool, name sql.NullString, status string, createdAt, updatedAt time.Time) *User {
 	return &User{
 		ID:            id,
 		Email:         email,
 		EmailVerified: emailVerified,
 		Name:          nullStringToString(name),
-		AvatarURL:     nullStringToPtr(avatar),
 		Status:        status,
 		CreatedAt:     createdAt,
 		UpdatedAt:     updatedAt,

--- a/internal/upstream/oidc.go
+++ b/internal/upstream/oidc.go
@@ -108,7 +108,6 @@ func (p *OIDCProvider) Exchange(ctx context.Context, code string) (*UserInfo, er
 		Email:         info.Email,
 		EmailVerified: bool(info.EmailVerified),
 		Name:          info.Name,
-		Picture:       info.Picture,
 	}, nil
 }
 

--- a/internal/upstream/oidc_test.go
+++ b/internal/upstream/oidc_test.go
@@ -48,7 +48,6 @@ func newFakeIdP(t *testing.T) *fakeIdP {
 			"email":          "test@example.com",
 			"email_verified": true,
 			"name":           "Test User",
-			"picture":        "https://example.com/photo.jpg",
 		},
 	}
 
@@ -278,7 +277,6 @@ func TestOIDCProvider_UserInfoMapping_AllFields(t *testing.T) {
 		"email":          "map@example.com",
 		"email_verified": true,
 		"name":           "Map User",
-		"picture":        "https://example.com/pic.jpg",
 	}
 	p := idp.newProvider(t)
 	info, err := p.Exchange(context.Background(), "fake-code")
@@ -296,9 +294,6 @@ func TestOIDCProvider_UserInfoMapping_AllFields(t *testing.T) {
 	}
 	if info.Name != "Map User" {
 		t.Errorf("Name = %q", info.Name)
-	}
-	if info.Picture != "https://example.com/pic.jpg" {
-		t.Errorf("Picture = %q", info.Picture)
 	}
 }
 
@@ -346,21 +341,6 @@ func TestOIDCProvider_EmailVerified_Absent(t *testing.T) {
 	}
 	if info.EmailVerified {
 		t.Error("email_verified absent in IdP response but UserInfo.EmailVerified=true")
-	}
-}
-
-// ── oidc-map-005: picture field mapped ───────────────────────────────────────
-
-func TestOIDCProvider_Picture_Mapped(t *testing.T) {
-	idp := newFakeIdP(t)
-	idp.userInfoResp["picture"] = "https://example.com/avatar.jpg"
-	p := idp.newProvider(t)
-	info, err := p.Exchange(context.Background(), "fake-code")
-	if err != nil {
-		t.Fatalf("Exchange: %v", err)
-	}
-	if info.Picture != "https://example.com/avatar.jpg" {
-		t.Errorf("Picture = %q, want https://example.com/avatar.jpg", info.Picture)
 	}
 }
 

--- a/internal/upstream/provider.go
+++ b/internal/upstream/provider.go
@@ -8,7 +8,6 @@ type UserInfo struct {
 	Email         string
 	EmailVerified bool
 	Name          string
-	Picture       string
 }
 
 // Provider abstracts the upstream OIDC IdP.

--- a/migrations/001_init.up.sql
+++ b/migrations/001_init.up.sql
@@ -8,7 +8,6 @@ CREATE TABLE users (
     email                 TEXT NOT NULL UNIQUE,
     email_verified        BOOLEAN NOT NULL DEFAULT false,
     name                  TEXT,
-    avatar_url            TEXT,
     status                TEXT NOT NULL DEFAULT 'active'
                           CHECK (status IN ('active', 'disabled', 'pending_deletion', 'deleted')),
     deletion_requested_at TIMESTAMPTZ,

--- a/migrations/005_drop_users_avatar_url.down.sql
+++ b/migrations/005_drop_users_avatar_url.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS avatar_url TEXT;

--- a/migrations/005_drop_users_avatar_url.up.sql
+++ b/migrations/005_drop_users_avatar_url.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    DROP COLUMN IF EXISTS avatar_url;


### PR DESCRIPTION
## Summary
- Remove `avatar_url` from the `users` schema and add migration 005 to drop it for existing deployments.
- Stop mapping/storing upstream OIDC `picture` values in `UserInfo` and signup persistence.
- Regenerate sqlc outputs and update docs/tests to reflect the reduced stored Google/OIDC profile surface.

## Why
`avatar_url` is not needed for Authgate's authentication role, was only captured at signup, and increases the profile/PII surface without improving token issuance or account lifecycle behavior.

## Validation
- `git diff --check`
- `sqlc generate`
- `sqlc vet`
- `go test ./...`
- `go test -tags=integration ./internal/... -run '^$'`