### PR TITLE
fix(upstream): bind IdP login to state cookie + PKCE (login CSRF)

### DIFF
--- a/docs/security/001-audit-evidence-matrix.md
+++ b/docs/security/001-audit-evidence-matrix.md
@@ -83,6 +83,7 @@ audit_log
 | KR-COMM-001 | IP/UA 등 접속 메타데이터를 추적할 수 있는가 | `audit_log.ip_address`, `audit_log.user_agent` | `internal/storage/audit.go`, `internal/clientinfo/*` | `internal/clientinfo/clientinfo_test.go` | DONE |
 | SOC2-CC7-001 | 보안 이상징후를 탐지할 이벤트가 있는가 | inactive user access, refresh reuse detection, channel mismatch | `internal/service/*`, `internal/storage/storage_auth_tokens.go` | `internal/service/audit_test.go`, `internal/service/login_unit_test.go` | DONE |
 | SOC2-CC7-002 | abuse 방어가 있는가 | per-IP rate limit for auth/token/callback endpoints, CIMD failure rate limit | `internal/app/routes.go`, `internal/middleware/ratelimit.go`, `internal/adapter/mcp/cimd.go` | `internal/integration/integration_ratelimit_test.go`, `internal/adapter/mcp/*ratelimit*_test.go` | DONE |
+| SOC2-CC6-003 | 상위 IdP 로그인 CSRF/인가코드 인젝션을 방어하는가 | 상위 IdP 콜백에 암호화 state 쿠키 바인딩 + PKCE(S256) (browser/device/mcp 3채널) | `internal/upstream/oidc.go` (`rp.AuthURLHandler`/`CodeExchangeHandler`/`WithPKCE`) | `internal/upstream/oidc_test.go` | DONE |
 | SOC2-CC8-001 | 변경관리 evidence를 확보할 수 있는가 | GitHub PR, CI checks, vulnerability check | GitHub repository / Actions | PR checks | DONE |
 | SOC2-CC8-002 | dependency vulnerability evidence가 있는가 | `govulncheck` local/CI 실행 | GitHub Actions, PR body | CI `Vulnerability Check` | DONE |
 
@@ -128,6 +129,7 @@ audit_log
 | GAP | 설명 | 다음 작업 후보 |
 |-----|------|----------------|
 | GAP-OPS-001 | SOC 2 운영 evidence(PR 리뷰, access review, backup restore test)는 GitHub/운영 시스템에 존재해야 하며 authgate DB에는 저장하지 않는다. | 운영 evidence export/checklist 문서 |
+| GAP-SEC-001 | 상위 IdP id_token의 `nonce` 검증 미적용. state 쿠키 + PKCE로 로그인 CSRF는 차단했으나 id_token 재생 바인딩은 별도. | `rp.WithVerifierOpts(rp.WithNonce(...))` + 요청별 nonce 저장 후속 PR |
 
 ## 완료 기준
 

--- a/docs/spec/002-browser-login.md
+++ b/docs/spec/002-browser-login.md
@@ -159,8 +159,8 @@ sequenceDiagram
 | redirect_uri 불일치 | `invalid_request` | 400 | zitadel이 처리 |
 | PKCE 없음 / plain | `invalid_request` | 400 | S256만 허용 |
 | state 누락/불일치 | `invalid_request` | 400 | CSRF 보호 |
-| IdP 인증 사용자 취소/콜백 오류 | `invalid_request` 또는 `upstream_error` | 400/500 | authgate 콜백에서 오류 페이지 렌더 |
-| IdP 서버 오류 | `upstream_error` | 500 | IdP 연동 실패 |
+| state 쿠키 누락/불일치 (로그인 CSRF) | `authentication failed` | 401 | 상위 핸들러(`rp.CodeExchangeHandler`)가 state 쿠키 검증 실패 시 일반 메시지로 거부 |
+| IdP 코드 교환 실패 / IdP 서버 오류 | `authentication failed` | 401 | 상위 핸들러가 교환 실패를 일반 메시지로 거부 (내부 오류 문자열 미노출) |
 | DB 오류 (유저 조회) | `internal_error` | 500 | 가입 시도 안 함 |
 | 이메일 충돌 | `email_conflict` | 409 | 같은 email, 다른 IdP sub |
 | disabled | `account_inactive` | 403 | 로그인 차단 |
@@ -192,7 +192,8 @@ RecoverUser 자체는 원자적이다 (단일 UPDATE).
 ## 보안 요구사항
 
 - 모든 `/authorize` 요청에서 PKCE S256 필수 (plain 불허, code_challenge 누락 불허)
-- `state` 파라미터: authRequestID를 state로 사용. CSRF 보호 역할
+- 상위 IdP 로그인 CSRF 방어: `state`(authRequestID)를 암호화된 state 쿠키에 바인딩하고 콜백에서 대조 (`rp.AuthURLHandler` / `rp.CodeExchangeHandler`). 콜백을 시작한 브라우저만 완료 가능 → 인가코드 인젝션/세션 스왑 차단
+- 상위 IdP 교환에 PKCE(S256) 적용 (`rp.WithPKCE`). nonce 검증은 후속 작업 (아래 GAP 참조)
 - confidential 클라이언트: client_secret bcrypt 검증
 - public 클라이언트: client_secret 없음, PKCE가 유일한 보호
 - 세션 쿠키: `HttpOnly`, `SameSite=Strict`, `Secure=!DevMode`

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -47,24 +47,24 @@ func Run() {
 	deviceProvider := mustBuildUpstreamProvider(ctx, cfg, "/device/auth/callback", upstreamOpts)
 
 	// Service layer
-	loginService := service.NewLoginService(store, browserProvider, cfg.SessionTTL)
+	loginService := service.NewLoginService(store, browserProvider.Name(), cfg.SessionTTL)
 
 	// Device service
-	deviceService := service.NewDeviceService(store, deviceProvider, cfg.PublicURL, cfg.SessionTTL, clk)
+	deviceService := service.NewDeviceService(store, deviceProvider.Name(), cfg.PublicURL, cfg.SessionTTL, clk)
 
 	// Account service
 	accountService := service.NewAccountService(store)
 
 	// Handler layer
-	loginHandler := handler.NewLoginHandler(loginService, cfg.DevMode, cfg.BrandName)
-	deviceHandler := handler.NewDeviceHandler(deviceService, cfg.DevMode, cfg.BrandName)
+	loginHandler := handler.NewLoginHandler(loginService, browserProvider, cfg.DevMode, cfg.BrandName)
+	deviceHandler := handler.NewDeviceHandler(deviceService, deviceProvider, cfg.DevMode, cfg.BrandName)
 	accountHandler := handler.NewAccountHandler(accountService, cfg.PublicURL)
 
 	var mcpLoginHandler *handler.MCPLoginHandler
 	if cfg.EnableMCP {
 		mcpProvider := mustBuildUpstreamProvider(ctx, cfg, "/mcp/callback", upstreamOpts)
-		mcpLoginService := service.NewMCPLoginService(store, mcpProvider, cfg.SessionTTL)
-		mcpLoginHandler = handler.NewMCPLoginHandler(mcpLoginService, cfg.DevMode, cfg.BrandName)
+		mcpLoginService := service.NewMCPLoginService(store, mcpProvider.Name(), cfg.SessionTTL)
+		mcpLoginHandler = handler.NewMCPLoginHandler(mcpLoginService, mcpProvider, cfg.DevMode, cfg.BrandName)
 	}
 
 	// Load client config and derive CORS allowed origins.

--- a/internal/app/oidc.go
+++ b/internal/app/oidc.go
@@ -67,6 +67,7 @@ func buildUpstreamOptions(cfg *config.Config) []upstream.Option {
 		opts = append(opts, upstream.WithInternalURL(cfg.OIDCInternalURL))
 	}
 	opts = append(opts, upstream.WithHTTPTimeout(cfg.OIDCHTTPTimeout))
+	opts = append(opts, upstream.WithCookieSecret(cfg.SessionSecret, !cfg.DevMode))
 	return opts
 }
 

--- a/internal/app/routes_test.go
+++ b/internal/app/routes_test.go
@@ -115,10 +115,10 @@ func TestRegisterAuthgateRoutes_RateLimitsSensitiveAuthgateEndpoints(t *testing.
 			registerAuthgateRoutes(
 				mux,
 				rateLimitTestConfig(),
-				handler.NewLoginHandler(nil, true, "authgate"),
-				handler.NewDeviceHandler(nil, true, "authgate"),
+				handler.NewLoginHandler(nil, nil, true, "authgate"),
+				handler.NewDeviceHandler(nil, nil, true, "authgate"),
 				handler.NewAccountHandler(nil, "http://authgate.example.com"),
-				handler.NewMCPLoginHandler(nil, true, "authgate"),
+				handler.NewMCPLoginHandler(nil, nil, true, "authgate"),
 			)
 
 			assertRateLimited(t, mux, tt.method, tt.path)

--- a/internal/handler/device.go
+++ b/internal/handler/device.go
@@ -9,17 +9,20 @@ import (
 	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/pages"
 	"github.com/kangheeyong/authgate/internal/service"
+	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
 type DeviceHandler struct {
 	deviceService *service.DeviceService
+	provider      upstream.Provider
 	devMode       bool
 	brandName     string
 }
 
-func NewDeviceHandler(deviceService *service.DeviceService, devMode bool, brandName string) *DeviceHandler {
+func NewDeviceHandler(deviceService *service.DeviceService, provider upstream.Provider, devMode bool, brandName string) *DeviceHandler {
 	return &DeviceHandler{
 		deviceService: deviceService,
+		provider:      provider,
 		devMode:       devMode,
 		brandName:     brandName,
 	}
@@ -66,8 +69,7 @@ func (h *DeviceHandler) HandleDevicePage(w http.ResponseWriter, r *http.Request)
 		})
 
 	case service.DeviceRedirectIdP:
-		//nolint:gosec // Redirect target is the upstream IdP authorization URL built by DeviceService.
-		http.Redirect(w, r, result.UserCode, http.StatusFound) // UserCode holds the auth URL
+		h.provider.Redirect(w, r, result.UserCode) // UserCode holds the state (user_code)
 
 	case service.DeviceError:
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -78,25 +80,25 @@ func (h *DeviceHandler) HandleDevicePage(w http.ResponseWriter, r *http.Request)
 
 // HandleDeviceCallback handles GET /device/auth/callback?code=xxx&state=user_code
 func (h *DeviceHandler) HandleDeviceCallback(w http.ResponseWriter, r *http.Request) {
-	code := r.URL.Query().Get("code")
-	userCode := r.URL.Query().Get("state")
 	info := clientinfo.FromContext(r.Context())
 
-	result := h.deviceService.HandleDeviceCallback(r.Context(), code, userCode, info.IP, info.UserAgent)
+	h.provider.Callback(w, r, func(w http.ResponseWriter, r *http.Request, state string, userInfo *upstream.UserInfo) {
+		result := h.deviceService.CompleteDeviceLogin(r.Context(), state, userInfo, info.IP, info.UserAgent)
 
-	switch result.Action {
-	case service.DeviceRedirectBack:
-		if result.SessionID != "" {
-			setSessionCookie(w, result.SessionID, h.devMode)
+		switch result.Action {
+		case service.DeviceRedirectBack:
+			if result.SessionID != "" {
+				setSessionCookie(w, result.SessionID, h.devMode)
+			}
+			//nolint:gosec // Internal redirect to the fixed device endpoint with a service-issued user code.
+			http.Redirect(w, r, "/device?user_code="+result.UserCode, http.StatusFound)
+
+		case service.DeviceError:
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(result.ErrorCode)
+			_ = pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: result.ErrorCode, Message: result.Error})
 		}
-		//nolint:gosec // Internal redirect to the fixed device endpoint with a service-issued user code.
-		http.Redirect(w, r, "/device?user_code="+result.UserCode, http.StatusFound)
-
-	case service.DeviceError:
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(result.ErrorCode)
-		_ = pages.RenderError(w, pages.ErrorData{BrandName: h.brandName, Code: result.ErrorCode, Message: result.Error})
-	}
+	})
 }
 
 // HandleDeviceApprove handles POST /device/approve

--- a/internal/handler/device_test.go
+++ b/internal/handler/device_test.go
@@ -8,13 +8,17 @@ import (
 	"testing"
 
 	"github.com/kangheeyong/authgate/internal/service"
+	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
 // newTestDeviceHandler creates a DeviceHandler with a minimal DeviceService.
 // nil storage is safe as long as the code path under test exits before touching it.
 func newTestDeviceHandler() *DeviceHandler {
-	svc := service.NewDeviceService(nil, nil, "", 0, nil)
-	return NewDeviceHandler(svc, true, "authgate") // devMode=true
+	svc := service.NewDeviceService(nil, "", "", 0, nil)
+	// FakeProvider.Callback delivers the (empty) state to CompleteDeviceLogin,
+	// which returns the 400 "invalid_request" the callback test asserts.
+	provider := &upstream.FakeProvider{User: &upstream.UserInfo{Sub: "sub"}}
+	return NewDeviceHandler(svc, provider, true, "authgate") // devMode=true
 }
 
 // ── Method guard ──────────────────────────────────────────────────────────────

--- a/internal/handler/login.go
+++ b/internal/handler/login.go
@@ -6,17 +6,20 @@ import (
 	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/pages"
 	"github.com/kangheeyong/authgate/internal/service"
+	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
 type LoginHandler struct {
 	loginService *service.LoginService
+	provider     upstream.Provider
 	devMode      bool
 	brandName    string
 }
 
-func NewLoginHandler(loginService *service.LoginService, devMode bool, brandName string) *LoginHandler {
+func NewLoginHandler(loginService *service.LoginService, provider upstream.Provider, devMode bool, brandName string) *LoginHandler {
 	return &LoginHandler{
 		loginService: loginService,
+		provider:     provider,
 		devMode:      devMode,
 		brandName:    brandName,
 	}
@@ -32,8 +35,7 @@ func (h *LoginHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 
 	switch result.Action {
 	case service.ActionRedirectToIdP:
-		//nolint:gosec // Redirect target is the upstream IdP authorization URL built by LoginService.
-		http.Redirect(w, r, result.RedirectURL, http.StatusFound)
+		h.provider.Redirect(w, r, result.AuthRequestID)
 
 	case service.ActionAutoApprove:
 		// Redirect back to zitadel's authorize callback
@@ -47,23 +49,23 @@ func (h *LoginHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 
 // HandleCallback handles GET /login/callback?code=xxx&state=authRequestID
 func (h *LoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
-	code := r.URL.Query().Get("code")
-	authRequestID := r.URL.Query().Get("state")
 	info := clientinfo.FromContext(r.Context())
 
-	result := h.loginService.HandleCallback(r.Context(), code, authRequestID, info.IP, info.UserAgent)
+	h.provider.Callback(w, r, func(w http.ResponseWriter, r *http.Request, state string, userInfo *upstream.UserInfo) {
+		result := h.loginService.CompleteBrowserLogin(r.Context(), state, userInfo, info.IP, info.UserAgent)
 
-	switch result.Action {
-	case service.ActionAutoApprove:
-		if result.SessionID != "" {
-			setSessionCookie(w, result.SessionID, h.devMode)
+		switch result.Action {
+		case service.ActionAutoApprove:
+			if result.SessionID != "" {
+				setSessionCookie(w, result.SessionID, h.devMode)
+			}
+			//nolint:gosec // Internal redirect to the fixed OIDC callback with a service-issued auth request ID.
+			http.Redirect(w, r, "/authorize/callback?id="+result.AuthRequestID, http.StatusFound)
+
+		case service.ActionError:
+			h.renderError(w, result.ErrorCode, result.Error)
 		}
-		//nolint:gosec // Internal redirect to the fixed OIDC callback with a service-issued auth request ID.
-		http.Redirect(w, r, "/authorize/callback?id="+result.AuthRequestID, http.StatusFound)
-
-	case service.ActionError:
-		h.renderError(w, result.ErrorCode, result.Error)
-	}
+	})
 }
 
 func (h *LoginHandler) renderError(w http.ResponseWriter, code int, message string) {

--- a/internal/handler/login_test.go
+++ b/internal/handler/login_test.go
@@ -7,11 +7,15 @@ import (
 	"testing"
 
 	"github.com/kangheeyong/authgate/internal/service"
+	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
 func newTestLoginHandler(devMode bool) *LoginHandler {
-	svc := service.NewLoginService(nil, nil, 0)
-	return NewLoginHandler(svc, devMode, "authgate")
+	svc := service.NewLoginService(nil, "", 0)
+	// FakeProvider.Callback delivers the (empty) state to CompleteBrowserLogin,
+	// which returns the 400 "missing code or state" the callback test asserts.
+	provider := &upstream.FakeProvider{User: &upstream.UserInfo{Sub: "sub"}}
+	return NewLoginHandler(svc, provider, devMode, "authgate")
 }
 
 func TestLogin_MissingAuthRequestID_ReturnsBadRequest(t *testing.T) {

--- a/internal/handler/mcp_login.go
+++ b/internal/handler/mcp_login.go
@@ -6,17 +6,20 @@ import (
 	"github.com/kangheeyong/authgate/internal/clientinfo"
 	"github.com/kangheeyong/authgate/internal/pages"
 	"github.com/kangheeyong/authgate/internal/service"
+	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
 type MCPLoginHandler struct {
 	loginService *service.MCPLoginService
+	provider     upstream.Provider
 	devMode      bool
 	brandName    string
 }
 
-func NewMCPLoginHandler(loginService *service.MCPLoginService, devMode bool, brandName string) *MCPLoginHandler {
+func NewMCPLoginHandler(loginService *service.MCPLoginService, provider upstream.Provider, devMode bool, brandName string) *MCPLoginHandler {
 	return &MCPLoginHandler{
 		loginService: loginService,
+		provider:     provider,
 		devMode:      devMode,
 		brandName:    brandName,
 	}
@@ -32,8 +35,7 @@ func (h *MCPLoginHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 
 	switch result.Action {
 	case service.ActionRedirectToIdP:
-		//nolint:gosec // Redirect target is the upstream IdP authorization URL built by MCPLoginService.
-		http.Redirect(w, r, result.RedirectURL, http.StatusFound)
+		h.provider.Redirect(w, r, result.AuthRequestID)
 	case service.ActionAutoApprove:
 		//nolint:gosec // Internal redirect to the fixed OIDC callback with a service-issued auth request ID.
 		http.Redirect(w, r, "/authorize/callback?id="+result.AuthRequestID, http.StatusFound)
@@ -46,24 +48,24 @@ func (h *MCPLoginHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 
 // HandleCallback handles GET /mcp/callback?code=xxx&state=authRequestID
 func (h *MCPLoginHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
-	code := r.URL.Query().Get("code")
-	authRequestID := r.URL.Query().Get("state")
 	info := clientinfo.FromContext(r.Context())
 
-	result := h.loginService.HandleCallback(r.Context(), code, authRequestID, info.IP, info.UserAgent)
+	h.provider.Callback(w, r, func(w http.ResponseWriter, r *http.Request, state string, userInfo *upstream.UserInfo) {
+		result := h.loginService.CompleteMCPLogin(r.Context(), state, userInfo, info.IP, info.UserAgent)
 
-	switch result.Action {
-	case service.ActionAutoApprove:
-		if result.SessionID != "" {
-			setSessionCookie(w, result.SessionID, h.devMode)
+		switch result.Action {
+		case service.ActionAutoApprove:
+			if result.SessionID != "" {
+				setSessionCookie(w, result.SessionID, h.devMode)
+			}
+			//nolint:gosec // Internal redirect to the fixed OIDC callback with a service-issued auth request ID.
+			http.Redirect(w, r, "/authorize/callback?id="+result.AuthRequestID, http.StatusFound)
+		case service.ActionError:
+			h.renderError(w, result.ErrorCode, result.Error)
+		default:
+			h.renderError(w, http.StatusInternalServerError, "invalid mcp callback action")
 		}
-		//nolint:gosec // Internal redirect to the fixed OIDC callback with a service-issued auth request ID.
-		http.Redirect(w, r, "/authorize/callback?id="+result.AuthRequestID, http.StatusFound)
-	case service.ActionError:
-		h.renderError(w, result.ErrorCode, result.Error)
-	default:
-		h.renderError(w, http.StatusInternalServerError, "invalid mcp callback action")
-	}
+	})
 }
 
 func (h *MCPLoginHandler) renderError(w http.ResponseWriter, code int, message string) {

--- a/internal/handler/mcp_login_test.go
+++ b/internal/handler/mcp_login_test.go
@@ -6,11 +6,15 @@ import (
 	"testing"
 
 	"github.com/kangheeyong/authgate/internal/service"
+	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
 func newTestMCPLoginHandler(devMode bool) *MCPLoginHandler {
-	svc := service.NewMCPLoginService(nil, nil, 0)
-	return NewMCPLoginHandler(svc, devMode, "authgate")
+	svc := service.NewMCPLoginService(nil, "", 0)
+	// FakeProvider.Callback delivers the (empty) state to CompleteMCPLogin,
+	// which returns the 400 "missing code or state" the callback test asserts.
+	provider := &upstream.FakeProvider{User: &upstream.UserInfo{Sub: "sub"}}
+	return NewMCPLoginHandler(svc, provider, devMode, "authgate")
 }
 
 func TestMCPLogin_MissingAuthRequestID_ReturnsBadRequest(t *testing.T) {

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -143,18 +143,18 @@ func SetupTestServerWithOptions(t *testing.T, opts SetupOptions) *TestServer {
 	}
 
 	// Services
-	loginSvc := service.NewLoginService(store, fakeProvider, 24*time.Hour)
-	deviceSvc := service.NewDeviceService(store, fakeProvider, srv.URL, 24*time.Hour, clk)
+	loginSvc := service.NewLoginService(store, fakeProvider.Name(), 24*time.Hour)
+	deviceSvc := service.NewDeviceService(store, fakeProvider.Name(), srv.URL, 24*time.Hour, clk)
 	accountSvc := service.NewAccountService(store)
 
 	// Handlers
-	loginHandler := handler.NewLoginHandler(loginSvc, true, "authgate")
-	deviceHandler := handler.NewDeviceHandler(deviceSvc, true, "authgate")
+	loginHandler := handler.NewLoginHandler(loginSvc, fakeProvider, true, "authgate")
+	deviceHandler := handler.NewDeviceHandler(deviceSvc, fakeProvider, true, "authgate")
 	accountHandler := handler.NewAccountHandler(accountSvc, srv.URL)
 	var mcpLoginHandler *handler.MCPLoginHandler
 	if opts.EnableMCP {
-		mcpLoginSvc := service.NewMCPLoginService(store, fakeProvider, 24*time.Hour)
-		mcpLoginHandler = handler.NewMCPLoginHandler(mcpLoginSvc, true, "authgate")
+		mcpLoginSvc := service.NewMCPLoginService(store, fakeProvider.Name(), 24*time.Hour)
+		mcpLoginHandler = handler.NewMCPLoginHandler(mcpLoginSvc, fakeProvider, true, "authgate")
 	}
 
 	// Routes

--- a/internal/service/account_test.go
+++ b/internal/service/account_test.go
@@ -21,6 +21,7 @@ type accountFixture struct {
 	Store      *storage.Storage
 	DB         *sql.DB
 	Clock      *clock.FixedClock
+	FakeUser   *upstream.UserInfo
 }
 
 func setupAccountTest(t *testing.T) *accountFixture {
@@ -36,13 +37,14 @@ func setupAccountTest(t *testing.T) *accountFixture {
 	}
 
 	accountSvc := NewAccountService(store)
-	loginSvc := NewLoginService(store, fakeProvider, 24*time.Hour)
+	loginSvc := NewLoginService(store, fakeProvider.Name(), 24*time.Hour)
 	return &accountFixture{
 		AccountSvc: accountSvc,
 		LoginSvc:   loginSvc,
 		Store:      store,
 		DB:         db,
 		Clock:      clk,
+		FakeUser:   fakeProvider.User,
 	}
 }
 
@@ -160,7 +162,7 @@ func TestE2E_DeleteThenRecover(t *testing.T) {
 	}
 
 	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e4-recovery")
-	result := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test")
+	result := fx.LoginSvc.CompleteBrowserLogin(ctx, arID, fx.FakeUser, "127.0.0.1", "test")
 
 	if result.Action != ActionAutoApprove {
 		t.Errorf("action = %v, want AutoApprove (recovered)", result.Action)
@@ -197,7 +199,7 @@ func TestE2E_DeleteThenReregister(t *testing.T) {
 	}
 
 	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e5-reregister")
-	result := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test")
+	result := fx.LoginSvc.CompleteBrowserLogin(ctx, arID, fx.FakeUser, "127.0.0.1", "test")
 
 	if result.Action != ActionAutoApprove {
 		t.Errorf("action = %v, want AutoApprove (new signup after deletion)", result.Action)
@@ -216,7 +218,7 @@ func TestAccount004_PendingDeletion_DeviceRejected(t *testing.T) {
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 	insertDeviceCode(t, fx.Store, "PD-CODE", fx.Clock)
 
-	result := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "PD-CODE", "127.0.0.1", "test")
+	result := fx.DeviceSvc.CompleteDeviceLogin(ctx, "PD-CODE", fx.FakeUser, "127.0.0.1", "test")
 	if result.Action != DeviceError {
 		t.Errorf("action = %v, want DeviceError (pending_deletion on device)", result.Action)
 	}
@@ -234,7 +236,7 @@ func TestAccount004b_PendingDeletion_MCPRejected(t *testing.T) {
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	arID, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "pd-mcp", "http://localhost/mcp")
-	result := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
+	result := fx.MCPLoginSvc.CompleteMCPLogin(ctx, arID, fx.FakeUser, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error (pending_deletion via MCP)", result.Action)

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -62,11 +62,11 @@ func requireSingleAuditEvent(t *testing.T, db *sql.DB, userID, eventType string)
 }
 
 func TestAudit001_BrowserSignup(t *testing.T) {
-	svc, store := setupLoginService(t)
+	svc, store, fakeUser := setupLoginService(t)
 	ctx := context.Background()
 
 	arID, _ := store.CreateTestAuthRequest(ctx, "audit-signup")
-	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test-agent")
+	result := svc.CompleteBrowserLogin(ctx, arID, fakeUser, "127.0.0.1", "test-agent")
 	if result.Action != ActionAutoApprove {
 		t.Fatalf("action = %v, want AutoApprove", result.Action)
 	}
@@ -89,7 +89,7 @@ func TestAudit001_BrowserSignup(t *testing.T) {
 
 func TestAudit002_LoginChannels(t *testing.T) {
 	t.Run("browser", func(t *testing.T) {
-		svc, store := setupBrowserExtTest(t)
+		svc, store, fakeUser := setupBrowserExtTest(t)
 		ctx := context.Background()
 
 		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-browser@test.com", EmailVerified: true, Name: "Browser", Provider: "google", ProviderUserID: "browser-ext-sub", ProviderEmail: "audit-browser@test.com"})
@@ -98,7 +98,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		}
 		arID, _ := store.CreateTestAuthRequest(ctx, "audit-browser")
 
-		result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "browser-agent")
+		result := svc.CompleteBrowserLogin(ctx, arID, fakeUser, "127.0.0.1", "browser-agent")
 		if result.Action != ActionAutoApprove {
 			t.Fatalf("action = %v, want AutoApprove", result.Action)
 		}
@@ -110,7 +110,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 	})
 
 	t.Run("device", func(t *testing.T) {
-		svc, store, clk := setupDeviceExtTest(t, "audit-device-sub")
+		svc, store, clk, fakeUser := setupDeviceExtTest(t, "audit-device-sub")
 		ctx := context.Background()
 
 		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device@test.com", EmailVerified: true, Name: "Device", Provider: "google", ProviderUserID: "audit-device-sub", ProviderEmail: "audit-device@test.com"})
@@ -119,7 +119,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		}
 		insertDeviceCode(t, store, "AUDT-DEV", clk)
 
-		result := svc.HandleDeviceCallback(ctx, "fake-code", "AUDT-DEV", "127.0.0.1", "device-agent")
+		result := svc.CompleteDeviceLogin(ctx, "AUDT-DEV", fakeUser, "127.0.0.1", "device-agent")
 		if result.Action != DeviceRedirectBack {
 			t.Fatalf("action = %v, want DeviceRedirectBack", result.Action)
 		}
@@ -131,7 +131,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 	})
 
 	t.Run("mcp", func(t *testing.T) {
-		svc, store := setupMCPExtTest(t, "audit-mcp-sub")
+		svc, store, fakeUser := setupMCPExtTest(t, "audit-mcp-sub")
 		ctx := context.Background()
 
 		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "audit-mcp-sub", ProviderEmail: "audit-mcp@test.com"})
@@ -140,7 +140,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		}
 		arID, _ := store.CreateTestAuthRequestWithResource(ctx, "audit-mcp", "http://localhost/mcp")
 
-		result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-agent")
+		result := svc.CompleteMCPLogin(ctx, arID, fakeUser, "127.0.0.1", "mcp-agent")
 		if result.Action != ActionAutoApprove {
 			t.Fatalf("action = %v, want AutoApprove", result.Action)
 		}
@@ -157,7 +157,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 // skip-IdP path with reused_session=true to keep audit history symmetric with
 // the auth.token_revoked rows that follow.
 func TestAudit_ReusedSession_AuthLoginRecorded(t *testing.T) {
-	svc, store := setupBrowserExtTest(t)
+	svc, store, _ := setupBrowserExtTest(t)
 	ctx := context.Background()
 
 	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-reuse@test.com", EmailVerified: true, Name: "Reuse", Provider: "google", ProviderUserID: "browser-ext-sub", ProviderEmail: "audit-reuse@test.com"})
@@ -195,7 +195,7 @@ func TestAudit_ReusedSession_AuthLoginRecorded(t *testing.T) {
 // flow must also emit auth.login with reused_session=true so audit history is
 // symmetric across channels.
 func TestAudit_ReusedSession_MCP_AuthLoginRecorded(t *testing.T) {
-	svc, store := setupMCPExtTest(t, "audit-mcp-reuse-sub")
+	svc, store, _ := setupMCPExtTest(t, "audit-mcp-reuse-sub")
 	ctx := context.Background()
 
 	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp-reuse@test.com", EmailVerified: true, Name: "MCP Reuse", Provider: "google", ProviderUserID: "audit-mcp-reuse-sub", ProviderEmail: "audit-mcp-reuse@test.com"})
@@ -235,7 +235,7 @@ func TestAudit_ReusedSession_MCP_AuthLoginRecorded(t *testing.T) {
 }
 
 func TestAudit004_DeviceApproved(t *testing.T) {
-	svc, store, clk := setupDeviceService(t)
+	svc, store, clk, _ := setupDeviceService(t)
 	ctx := context.Background()
 
 	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-approve@test.com", EmailVerified: true, Name: "Approve", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "audit-approve@test.com"})
@@ -260,7 +260,7 @@ func TestAudit004_DeviceApproved(t *testing.T) {
 }
 
 func TestAudit005_DeviceDenied(t *testing.T) {
-	svc, store, clk := setupDeviceService(t)
+	svc, store, clk, _ := setupDeviceService(t)
 	ctx := context.Background()
 
 	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-deny@test.com", EmailVerified: true, Name: "Deny", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "audit-deny@test.com"})
@@ -285,7 +285,7 @@ func TestAudit005_DeviceDenied(t *testing.T) {
 }
 
 func TestAudit006_DeletionRequested(t *testing.T) {
-	loginSvc, store := setupLoginService(t)
+	loginSvc, store, fakeUser := setupLoginService(t)
 	svc := NewAccountService(store)
 	ctx := context.Background()
 
@@ -293,7 +293,7 @@ func TestAudit006_DeletionRequested(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create auth request: %v", err)
 	}
-	loginResult := loginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "login-agent")
+	loginResult := loginSvc.CompleteBrowserLogin(ctx, arID, fakeUser, "127.0.0.1", "login-agent")
 	if loginResult.Action != ActionAutoApprove {
 		t.Fatalf("login action = %v, want AutoApprove", loginResult.Action)
 	}
@@ -324,7 +324,7 @@ func TestAudit006_DeletionRequested(t *testing.T) {
 }
 
 func TestAudit007_DeletionCancelled(t *testing.T) {
-	svc, store := setupLoginService(t)
+	svc, store, fakeUser := setupLoginService(t)
 	ctx := context.Background()
 
 	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-recover@test.com", EmailVerified: true, Name: "Recover", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "audit-recover@test.com"})
@@ -336,7 +336,7 @@ func TestAudit007_DeletionCancelled(t *testing.T) {
 	}
 	arID, _ := store.CreateTestAuthRequest(ctx, "audit-recover")
 
-	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "recover-agent")
+	result := svc.CompleteBrowserLogin(ctx, arID, fakeUser, "127.0.0.1", "recover-agent")
 	if result.Action != ActionAutoApprove {
 		t.Fatalf("action = %v, want AutoApprove", result.Action)
 	}
@@ -367,7 +367,7 @@ func TestAudit009_InactiveUser(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc, store := setupLoginService(t)
+			svc, store, fakeUser := setupLoginService(t)
 			ctx := context.Background()
 
 			user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-inactive-" + tt.name + "@test.com", EmailVerified: true, Name: "Inactive", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "audit-inactive@test.com"})
@@ -382,7 +382,7 @@ func TestAudit009_InactiveUser(t *testing.T) {
 				t.Fatalf("create auth request: %v", err)
 			}
 
-			result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "inactive-agent")
+			result := svc.CompleteBrowserLogin(ctx, arID, fakeUser, "127.0.0.1", "inactive-agent")
 			if result.Action != ActionError {
 				t.Fatalf("action = %v, want Error", result.Action)
 			}
@@ -396,7 +396,7 @@ func TestAudit009_InactiveUser(t *testing.T) {
 }
 
 func TestAuditSecurity003_DeviceInactiveUser(t *testing.T) {
-	svc, store, clk := setupDeviceExtTest(t, "audit-device-inactive-sub")
+	svc, store, clk, fakeUser := setupDeviceExtTest(t, "audit-device-inactive-sub")
 	ctx := context.Background()
 
 	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-inactive@test.com", EmailVerified: true, Name: "Inactive Device", Provider: "google", ProviderUserID: "audit-device-inactive-sub", ProviderEmail: "audit-device-inactive@test.com"})
@@ -408,7 +408,7 @@ func TestAuditSecurity003_DeviceInactiveUser(t *testing.T) {
 	}
 	insertDeviceCode(t, store, "AUDT-INAC", clk)
 
-	result := svc.HandleDeviceCallback(ctx, "fake-code", "AUDT-INAC", "127.0.0.1", "device-inactive-agent")
+	result := svc.CompleteDeviceLogin(ctx, "AUDT-INAC", fakeUser, "127.0.0.1", "device-inactive-agent")
 	if result.Action != DeviceError {
 		t.Fatalf("action = %v, want DeviceError", result.Action)
 	}
@@ -420,7 +420,7 @@ func TestAuditSecurity003_DeviceInactiveUser(t *testing.T) {
 }
 
 func TestAuditSecurity_DevicePendingDeletionInactiveUser(t *testing.T) {
-	svc, store, clk := setupDeviceExtTest(t, "audit-device-pending-sub")
+	svc, store, clk, fakeUser := setupDeviceExtTest(t, "audit-device-pending-sub")
 	ctx := context.Background()
 
 	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-pending@test.com", EmailVerified: true, Name: "Pending Device", Provider: "google", ProviderUserID: "audit-device-pending-sub", ProviderEmail: "audit-device-pending@test.com"})
@@ -432,7 +432,7 @@ func TestAuditSecurity_DevicePendingDeletionInactiveUser(t *testing.T) {
 	}
 	insertDeviceCode(t, store, "AUDT-PEND", clk)
 
-	result := svc.HandleDeviceCallback(ctx, "fake-code", "AUDT-PEND", "127.0.0.1", "device-pending-agent")
+	result := svc.CompleteDeviceLogin(ctx, "AUDT-PEND", fakeUser, "127.0.0.1", "device-pending-agent")
 	if result.Action != DeviceError {
 		t.Fatalf("action = %v, want DeviceError", result.Action)
 	}
@@ -458,7 +458,7 @@ func TestAuditSecurity_MCPInactiveUser_Metadata(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc, store := setupMCPExtTest(t, "audit-mcp-"+tt.name+"-sub")
+			svc, store, fakeUser := setupMCPExtTest(t, "audit-mcp-"+tt.name+"-sub")
 			ctx := context.Background()
 
 			user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp-" + tt.name + "@test.com", EmailVerified: true, Name: "MCP Inactive", Provider: "google", ProviderUserID: "audit-mcp-" + tt.name + "-sub", ProviderEmail: "audit-mcp-" + tt.name + "@test.com"})
@@ -470,7 +470,7 @@ func TestAuditSecurity_MCPInactiveUser_Metadata(t *testing.T) {
 			}
 			arID, _ := store.CreateTestAuthRequestWithResource(ctx, "audit-mcp-"+tt.name, "http://localhost/mcp")
 
-			result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-agent")
+			result := svc.CompleteMCPLogin(ctx, arID, fakeUser, "127.0.0.1", "mcp-agent")
 			if result.Action != ActionError {
 				t.Fatalf("action = %v, want ActionError", result.Action)
 			}

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -14,11 +14,11 @@ import (
 )
 
 type DeviceService struct {
-	store      DeviceStore
-	provider   upstream.Provider
-	sessionTTL time.Duration
-	publicURL  string
-	clock      clock.Clock
+	store        DeviceStore
+	providerName string
+	sessionTTL   time.Duration
+	publicURL    string
+	clock        clock.Clock
 }
 
 type DeviceStore interface {
@@ -32,13 +32,13 @@ type DeviceStore interface {
 	ResolveClient(ctx context.Context, clientID string) (*storage.ClientModel, error)
 }
 
-func NewDeviceService(store DeviceStore, provider upstream.Provider, publicURL string, sessionTTL time.Duration, clk clock.Clock) *DeviceService {
+func NewDeviceService(store DeviceStore, providerName string, publicURL string, sessionTTL time.Duration, clk clock.Clock) *DeviceService {
 	return &DeviceService{
-		store:      store,
-		provider:   provider,
-		publicURL:  publicURL,
-		sessionTTL: sessionTTL,
-		clock:      clk,
+		store:        store,
+		providerName: providerName,
+		publicURL:    publicURL,
+		sessionTTL:   sessionTTL,
+		clock:        clk,
 	}
 }
 
@@ -96,17 +96,19 @@ func (s *DeviceService) HandleDevicePage(ctx context.Context, userCode, sessionI
 	return &DevicePageResult{Action: DeviceShowApprove, UserCode: userCode}
 }
 
-// HandleDeviceCallback handles GET /device/auth/callback?code=xxx&state=user_code
-func (s *DeviceService) HandleDeviceCallback(ctx context.Context, code, userCode, ipAddress, userAgent string) *DevicePageResult {
-	if code == "" || userCode == "" {
+// CompleteDeviceLogin finishes the device callback after the upstream code
+// exchange has already happened inside the high-level CodeExchangeHandler
+// (which verified the state cookie / PKCE before exchange). state carries the
+// user_code; info is the resolved upstream identity.
+func (s *DeviceService) CompleteDeviceLogin(ctx context.Context, state string, info *upstream.UserInfo, ipAddress, userAgent string) *DevicePageResult {
+	userCode := state
+	if userCode == "" || info == nil {
 		return &DevicePageResult{Action: DeviceError, Error: "invalid_request", ErrorCode: http.StatusBadRequest}
 	}
 
-	// #186: validate the local user_code state BEFORE calling provider.Exchange.
-	// Without this gate an attacker can drive arbitrary callbacks at the
-	// upstream IdP token endpoint (amplification + quota burn) without ever
-	// holding a valid user_code. The browser callback got the same fix in
-	// #171; this matches that ordering invariant for RFC 8628 §3.3/§3.5.
+	// The state-cookie check inside CodeExchangeHandler already gated this
+	// request before the upstream exchange (anti-amplification per #186). We
+	// still validate the local user_code lifecycle before binding the subject.
 	deviceCode, err := s.store.GetDeviceCodeByUserCode(ctx, userCode)
 	if errors.Is(err, storage.ErrNotFound) {
 		return &DevicePageResult{Action: DeviceError, Error: "invalid_request", ErrorCode: http.StatusBadRequest}
@@ -125,11 +127,7 @@ func (s *DeviceService) HandleDeviceCallback(ctx context.Context, code, userCode
 		return &DevicePageResult{Action: DeviceError, Error: "invalid_request", ErrorCode: http.StatusBadRequest}
 	}
 
-	// Exchange code for user info
-	userInfo, err := s.provider.Exchange(ctx, code)
-	if err != nil {
-		return &DevicePageResult{Action: DeviceError, Error: "upstream_error", ErrorCode: http.StatusInternalServerError}
-	}
+	userInfo := info
 
 	user, result := s.findDeviceCallbackUser(ctx, userInfo.Sub)
 	if result != nil {
@@ -215,7 +213,7 @@ func (s *DeviceService) validateDevicePage(ctx context.Context, userCode string)
 }
 
 func (s *DeviceService) redirectDeviceToProvider(userCode string) *DevicePageResult {
-	return &DevicePageResult{Action: DeviceRedirectIdP, UserCode: s.provider.AuthURL(userCode)}
+	return &DevicePageResult{Action: DeviceRedirectIdP, UserCode: userCode}
 }
 
 func (s *DeviceService) ensureDeviceSessionAccess(ctx context.Context, user *storage.User) *DevicePageResult {
@@ -229,7 +227,7 @@ func (s *DeviceService) ensureDeviceSessionAccess(ctx context.Context, user *sto
 }
 
 func (s *DeviceService) findDeviceCallbackUser(ctx context.Context, providerUserID string) (*storage.User, *DevicePageResult) {
-	user, err := s.store.GetUserByProviderIdentity(ctx, s.provider.Name(), providerUserID)
+	user, err := s.store.GetUserByProviderIdentity(ctx, s.providerName, providerUserID)
 	if errors.Is(err, storage.ErrNotFound) {
 		return nil, &DevicePageResult{Action: DeviceError, Error: "account_not_found: please sign up via browser first", ErrorCode: http.StatusForbidden}
 	}

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
-func setupDeviceService(t *testing.T) (*DeviceService, *storage.Storage, clock.Clock) {
+func setupDeviceService(t *testing.T) (*DeviceService, *storage.Storage, clock.Clock, *upstream.UserInfo) {
 	t.Helper()
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
@@ -31,8 +31,8 @@ func setupDeviceService(t *testing.T) (*DeviceService, *storage.Storage, clock.C
 		},
 	}
 
-	svc := NewDeviceService(store, fakeProvider, "http://localhost:8080", 24*time.Hour, clk)
-	return svc, store, clk
+	svc := NewDeviceService(store, fakeProvider.Name(), "http://localhost:8080", 24*time.Hour, clk)
+	return svc, store, clk, fakeProvider.User
 }
 
 func insertDeviceCode(t *testing.T, store *storage.Storage, userCode string, clk clock.Clock) {
@@ -49,7 +49,7 @@ func insertDeviceCode(t *testing.T, store *storage.Storage, userCode string, clk
 }
 
 func TestDevicePage_NoUserCode_ShowEntry(t *testing.T) {
-	svc, _, _ := setupDeviceService(t)
+	svc, _, _, _ := setupDeviceService(t)
 	result := svc.HandleDevicePage(context.Background(), "", "")
 	if result.Action != DeviceShowEntry {
 		t.Errorf("action = %v, want DeviceShowEntry", result.Action)
@@ -57,7 +57,7 @@ func TestDevicePage_NoUserCode_ShowEntry(t *testing.T) {
 }
 
 func TestDevicePage_InvalidUserCode_ShowEntryWithError(t *testing.T) {
-	svc, _, _ := setupDeviceService(t)
+	svc, _, _, _ := setupDeviceService(t)
 	result := svc.HandleDevicePage(context.Background(), "INVALID", "")
 	if result.Action != DeviceShowEntry {
 		t.Errorf("action = %v, want DeviceShowEntry", result.Action)
@@ -68,7 +68,7 @@ func TestDevicePage_InvalidUserCode_ShowEntryWithError(t *testing.T) {
 }
 
 func TestDevicePage_ValidCode_NoSession_RedirectIdP(t *testing.T) {
-	svc, store, clk := setupDeviceService(t)
+	svc, store, clk, _ := setupDeviceService(t)
 	insertDeviceCode(t, store, "BCDF-GHKM", clk)
 
 	result := svc.HandleDevicePage(context.Background(), "BCDF-GHKM", "")
@@ -78,7 +78,7 @@ func TestDevicePage_ValidCode_NoSession_RedirectIdP(t *testing.T) {
 }
 
 func TestDevicePage_ValidCode_WithSession_ShowApprove(t *testing.T) {
-	svc, store, clk := setupDeviceService(t)
+	svc, store, clk, _ := setupDeviceService(t)
 	ctx := context.Background()
 
 	// Create active user and session
@@ -94,7 +94,7 @@ func TestDevicePage_ValidCode_WithSession_ShowApprove(t *testing.T) {
 }
 
 func TestDevicePage_InactiveUser_Rejected(t *testing.T) {
-	svc, store, clk := setupDeviceService(t)
+	svc, store, clk, _ := setupDeviceService(t)
 	ctx := context.Background()
 
 	// Create disabled user
@@ -114,7 +114,7 @@ func TestDevicePage_InactiveUser_Rejected(t *testing.T) {
 }
 
 func TestDeviceApprove_Allow(t *testing.T) {
-	svc, store, clk := setupDeviceService(t)
+	svc, store, clk, _ := setupDeviceService(t)
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-allow@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-allow-sub", ProviderEmail: "da@test.com"})
@@ -129,7 +129,7 @@ func TestDeviceApprove_Allow(t *testing.T) {
 }
 
 func TestDeviceApprove_Deny(t *testing.T) {
-	svc, store, clk := setupDeviceService(t)
+	svc, store, clk, _ := setupDeviceService(t)
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-deny@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-deny-sub", ProviderEmail: "dd@test.com"})
@@ -144,7 +144,7 @@ func TestDeviceApprove_Deny(t *testing.T) {
 }
 
 func TestDeviceApprove_NoSession_Unauthorized(t *testing.T) {
-	svc, store, clk := setupDeviceService(t)
+	svc, store, clk, _ := setupDeviceService(t)
 	insertDeviceCode(t, store, "NSES-CODE", clk)
 
 	result := svc.HandleDeviceApprove(context.Background(), "NSES-CODE", "approve", "", "127.0.0.1", "test")
@@ -157,13 +157,13 @@ func TestDeviceApprove_NoSession_Unauthorized(t *testing.T) {
 }
 
 func TestDeviceCallback_NewUser_SignupRequired(t *testing.T) {
-	svc, store, clk := setupDeviceService(t)
+	svc, store, clk, fakeUser := setupDeviceService(t)
 	// #186: callback now front-loads the user_code lookup, so seed a
 	// pending row before invoking — the post-Exchange "no user account"
 	// branch is what this test is asserting.
 	insertDeviceCode(t, store, "CBCK-CODE", clk)
 	// FakeProvider returns a user that doesn't exist in DB yet
-	result := svc.HandleDeviceCallback(context.Background(), "fake-code", "CBCK-CODE", "127.0.0.1", "test")
+	result := svc.CompleteDeviceLogin(context.Background(), "CBCK-CODE", fakeUser, "127.0.0.1", "test")
 	if result.Action != DeviceError {
 		t.Errorf("action = %v, want DeviceError (account_not_found)", result.Action)
 	}
@@ -173,13 +173,13 @@ func TestDeviceCallback_NewUser_SignupRequired(t *testing.T) {
 }
 
 func TestDeviceCallback_ExistingUser_RedirectBack(t *testing.T) {
-	svc, store, clk := setupDeviceService(t)
+	svc, store, clk, fakeUser := setupDeviceService(t)
 	ctx := context.Background()
 
 	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-cb@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "dc@test.com"})
 	insertDeviceCode(t, store, "RDIR-CODE", clk)
 
-	result := svc.HandleDeviceCallback(ctx, "fake-code", "RDIR-CODE", "127.0.0.1", "test")
+	result := svc.CompleteDeviceLogin(ctx, "RDIR-CODE", fakeUser, "127.0.0.1", "test")
 	if result.Action != DeviceRedirectBack {
 		t.Errorf("action = %v, want DeviceRedirectBack", result.Action)
 	}
@@ -193,14 +193,14 @@ func TestDeviceCallback_ExistingUser_RedirectBack(t *testing.T) {
 
 // device-005: recoverable_browser_only callback → account_inactive
 func TestDevice005_RecoverableCallback_Rejected(t *testing.T) {
-	svc, store, clk := setupDeviceExtTest(t, "dev-recover-sub")
+	svc, store, clk, fakeUser := setupDeviceExtTest(t, "dev-recover-sub")
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-recover@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-recover-sub", ProviderEmail: "drc@test.com"})
 	store.SetUserStatus(ctx, user.ID, "pending_deletion")
 	insertDeviceCode(t, store, "RECV-CODE", clk)
 
-	result := svc.HandleDeviceCallback(ctx, "fake-code", "RECV-CODE", "127.0.0.1", "test")
+	result := svc.CompleteDeviceLogin(ctx, "RECV-CODE", fakeUser, "127.0.0.1", "test")
 	if result.Action != DeviceError {
 		t.Errorf("action = %v, want DeviceError (recoverable on device)", result.Action)
 	}
@@ -211,14 +211,14 @@ func TestDevice005_RecoverableCallback_Rejected(t *testing.T) {
 
 // device-006: inactive callback → account_inactive
 func TestDevice006_InactiveCallback_Rejected(t *testing.T) {
-	svc, store, clk := setupDeviceExtTest(t, "dev-inactive-sub")
+	svc, store, clk, fakeUser := setupDeviceExtTest(t, "dev-inactive-sub")
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-inactive@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-inactive-sub", ProviderEmail: "di@test.com"})
 	store.DisableUser(ctx, user.ID)
 	insertDeviceCode(t, store, "INAC-CODE", clk)
 
-	result := svc.HandleDeviceCallback(ctx, "fake-code", "INAC-CODE", "127.0.0.1", "test")
+	result := svc.CompleteDeviceLogin(ctx, "INAC-CODE", fakeUser, "127.0.0.1", "test")
 	if result.Action != DeviceError {
 		t.Errorf("action = %v, want DeviceError (inactive on device)", result.Action)
 	}
@@ -229,14 +229,14 @@ func TestDevice006_InactiveCallback_Rejected(t *testing.T) {
 
 // device-004: deleted callback -> account_inactive
 func TestDeviceCallback_DeletedUser_Rejected(t *testing.T) {
-	svc, store, clk := setupDeviceExtTest(t, "dev-deleted-sub")
+	svc, store, clk, fakeUser := setupDeviceExtTest(t, "dev-deleted-sub")
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-deleted@test.com", EmailVerified: true, Name: "Deleted", Provider: "google", ProviderUserID: "dev-deleted-sub", ProviderEmail: "dev-deleted@test.com"})
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
 	insertDeviceCode(t, store, "DELD-CODE", clk)
 
-	result := svc.HandleDeviceCallback(ctx, "fake-code", "DELD-CODE", "127.0.0.1", "test")
+	result := svc.CompleteDeviceLogin(ctx, "DELD-CODE", fakeUser, "127.0.0.1", "test")
 	if result.Action != DeviceError {
 		t.Errorf("action = %v, want DeviceError (deleted on device)", result.Action)
 	}
@@ -247,7 +247,7 @@ func TestDeviceCallback_DeletedUser_Rejected(t *testing.T) {
 
 // device-011: approve 직전 inactive로 변경 → account_inactive
 func TestDevice011_ApproveAfterDisable(t *testing.T) {
-	svc, store, clk := setupDeviceExtTest(t, "dev-approve-dis-sub")
+	svc, store, clk, _ := setupDeviceExtTest(t, "dev-approve-dis-sub")
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-dis@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-approve-dis-sub", ProviderEmail: "dad@test.com"})
@@ -278,7 +278,7 @@ func TestDeviceApprove_AfterStatusTransition_Rejected(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc, store, clk := setupDeviceExtTest(t, "dev-approve-"+tt.status)
+			svc, store, clk, _ := setupDeviceExtTest(t, "dev-approve-"+tt.status)
 			ctx := context.Background()
 
 			user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-" + tt.status + "@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-approve-" + tt.status, ProviderEmail: "dev-approve-" + tt.status + "@test.com"})

--- a/internal/service/device_unit_test.go
+++ b/internal/service/device_unit_test.go
@@ -75,7 +75,7 @@ func TestDevice_HandleDevicePage_NoSession_Redirects(t *testing.T) {
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
-	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clk)
+	svc := NewDeviceService(store, provider.Name(), "http://localhost", 24*time.Hour, clk)
 
 	result := svc.HandleDevicePage(context.Background(), "UCODE", "")
 
@@ -99,7 +99,7 @@ func TestDevice_HandleDeviceApprove_Deny(t *testing.T) {
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
-	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clock.RealClock{})
+	svc := NewDeviceService(store, provider.Name(), "http://localhost", 24*time.Hour, clock.RealClock{})
 
 	result := svc.HandleDeviceApprove(context.Background(), "UCODE", "deny", "sess", "127.0.0.1", "ua")
 
@@ -134,7 +134,7 @@ func TestDevice_HandleDeviceApprove_Deny_NotPending_SkipsMutation(t *testing.T) 
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
-	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clock.RealClock{})
+	svc := NewDeviceService(store, provider.Name(), "http://localhost", 24*time.Hour, clock.RealClock{})
 
 	result := svc.HandleDeviceApprove(context.Background(), "UCODE", "deny", "sess", "127.0.0.1", "ua")
 
@@ -173,7 +173,7 @@ func TestDevice_HandleDeviceApprove_InvalidAction(t *testing.T) {
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
-	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clock.RealClock{})
+	svc := NewDeviceService(store, provider.Name(), "http://localhost", 24*time.Hour, clock.RealClock{})
 
 	result := svc.HandleDeviceApprove(context.Background(), "UCODE", "bogus", "sess", "127.0.0.1", "ua")
 
@@ -204,7 +204,7 @@ func TestDevice_HandleDeviceApprove_ApproveError(t *testing.T) {
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
-	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clock.RealClock{})
+	svc := NewDeviceService(store, provider.Name(), "http://localhost", 24*time.Hour, clock.RealClock{})
 
 	result := svc.HandleDeviceApprove(context.Background(), "UCODE", "approve", "sess", "127.0.0.1", "ua")
 
@@ -216,33 +216,14 @@ func TestDevice_HandleDeviceApprove_ApproveError(t *testing.T) {
 	}
 }
 
-// countingProvider is an upstream.Provider that records Exchange call
-// count so tests can assert "Exchange must not be called when local
-// state is invalid" — the load-bearing invariant for #186 (and the
-// matching browser fix #171).
-type countingProvider struct {
-	exchangeCalls int
-	user          *upstream.UserInfo
-}
-
-func (c *countingProvider) Name() string                { return "counting" }
-func (c *countingProvider) AuthURL(state string) string { return "/auth?state=" + state }
-func (c *countingProvider) Exchange(_ context.Context, _ string) (*upstream.UserInfo, error) {
-	c.exchangeCalls++
-	if c.user == nil {
-		return nil, errors.New("counting provider: no user")
-	}
-	return c.user, nil
-}
-
-// #186: device callback must NOT call provider.Exchange before
-// validating the local user_code state. An attacker hammering
-// /device/auth/callback?code=X&state=BOGUS otherwise amplifies traffic
-// to the upstream IdP and can drive token-endpoint quota burn for free.
-//
-// Three local-state failure modes — not_found, expired, non-pending —
-// must each fail fast without an outbound IdP call.
-func TestDevice_HandleDeviceCallback_RejectsBeforeExchange(t *testing.T) {
+// #186: the device callback must reject invalid local user_code state.
+// Pre-exchange amplification protection now lives in the high-level
+// CodeExchangeHandler (state cookie + PKCE verified before the upstream
+// token call), so the service-level guard runs on the post-exchange
+// CompleteDeviceLogin path. Each local-state failure mode — not_found,
+// expired, non-pending — must still surface DeviceError, and must reject
+// before any user lookup binds the freshly-authenticated subject.
+func TestDevice_CompleteDeviceLogin_RejectsInvalidLocalState(t *testing.T) {
 	clk := &clock.FixedClock{T: time.Date(2026, 4, 3, 0, 0, 0, 0, time.UTC)}
 	cases := []struct {
 		name string
@@ -256,21 +237,25 @@ func TestDevice_HandleDeviceCallback_RejectsBeforeExchange(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			getUserCalled := false
 			store := &fakeDeviceStore{
 				getDeviceCodeByUserCodeFn: func(context.Context, string) (*storage.DeviceCodeModel, error) {
 					return tc.dc, tc.err
 				},
+				getUserByProviderIdentity: func(context.Context, string, string) (*storage.User, error) {
+					getUserCalled = true
+					return &storage.User{ID: "u1", Status: "active"}, nil
+				},
 			}
-			provider := &countingProvider{user: &upstream.UserInfo{Sub: "sub"}}
-			svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clk)
+			svc := NewDeviceService(store, "google", "http://localhost", 24*time.Hour, clk)
 
-			result := svc.HandleDeviceCallback(context.Background(), "code", "UCODE", "127.0.0.1", "ua")
+			result := svc.CompleteDeviceLogin(context.Background(), "UCODE", &upstream.UserInfo{Sub: "sub"}, "127.0.0.1", "ua")
 
 			if result.Action != DeviceError {
 				t.Errorf("action = %v, want DeviceError", result.Action)
 			}
-			if provider.exchangeCalls != 0 {
-				t.Errorf("provider.Exchange called %d times, want 0 (must validate local state first)", provider.exchangeCalls)
+			if getUserCalled {
+				t.Errorf("user lookup ran despite invalid local state (must reject first)")
 			}
 		})
 	}
@@ -301,9 +286,9 @@ func TestDevice_HandleDeviceCallback_AuditLogIncludesSessionAndClient(t *testing
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub"}}
-	svc := NewDeviceService(store, provider, "http://localhost", 24*time.Hour, clk)
+	svc := NewDeviceService(store, provider.Name(), "http://localhost", 24*time.Hour, clk)
 
-	result := svc.HandleDeviceCallback(context.Background(), "code", "UCODE", "127.0.0.1", "ua")
+	result := svc.CompleteDeviceLogin(context.Background(), "UCODE", provider.User, "127.0.0.1", "ua")
 
 	if result.Action != DeviceRedirectBack {
 		t.Fatalf("action = %v, want %v", result.Action, DeviceRedirectBack)

--- a/internal/service/e2e_test.go
+++ b/internal/service/e2e_test.go
@@ -25,6 +25,7 @@ type e2eFixture struct {
 	Store       *storage.Storage
 	DB          *sql.DB
 	Clock       *clock.FixedClock
+	FakeUser    *upstream.UserInfo
 }
 
 func setupE2ETest(t *testing.T) *e2eFixture {
@@ -44,9 +45,9 @@ func setupE2ETest(t *testing.T) *e2eFixture {
 		User: &upstream.UserInfo{Sub: "e2e-sub", Email: "e2e@test.com", EmailVerified: true, Name: "E2E User"},
 	}
 
-	loginSvc := NewLoginService(store, fakeProvider, 24*time.Hour)
-	mcpLoginSvc := NewMCPLoginService(store, fakeProvider, 24*time.Hour)
-	deviceSvc := NewDeviceService(store, fakeProvider, "http://localhost:8080", 24*time.Hour, clk)
+	loginSvc := NewLoginService(store, fakeProvider.Name(), 24*time.Hour)
+	mcpLoginSvc := NewMCPLoginService(store, fakeProvider.Name(), 24*time.Hour)
+	deviceSvc := NewDeviceService(store, fakeProvider.Name(), "http://localhost:8080", 24*time.Hour, clk)
 	accountSvc := NewAccountService(store)
 	return &e2eFixture{
 		LoginSvc:    loginSvc,
@@ -56,6 +57,7 @@ func setupE2ETest(t *testing.T) *e2eFixture {
 		Store:       store,
 		DB:          db,
 		Clock:       clk,
+		FakeUser:    fakeProvider.User,
 	}
 }
 
@@ -80,28 +82,28 @@ func TestE2E1_SignupToAllChannels(t *testing.T) {
 
 	// 1. Browser signup → auto-approve (no terms step)
 	arID1, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e1-signup")
-	result := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID1, "127.0.0.1", "browser")
+	result := fx.LoginSvc.CompleteBrowserLogin(ctx, arID1, fx.FakeUser, "127.0.0.1", "browser")
 	if result.Action != ActionAutoApprove {
 		t.Fatalf("step 1: action = %v, want AutoApprove", result.Action)
 	}
 
 	// 2. Browser re-login → auto-approve
 	arID2, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e1-relogin")
-	relogin := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID2, "127.0.0.1", "browser")
+	relogin := fx.LoginSvc.CompleteBrowserLogin(ctx, arID2, fx.FakeUser, "127.0.0.1", "browser")
 	if relogin.Action != ActionAutoApprove {
 		t.Fatalf("step 2: action = %v, want AutoApprove", relogin.Action)
 	}
 
 	// 3. Device callback → should succeed (redirect back)
 	fx.Store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e1", "E2E1-CODE", fx.Clock.Now().Add(5*time.Minute), []string{"openid"})
-	devResult := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E1-CODE", "127.0.0.1", "cli")
+	devResult := fx.DeviceSvc.CompleteDeviceLogin(ctx, "E2E1-CODE", fx.FakeUser, "127.0.0.1", "cli")
 	if devResult.Action != DeviceRedirectBack {
 		t.Fatalf("step 3: device action = %v, want RedirectBack", devResult.Action)
 	}
 
 	// 4. MCP → auto-approve
 	arID3, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "e2e1-mcp", "http://localhost/mcp")
-	mcpResult := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arID3, "127.0.0.1", "mcp-client")
+	mcpResult := fx.MCPLoginSvc.CompleteMCPLogin(ctx, arID3, fx.FakeUser, "127.0.0.1", "mcp-client")
 	if mcpResult.Action != ActionAutoApprove {
 		t.Fatalf("step 4: mcp action = %v, want AutoApprove", mcpResult.Action)
 	}
@@ -117,34 +119,34 @@ func TestE2E2_SignupAbandonAndReturn(t *testing.T) {
 
 	// Step 2/3: 유저 DB 없음 → Device/MCP 차단 (account_not_found)
 	fx.Store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e2", "E2E2-DCODE", fx.Clock.Now().Add(5*time.Minute), []string{"openid"})
-	devResult := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E2-DCODE", "127.0.0.1", "cli")
+	devResult := fx.DeviceSvc.CompleteDeviceLogin(ctx, "E2E2-DCODE", fx.FakeUser, "127.0.0.1", "cli")
 	if devResult.Action != DeviceError {
 		t.Fatalf("device before signup: action=%v, want DeviceError", devResult.Action)
 	}
 
 	arIDMCP, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "e2e2-mcp-pre", "http://localhost/mcp")
-	mcpResult := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP, "127.0.0.1", "mcp")
+	mcpResult := fx.MCPLoginSvc.CompleteMCPLogin(ctx, arIDMCP, fx.FakeUser, "127.0.0.1", "mcp")
 	if mcpResult.Action != ActionError {
 		t.Fatalf("mcp before signup: action=%v, want ActionError", mcpResult.Action)
 	}
 
 	// Step 3: Browser 완료 → 가입 (새 유저 생성)
 	arIDBrowser, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e2-browser")
-	browserResult := fx.LoginSvc.HandleCallback(ctx, "fake-code", arIDBrowser, "127.0.0.1", "browser")
+	browserResult := fx.LoginSvc.CompleteBrowserLogin(ctx, arIDBrowser, fx.FakeUser, "127.0.0.1", "browser")
 	if browserResult.Action != ActionAutoApprove {
 		t.Fatalf("browser signup: action=%v, want ActionAutoApprove", browserResult.Action)
 	}
 
 	// 가입 후 Device 정상 동작
 	fx.Store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e2-ok", "E2E2-DCODE2", fx.Clock.Now().Add(5*time.Minute), []string{"openid"})
-	devResult2 := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E2-DCODE2", "127.0.0.1", "cli")
+	devResult2 := fx.DeviceSvc.CompleteDeviceLogin(ctx, "E2E2-DCODE2", fx.FakeUser, "127.0.0.1", "cli")
 	if devResult2.Action != DeviceRedirectBack {
 		t.Fatalf("device after signup: action=%v, want DeviceRedirectBack", devResult2.Action)
 	}
 
 	// 가입 후 MCP 정상 동작
 	arIDMCP2, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "e2e2-mcp-post", "http://localhost/mcp")
-	mcpResult2 := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP2, "127.0.0.1", "mcp")
+	mcpResult2 := fx.MCPLoginSvc.CompleteMCPLogin(ctx, arIDMCP2, fx.FakeUser, "127.0.0.1", "mcp")
 	if mcpResult2.Action != ActionAutoApprove {
 		t.Fatalf("mcp after signup: action=%v, want ActionAutoApprove", mcpResult2.Action)
 	}
@@ -178,19 +180,19 @@ func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
 
 	// 3. Device/MCP should be rejected
 	fx.Store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e4", "E2E4-CODE", fx.Clock.Now().Add(5*time.Minute), []string{"openid"})
-	devResult := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E4-CODE", "127.0.0.1", "cli")
+	devResult := fx.DeviceSvc.CompleteDeviceLogin(ctx, "E2E4-CODE", fx.FakeUser, "127.0.0.1", "cli")
 	if devResult.Action != DeviceError || devResult.ErrorCode != 403 {
 		t.Fatalf("step 3: device should reject pending_deletion user, got action=%v code=%d", devResult.Action, devResult.ErrorCode)
 	}
 	arIDMCP, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "e2e4-mcp", "http://localhost/mcp")
-	mcpResult := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP, "127.0.0.1", "mcp-client")
+	mcpResult := fx.MCPLoginSvc.CompleteMCPLogin(ctx, arIDMCP, fx.FakeUser, "127.0.0.1", "mcp-client")
 	if mcpResult.Action != ActionError || mcpResult.ErrorCode != 403 {
 		t.Fatalf("step 3: mcp should reject pending_deletion user, got action=%v code=%d", mcpResult.Action, mcpResult.ErrorCode)
 	}
 
 	// 4. Browser login recovers
 	arIDBrowser, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e4-browser")
-	recoverResult := fx.LoginSvc.HandleCallback(ctx, "fake-code", arIDBrowser, "127.0.0.1", "browser")
+	recoverResult := fx.LoginSvc.CompleteBrowserLogin(ctx, arIDBrowser, fx.FakeUser, "127.0.0.1", "browser")
 	if recoverResult.Action != ActionAutoApprove {
 		t.Fatalf("step 4: browser recovery action = %v, want AutoApprove", recoverResult.Action)
 	}
@@ -201,12 +203,12 @@ func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
 		t.Fatalf("step 5: refresh should succeed after recovery, got err=%v", err)
 	}
 	fx.Store.StoreDeviceAuthorization(ctx, "test-client", "dc-e2e4-ok", "E2E4-OK", fx.Clock.Now().Add(5*time.Minute), []string{"openid"})
-	devResult2 := fx.DeviceSvc.HandleDeviceCallback(ctx, "fake-code", "E2E4-OK", "127.0.0.1", "cli")
+	devResult2 := fx.DeviceSvc.CompleteDeviceLogin(ctx, "E2E4-OK", fx.FakeUser, "127.0.0.1", "cli")
 	if devResult2.Action != DeviceRedirectBack {
 		t.Fatalf("step 5: device should succeed after recovery, got action=%v", devResult2.Action)
 	}
 	arIDMCP2, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "e2e4-mcp-ok", "http://localhost/mcp")
-	mcpResult2 := fx.MCPLoginSvc.HandleCallback(ctx, "fake-code", arIDMCP2, "127.0.0.1", "mcp-client")
+	mcpResult2 := fx.MCPLoginSvc.CompleteMCPLogin(ctx, arIDMCP2, fx.FakeUser, "127.0.0.1", "mcp-client")
 	if mcpResult2.Action != ActionAutoApprove {
 		t.Fatalf("step 5: mcp should succeed after recovery, got action=%v", mcpResult2.Action)
 	}
@@ -233,7 +235,7 @@ func TestE2E5_RecoveryThenAuthRequestRetry(t *testing.T) {
 	}
 
 	// 2) 잘못된 authRequestID 콜백은 Exchange 이전에 거부되고 복구도 일어나지 않는다.
-	first := fx.LoginSvc.HandleCallback(ctx, "fake-code", "missing-auth-request", "127.0.0.1", "browser")
+	first := fx.LoginSvc.CompleteBrowserLogin(ctx, "missing-auth-request", fx.FakeUser, "127.0.0.1", "browser")
 	if first.Action != ActionError {
 		t.Fatalf("first action = %v, want ActionError", first.Action)
 	}
@@ -245,7 +247,7 @@ func TestE2E5_RecoveryThenAuthRequestRetry(t *testing.T) {
 
 	// 3) 유효한 authRequest로 한 번에 복구 + 완료.
 	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e5-retry")
-	second := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "browser")
+	second := fx.LoginSvc.CompleteBrowserLogin(ctx, arID, fx.FakeUser, "127.0.0.1", "browser")
 	if second.Action != ActionAutoApprove {
 		t.Fatalf("second action = %v, want ActionAutoApprove", second.Action)
 	}

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -12,9 +12,9 @@ import (
 )
 
 type LoginService struct {
-	store           LoginStore
-	browserProvider upstream.Provider
-	sessionTTL      time.Duration
+	store        LoginStore
+	providerName string
+	sessionTTL   time.Duration
 }
 
 type LoginStore interface {
@@ -53,11 +53,11 @@ func verifyAuthRequestChannel(ctx context.Context, store LoginStore, authReq *st
 	return "", 0
 }
 
-func NewLoginService(store LoginStore, browserProvider upstream.Provider, sessionTTL time.Duration) *LoginService {
+func NewLoginService(store LoginStore, providerName string, sessionTTL time.Duration) *LoginService {
 	return &LoginService{
-		store:           store,
-		browserProvider: browserProvider,
-		sessionTTL:      sessionTTL,
+		store:        store,
+		providerName: providerName,
+		sessionTTL:   sessionTTL,
 	}
 }
 
@@ -164,32 +164,29 @@ type CallbackResult struct {
 	ErrorCode     int
 }
 
-// HandleCallback processes GET /login/callback?code=xxx&state=authRequestID
-func (s *LoginService) HandleCallback(ctx context.Context, code, authRequestID, ipAddress, userAgent string) *CallbackResult {
-	return s.handleCallback(ctx, code, authRequestID, ipAddress, userAgent)
+// CompleteBrowserLogin finishes the browser callback after the upstream code
+// exchange has already happened inside the high-level CodeExchangeHandler
+// (which verified the state cookie / PKCE before exchange). state carries the
+// authRequestID; info is the resolved upstream identity.
+func (s *LoginService) CompleteBrowserLogin(ctx context.Context, state string, info *upstream.UserInfo, ipAddress, userAgent string) *CallbackResult {
+	return s.completeBrowserLogin(ctx, state, info, ipAddress, userAgent)
 }
 
-func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, ipAddress, userAgent string) *CallbackResult {
-	if code == "" || authRequestID == "" {
+func (s *LoginService) completeBrowserLogin(ctx context.Context, authRequestID string, userInfo *upstream.UserInfo, ipAddress, userAgent string) *CallbackResult {
+	if authRequestID == "" || userInfo == nil {
 		return &CallbackResult{Action: ActionError, Error: "missing code or state", ErrorCode: http.StatusBadRequest}
 	}
 
-	// Validate the local auth_request — and its channel binding — BEFORE
-	// contacting the upstream IdP. This blocks attacker-controlled callback
-	// spam (random `state` values) from amplifying outbound traffic to the
-	// IdP, and gives a clean fail-fast for callbacks that arrive after the
-	// auth_request has expired.
+	// The state-cookie check inside CodeExchangeHandler already gated this
+	// request before the upstream exchange, so the anti-amplification ordering
+	// is satisfied. We still resolve the local auth_request and verify its
+	// channel binding before completing it.
 	authReq, result := s.getCallbackAuthRequest(ctx, authRequestID)
 	if result != nil {
 		return result
 	}
 	if errMsg, statusCode := verifyAuthRequestChannel(ctx, s.store, authReq, "browser", ipAddress, userAgent, nil); errMsg != "" {
 		return &CallbackResult{Action: ActionError, Error: errMsg, ErrorCode: statusCode}
-	}
-
-	userInfo, err := s.browserProvider.Exchange(ctx, code)
-	if err != nil {
-		return &CallbackResult{Action: ActionError, Error: "upstream_error", ErrorCode: http.StatusInternalServerError}
 	}
 
 	user, signedUp, recovered, result := s.prepareBrowserCallbackUser(ctx, userInfo, authReq, ipAddress, userAgent)
@@ -226,7 +223,7 @@ func (s *LoginService) handleCallback(ctx context.Context, code, authRequestID, 
 // race against expiration/cleanup between fetch and audit (Codex review NIT
 // on PR #218).
 func (s *LoginService) prepareBrowserCallbackUser(ctx context.Context, userInfo *upstream.UserInfo, authReq *storage.AuthRequestModel, ipAddress, userAgent string) (*storage.User, bool, bool, *CallbackResult) {
-	providerName := s.browserProvider.Name()
+	providerName := s.providerName
 	user, err := s.store.GetUserByProviderIdentity(ctx, providerName, userInfo.Sub)
 	if errors.Is(err, storage.ErrNotFound) {
 		user, result := s.signupBrowserUser(ctx, providerName, userInfo, authReq, ipAddress, userAgent)
@@ -255,7 +252,7 @@ func (s *LoginService) getCallbackAuthRequest(ctx context.Context, authRequestID
 }
 
 func (s *LoginService) redirectToProvider(authRequestID string) *LoginResult {
-	return &LoginResult{Action: ActionRedirectToIdP, RedirectURL: s.browserProvider.AuthURL(authRequestID)}
+	return &LoginResult{Action: ActionRedirectToIdP, AuthRequestID: authRequestID}
 }
 
 func (s *LoginService) recoverUser(ctx context.Context, userID string) error {

--- a/internal/service/login_test.go
+++ b/internal/service/login_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kangheeyong/authgate/internal/upstream"
 )
 
-func setupLoginService(t *testing.T) (*LoginService, *storage.Storage) {
+func setupLoginService(t *testing.T) (*LoginService, *storage.Storage, *upstream.UserInfo) {
 	t.Helper()
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
@@ -31,25 +31,27 @@ func setupLoginService(t *testing.T) (*LoginService, *storage.Storage) {
 		},
 	}
 
-	svc := NewLoginService(store, fakeProvider, 24*time.Hour)
-	return svc, store
+	svc := NewLoginService(store, fakeProvider.Name(), 24*time.Hour)
+	return svc, store, fakeProvider.User
 }
 
 func TestHandleLogin_NoSession_RedirectsToIdP(t *testing.T) {
-	svc, _ := setupLoginService(t)
+	svc, _, _ := setupLoginService(t)
 
 	result := svc.HandleLogin(context.Background(), "req-123", "", "127.0.0.1", "test")
 
 	if result.Action != ActionRedirectToIdP {
 		t.Errorf("action = %v, want RedirectToIdP", result.Action)
 	}
-	if result.RedirectURL == "" {
-		t.Error("redirect URL should not be empty")
+	// The redirect now carries the authRequestID as the state value; the handler
+	// builds the actual IdP URL via provider.Redirect (high-level AuthURLHandler).
+	if result.AuthRequestID != "req-123" {
+		t.Errorf("authRequestID = %q, want req-123", result.AuthRequestID)
 	}
 }
 
 func TestHandleLogin_MissingAuthRequestID_Error(t *testing.T) {
-	svc, _ := setupLoginService(t)
+	svc, _, _ := setupLoginService(t)
 
 	result := svc.HandleLogin(context.Background(), "", "", "", "")
 
@@ -59,7 +61,7 @@ func TestHandleLogin_MissingAuthRequestID_Error(t *testing.T) {
 }
 
 func TestHandleCallback_NewUser_Signup_AutoApprove(t *testing.T) {
-	svc, store := setupLoginService(t)
+	svc, store, fakeUser := setupLoginService(t)
 	ctx := context.Background()
 
 	arID, err := store.CreateTestAuthRequest(ctx, "new-user")
@@ -67,7 +69,7 @@ func TestHandleCallback_NewUser_Signup_AutoApprove(t *testing.T) {
 		t.Fatalf("create auth request: %v", err)
 	}
 
-	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test-agent")
+	result := svc.CompleteBrowserLogin(ctx, arID, fakeUser, "127.0.0.1", "test-agent")
 
 	if result.Action != ActionAutoApprove {
 		t.Errorf("action = %v, want AutoApprove (new user is immediately active)", result.Action)
@@ -81,7 +83,7 @@ func TestHandleCallback_NewUser_Signup_AutoApprove(t *testing.T) {
 }
 
 func TestHandleCallback_ExistingUser_AutoApprove(t *testing.T) {
-	svc, store := setupLoginService(t)
+	svc, store, fakeUser := setupLoginService(t)
 	ctx := context.Background()
 
 	// Pre-create user
@@ -96,7 +98,7 @@ func TestHandleCallback_ExistingUser_AutoApprove(t *testing.T) {
 		t.Fatalf("create auth request: %v", err)
 	}
 
-	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test-agent")
+	result := svc.CompleteBrowserLogin(ctx, arID, fakeUser, "127.0.0.1", "test-agent")
 
 	if result.Action != ActionAutoApprove {
 		t.Errorf("action = %v, want AutoApprove", result.Action)
@@ -107,7 +109,7 @@ func TestHandleCallback_ExistingUser_AutoApprove(t *testing.T) {
 }
 
 func TestHandleCallback_PendingDeletion_RecoveryAutoApprove(t *testing.T) {
-	svc, store := setupLoginService(t)
+	svc, store, fakeUser := setupLoginService(t)
 	ctx := context.Background()
 
 	// Create user, then set to pending_deletion
@@ -122,7 +124,7 @@ func TestHandleCallback_PendingDeletion_RecoveryAutoApprove(t *testing.T) {
 		t.Fatalf("create auth request: %v", err)
 	}
 
-	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test-agent")
+	result := svc.CompleteBrowserLogin(ctx, arID, fakeUser, "127.0.0.1", "test-agent")
 
 	// Should recover and auto-approve
 	if result.Action != ActionAutoApprove {
@@ -134,7 +136,7 @@ func TestHandleCallback_PendingDeletion_RecoveryAutoApprove(t *testing.T) {
 }
 
 func TestHandleCallback_InactiveUser_Error(t *testing.T) {
-	svc, store := setupLoginService(t)
+	svc, store, fakeUser := setupLoginService(t)
 	ctx := context.Background()
 
 	// Create disabled user
@@ -145,32 +147,13 @@ func TestHandleCallback_InactiveUser_Error(t *testing.T) {
 		t.Fatalf("create auth request: %v", err)
 	}
 
-	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test-agent")
+	result := svc.CompleteBrowserLogin(ctx, arID, fakeUser, "127.0.0.1", "test-agent")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error", result.Action)
 	}
 	if result.ErrorCode != 403 {
 		t.Errorf("errorCode = %d, want 403", result.ErrorCode)
-	}
-}
-
-func TestHandleCallback_UpstreamError_Sanitized(t *testing.T) {
-	svc, store := setupLoginService(t)
-	ctx := context.Background()
-	svc.browserProvider = &upstream.FakeProvider{ProviderName: "google"}
-
-	// #162: callback now validates the local auth_request before contacting
-	// the upstream IdP. Use a real auth_request so we exercise the
-	// upstream-error sanitization path rather than the local-state guard.
-	arID, _ := store.CreateTestAuthRequest(ctx, "upstream-err")
-	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "test-agent")
-
-	if result.Action != ActionError {
-		t.Fatalf("action = %v, want ActionError", result.Action)
-	}
-	if result.Error != "upstream_error" {
-		t.Fatalf("error = %q, want upstream_error", result.Error)
 	}
 }
 
@@ -191,7 +174,7 @@ func TestBrowser007_RecoveryRetryIdempotent(t *testing.T) {
 
 	// First attempt: callback with bogus authRequestID is rejected before
 	// Exchange. Recovery does NOT happen.
-	result1 := fx.LoginSvc.HandleCallback(ctx, "fake-code", "invalid-ar-id", "127.0.0.1", "browser")
+	result1 := fx.LoginSvc.CompleteBrowserLogin(ctx, "invalid-ar-id", fx.FakeUser, "127.0.0.1", "browser")
 	if result1.Action != ActionError {
 		t.Fatalf("invalid authRequestID should be rejected, got %v", result1.Action)
 	}
@@ -203,7 +186,7 @@ func TestBrowser007_RecoveryRetryIdempotent(t *testing.T) {
 
 	// Second attempt: valid authRequestID — recovery + completion in one shot.
 	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "retry")
-	result2 := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "browser")
+	result2 := fx.LoginSvc.CompleteBrowserLogin(ctx, arID, fx.FakeUser, "127.0.0.1", "browser")
 	if result2.Action != ActionAutoApprove {
 		t.Errorf("retry action = %v, want AutoApprove", result2.Action)
 	}
@@ -214,7 +197,7 @@ func TestBrowser007_RecoveryRetryIdempotent(t *testing.T) {
 
 	// Third attempt: idempotent retry on a fresh authRequestID also succeeds.
 	arID2, _ := fx.Store.CreateTestAuthRequest(ctx, "retry-2")
-	result3 := fx.LoginSvc.HandleCallback(ctx, "fake-code", arID2, "127.0.0.1", "browser")
+	result3 := fx.LoginSvc.CompleteBrowserLogin(ctx, arID2, fx.FakeUser, "127.0.0.1", "browser")
 	if result3.Action != ActionAutoApprove {
 		t.Errorf("idempotent retry action = %v, want AutoApprove", result3.Action)
 	}

--- a/internal/service/login_unit_test.go
+++ b/internal/service/login_unit_test.go
@@ -89,7 +89,7 @@ func TestLogin_HandleLogin_RecoversPendingDeletionSession(t *testing.T) {
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "s1"}}
-	svc := NewLoginService(store, provider, 24*time.Hour)
+	svc := NewLoginService(store, provider.Name(), 24*time.Hour)
 
 	result := svc.HandleLogin(context.Background(), "ar-1", "sess-1", "127.0.0.1", "ua")
 
@@ -125,9 +125,9 @@ func TestLogin_HandleCallback_EmailConflict(t *testing.T) {
 			Name:          "Dup",
 		},
 	}
-	svc := NewLoginService(store, provider, 24*time.Hour)
+	svc := NewLoginService(store, provider.Name(), 24*time.Hour)
 
-	result := svc.HandleCallback(context.Background(), "code", "ar-1", "127.0.0.1", "ua")
+	result := svc.CompleteBrowserLogin(context.Background(), "ar-1", provider.User, "127.0.0.1", "ua")
 
 	if result.Action != ActionError {
 		t.Fatalf("action = %v, want %v", result.Action, ActionError)
@@ -159,9 +159,9 @@ func TestLogin_HandleCallback_ExistingUser_AuditLogIncludesSessionAndClient(t *t
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub-1"}}
-	svc := NewLoginService(store, provider, 24*time.Hour)
+	svc := NewLoginService(store, provider.Name(), 24*time.Hour)
 
-	result := svc.HandleCallback(context.Background(), "code", "ar-1", "127.0.0.1", "ua")
+	result := svc.CompleteBrowserLogin(context.Background(), "ar-1", provider.User, "127.0.0.1", "ua")
 
 	if result.Action != ActionAutoApprove {
 		t.Fatalf("action = %v, want %v", result.Action, ActionAutoApprove)
@@ -204,9 +204,9 @@ func TestLogin_HandleCallback_SignupAuditLogIncludesChannel(t *testing.T) {
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub-1"}}
-	svc := NewLoginService(store, provider, 24*time.Hour)
+	svc := NewLoginService(store, provider.Name(), 24*time.Hour)
 
-	result := svc.HandleCallback(context.Background(), "code", "ar-1", "127.0.0.1", "ua")
+	result := svc.CompleteBrowserLogin(context.Background(), "ar-1", provider.User, "127.0.0.1", "ua")
 
 	if result.Action != ActionAutoApprove {
 		t.Fatalf("action = %v, want %v", result.Action, ActionAutoApprove)
@@ -259,7 +259,7 @@ func TestLogin_HandleLogin_RejectsCrossChannelAuthRequest(t *testing.T) {
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "s1"}}
-	svc := NewLoginService(store, provider, 24*time.Hour)
+	svc := NewLoginService(store, provider.Name(), 24*time.Hour)
 
 	result := svc.HandleLogin(context.Background(), "ar-1", "sess-1", "127.0.0.1", "ua")
 
@@ -306,9 +306,9 @@ func TestMCPLogin_HandleCallback_AuditLogIncludesSessionAndClient(t *testing.T) 
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "sub-1"}}
-	svc := NewMCPLoginService(store, provider, 24*time.Hour)
+	svc := NewMCPLoginService(store, provider.Name(), 24*time.Hour)
 
-	result := svc.HandleCallback(context.Background(), "code", "ar-1", "127.0.0.1", "ua")
+	result := svc.CompleteMCPLogin(context.Background(), "ar-1", provider.User, "127.0.0.1", "ua")
 
 	if result.Action != ActionAutoApprove {
 		t.Fatalf("action = %v, want %v", result.Action, ActionAutoApprove)
@@ -328,7 +328,7 @@ func TestLogin_HandleLogin_NoSession_Redirect(t *testing.T) {
 		},
 	}
 	provider := &upstream.FakeProvider{ProviderName: "google", User: &upstream.UserInfo{Sub: "s1"}}
-	svc := NewLoginService(store, provider, 24*time.Hour)
+	svc := NewLoginService(store, provider.Name(), 24*time.Hour)
 
 	result := svc.HandleLogin(context.Background(), "ar-1", "sess-1", "127.0.0.1", "ua")
 

--- a/internal/service/mcp_login.go
+++ b/internal/service/mcp_login.go
@@ -13,16 +13,16 @@ import (
 
 // MCPLoginService owns MCP channel login/callback orchestration.
 type MCPLoginService struct {
-	store       LoginStore
-	mcpProvider upstream.Provider
-	sessionTTL  time.Duration
+	store        LoginStore
+	providerName string
+	sessionTTL   time.Duration
 }
 
-func NewMCPLoginService(store LoginStore, mcpProvider upstream.Provider, sessionTTL time.Duration) *MCPLoginService {
+func NewMCPLoginService(store LoginStore, providerName string, sessionTTL time.Duration) *MCPLoginService {
 	return &MCPLoginService{
-		store:       store,
-		mcpProvider: mcpProvider,
-		sessionTTL:  sessionTTL,
+		store:        store,
+		providerName: providerName,
+		sessionTTL:   sessionTTL,
 	}
 }
 
@@ -66,11 +66,16 @@ func (s *MCPLoginService) HandleLogin(ctx context.Context, authRequestID, sessio
 		}
 	}
 
-	return &LoginResult{Action: ActionRedirectToIdP, RedirectURL: s.mcpProvider.AuthURL(authRequestID)}
+	return &LoginResult{Action: ActionRedirectToIdP, AuthRequestID: authRequestID}
 }
 
-func (s *MCPLoginService) HandleCallback(ctx context.Context, code, authRequestID, ipAddress, userAgent string) *CallbackResult {
-	if code == "" || authRequestID == "" {
+// CompleteMCPLogin finishes the MCP callback after the upstream code exchange
+// has already happened inside the high-level CodeExchangeHandler (which
+// verified the state cookie / PKCE before exchange). state carries the
+// authRequestID; info is the resolved upstream identity.
+func (s *MCPLoginService) CompleteMCPLogin(ctx context.Context, state string, info *upstream.UserInfo, ipAddress, userAgent string) *CallbackResult {
+	authRequestID := state
+	if authRequestID == "" || info == nil {
 		return &CallbackResult{Action: ActionError, Error: "missing code or state", ErrorCode: http.StatusBadRequest}
 	}
 
@@ -97,12 +102,9 @@ func (s *MCPLoginService) HandleCallback(ctx context.Context, code, authRequestI
 		return &CallbackResult{Action: ActionError, Error: errMsg, ErrorCode: statusCode}
 	}
 
-	userInfo, err := s.mcpProvider.Exchange(ctx, code)
-	if err != nil {
-		return &CallbackResult{Action: ActionError, Error: "upstream_error", ErrorCode: http.StatusInternalServerError}
-	}
+	userInfo := info
 
-	providerName := s.mcpProvider.Name()
+	providerName := s.providerName
 	user, err := s.store.GetUserByProviderIdentity(ctx, providerName, userInfo.Sub)
 	if errors.Is(err, storage.ErrNotFound) {
 		return &CallbackResult{Action: ActionError, Error: "account_not_found", ErrorCode: http.StatusForbidden}

--- a/internal/service/mcp_test.go
+++ b/internal/service/mcp_test.go
@@ -17,7 +17,7 @@ import (
 // MCP uses dedicated login/callback paths and applies MCP channel policy.
 // These tests verify the MCP channel guard works correctly.
 
-func setupMCPTest(t *testing.T) (*MCPLoginService, *storage.Storage) {
+func setupMCPTest(t *testing.T) (*MCPLoginService, *storage.Storage, *upstream.UserInfo) {
 	t.Helper()
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
@@ -29,18 +29,18 @@ func setupMCPTest(t *testing.T) (*MCPLoginService, *storage.Storage) {
 		User: &upstream.UserInfo{Sub: "mcp-sub-123", Email: "mcp@test.com", EmailVerified: true, Name: "MCP User"},
 	}
 
-	svc := NewMCPLoginService(store, fakeProvider, 24*time.Hour)
-	return svc, store
+	svc := NewMCPLoginService(store, fakeProvider.Name(), 24*time.Hour)
+	return svc, store, fakeProvider.User
 }
 
 func TestMCP_CompleteUser_AutoApprove(t *testing.T) {
-	svc, store := setupMCPTest(t)
+	svc, store, fakeUser := setupMCPTest(t)
 	ctx := context.Background()
 
 	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-ok@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "mcp-sub-123", ProviderEmail: "mcp@test.com"})
 	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-ok", "http://localhost/mcp")
 
-	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
+	result := svc.CompleteMCPLogin(ctx, arID, fakeUser, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionAutoApprove {
 		t.Errorf("action = %v, want AutoApprove (MCP active user)", result.Action)
@@ -48,11 +48,11 @@ func TestMCP_CompleteUser_AutoApprove(t *testing.T) {
 }
 
 func TestMCP_NewUser_SignupRequired(t *testing.T) {
-	svc, store := setupMCPTest(t)
+	svc, store, fakeUser := setupMCPTest(t)
 	ctx := context.Background()
 
 	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-new", "http://localhost/mcp")
-	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
+	result := svc.CompleteMCPLogin(ctx, arID, fakeUser, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error (MCP new user)", result.Action)
@@ -63,14 +63,14 @@ func TestMCP_NewUser_SignupRequired(t *testing.T) {
 }
 
 func TestMCP_DisabledUser_Rejected(t *testing.T) {
-	svc, store := setupMCPTest(t)
+	svc, store, fakeUser := setupMCPTest(t)
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-dis@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "mcp-sub-123", ProviderEmail: "mcp@test.com"})
 	store.DisableUser(ctx, user.ID)
 
 	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-dis", "http://localhost/mcp")
-	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
+	result := svc.CompleteMCPLogin(ctx, arID, fakeUser, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error (disabled user)", result.Action)
@@ -82,14 +82,14 @@ func TestMCP_DisabledUser_Rejected(t *testing.T) {
 
 // mcp-005: recoverable_browser_only → MCP callback → account_inactive
 func TestMCP005_Recoverable_Rejected(t *testing.T) {
-	svc, store := setupMCPExtTest(t, "mcp-005-sub")
+	svc, store, fakeUser := setupMCPExtTest(t, "mcp-005-sub")
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-recover@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "mcp-005-sub", ProviderEmail: "mrc@test.com"})
 	store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-005", "http://localhost/mcp")
-	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
+	result := svc.CompleteMCPLogin(ctx, arID, fakeUser, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error (recoverable via MCP)", result.Action)
@@ -101,7 +101,7 @@ func TestMCP005_Recoverable_Rejected(t *testing.T) {
 
 // channel-005: pending_deletion + mcp(login with session) -> account_inactive
 func TestMCPLogin_PendingDeletionSession_Rejected(t *testing.T) {
-	svc, store := setupMCPTest(t)
+	svc, store, _ := setupMCPTest(t)
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-login-pending@test.com", EmailVerified: true, Name: "MCP Pending", Provider: "google", ProviderUserID: "mcp-login-pending-sub", ProviderEmail: "mcp-login-pending@test.com"})
@@ -126,7 +126,7 @@ func TestMCPLogin_PendingDeletionSession_Rejected(t *testing.T) {
 
 // channel-005: deleted + mcp(login with session) -> account_inactive
 func TestMCPLogin_DeletedSession_Rejected(t *testing.T) {
-	svc, store := setupMCPTest(t)
+	svc, store, _ := setupMCPTest(t)
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-login-deleted@test.com", EmailVerified: true, Name: "MCP Deleted", Provider: "google", ProviderUserID: "mcp-login-deleted-sub", ProviderEmail: "mcp-login-deleted@test.com"})
@@ -149,32 +149,16 @@ func TestMCPLogin_DeletedSession_Rejected(t *testing.T) {
 	}
 }
 
-func TestMCPCallback_UpstreamError_Sanitized(t *testing.T) {
-	svc, store := setupMCPTest(t)
-	ctx := context.Background()
-	svc.mcpProvider = &upstream.FakeProvider{ProviderName: "google"}
-
-	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "upstream-err", "http://localhost/mcp")
-	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
-
-	if result.Action != ActionError {
-		t.Fatalf("action = %v, want ActionError", result.Action)
-	}
-	if result.Error != "upstream_error" {
-		t.Fatalf("error = %q, want upstream_error", result.Error)
-	}
-}
-
 // mcp-004: deleted user callback -> account_inactive
 func TestMCP_DeletedUser_Rejected(t *testing.T) {
-	svc, store := setupMCPExtTest(t, "mcp-deleted-sub")
+	svc, store, fakeUser := setupMCPExtTest(t, "mcp-deleted-sub")
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-deleted@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "mcp-deleted-sub", ProviderEmail: "mcp-deleted@test.com"})
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
 	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-deleted", "http://localhost/mcp")
 
-	result := svc.HandleCallback(ctx, "fake-code", arID, "127.0.0.1", "mcp-client")
+	result := svc.CompleteMCPLogin(ctx, arID, fakeUser, "127.0.0.1", "mcp-client")
 
 	if result.Action != ActionError {
 		t.Errorf("action = %v, want Error (deleted user)", result.Action)

--- a/internal/service/testhelpers_test.go
+++ b/internal/service/testhelpers_test.go
@@ -22,22 +22,26 @@ type gapFixture struct {
 	Store       *storage.Storage
 	DB          *sql.DB
 	Clock       *clock.FixedClock
+	// FakeUser is the upstream identity the high-level provider would deliver to
+	// the Complete* callbacks; tests pass it directly now that the service layer
+	// no longer performs the upstream exchange itself.
+	FakeUser *upstream.UserInfo
 }
 
 // setupBrowserExtTest creates a LoginService with a fixed sub for browser extended tests.
-func setupBrowserExtTest(t *testing.T) (*LoginService, *storage.Storage) {
+func setupBrowserExtTest(t *testing.T) (*LoginService, *storage.Storage, *upstream.UserInfo) {
 	t.Helper()
 	return setupLoginServiceWithSub(t, "browser-ext-sub", "browser-ext@test.com")
 }
 
 // setupMCPExtTest creates an MCPLoginService with a configurable sub for MCP tests.
-func setupMCPExtTest(t *testing.T, sub string) (*MCPLoginService, *storage.Storage) {
+func setupMCPExtTest(t *testing.T, sub string) (*MCPLoginService, *storage.Storage, *upstream.UserInfo) {
 	t.Helper()
 	return setupMCPLoginServiceWithSub(t, sub, sub+"@test.com")
 }
 
 // setupDeviceExtTest creates a DeviceService with a configurable sub.
-func setupDeviceExtTest(t *testing.T, sub string) (*DeviceService, *storage.Storage, clock.Clock) {
+func setupDeviceExtTest(t *testing.T, sub string) (*DeviceService, *storage.Storage, clock.Clock, *upstream.UserInfo) {
 	t.Helper()
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
@@ -47,8 +51,8 @@ func setupDeviceExtTest(t *testing.T, sub string) (*DeviceService, *storage.Stor
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: sub, Email: sub + "@test.com", EmailVerified: true, Name: "Device Ext"},
 	}
-	svc := NewDeviceService(store, fakeProvider, "http://localhost:8080", 24*time.Hour, clk)
-	return svc, store, clk
+	svc := NewDeviceService(store, fakeProvider.Name(), "http://localhost:8080", 24*time.Hour, clk)
+	return svc, store, clk, fakeProvider.User
 }
 
 // setupAccountExtTest creates an AccountService for account extended tests.
@@ -74,9 +78,9 @@ func setupGapTest(t *testing.T) *gapFixture {
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: "gap-sub", Email: "gap@test.com", EmailVerified: true, Name: "Gap User"},
 	}
-	loginSvc := NewLoginService(store, fakeProvider, 24*time.Hour)
-	mcpLoginSvc := NewMCPLoginService(store, fakeProvider, 24*time.Hour)
-	deviceSvc := NewDeviceService(store, fakeProvider, "http://localhost:8080", 24*time.Hour, clk)
+	loginSvc := NewLoginService(store, fakeProvider.Name(), 24*time.Hour)
+	mcpLoginSvc := NewMCPLoginService(store, fakeProvider.Name(), 24*time.Hour)
+	deviceSvc := NewDeviceService(store, fakeProvider.Name(), "http://localhost:8080", 24*time.Hour, clk)
 	accountSvc := NewAccountService(store)
 	return &gapFixture{
 		LoginSvc:    loginSvc,
@@ -86,11 +90,12 @@ func setupGapTest(t *testing.T) *gapFixture {
 		Store:       store,
 		DB:          db,
 		Clock:       clk,
+		FakeUser:    fakeProvider.User,
 	}
 }
 
 // setupLoginServiceWithSub creates a LoginService with a specific upstream sub/email.
-func setupLoginServiceWithSub(t *testing.T, sub, email string) (*LoginService, *storage.Storage) {
+func setupLoginServiceWithSub(t *testing.T, sub, email string) (*LoginService, *storage.Storage, *upstream.UserInfo) {
 	t.Helper()
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
@@ -100,12 +105,12 @@ func setupLoginServiceWithSub(t *testing.T, sub, email string) (*LoginService, *
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: sub, Email: email, EmailVerified: true, Name: "Test User"},
 	}
-	svc := NewLoginService(store, fakeProvider, 24*time.Hour)
-	return svc, store
+	svc := NewLoginService(store, fakeProvider.Name(), 24*time.Hour)
+	return svc, store, fakeProvider.User
 }
 
 // setupMCPLoginServiceWithSub creates an MCPLoginService with a specific upstream sub/email.
-func setupMCPLoginServiceWithSub(t *testing.T, sub, email string) (*MCPLoginService, *storage.Storage) {
+func setupMCPLoginServiceWithSub(t *testing.T, sub, email string) (*MCPLoginService, *storage.Storage, *upstream.UserInfo) {
 	t.Helper()
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
@@ -115,6 +120,6 @@ func setupMCPLoginServiceWithSub(t *testing.T, sub, email string) (*MCPLoginServ
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: sub, Email: email, EmailVerified: true, Name: "Test User"},
 	}
-	svc := NewMCPLoginService(store, fakeProvider, 24*time.Hour)
-	return svc, store
+	svc := NewMCPLoginService(store, fakeProvider.Name(), 24*time.Hour)
+	return svc, store, fakeProvider.User
 }

--- a/internal/upstream/mock.go
+++ b/internal/upstream/mock.go
@@ -1,11 +1,11 @@
 package upstream
 
-import (
-	"context"
-	"fmt"
-)
+import "net/http"
 
 // FakeProvider returns a hardcoded user without any HTTP calls. For unit tests only.
+//
+// It simulates an already-trusted exchange (no state-cookie or PKCE
+// enforcement) so existing integration/unit tests keep working.
 type FakeProvider struct {
 	User         *UserInfo
 	ProviderName string // defaults to "fake" if empty
@@ -18,13 +18,15 @@ func (f *FakeProvider) Name() string {
 	return "fake"
 }
 
-func (f *FakeProvider) AuthURL(state string) string {
-	return "/fake-auth?state=" + state
+func (f *FakeProvider) Redirect(w http.ResponseWriter, r *http.Request, state string) {
+	http.Redirect(w, r, "/fake-auth?state="+state, http.StatusFound)
 }
 
-func (f *FakeProvider) Exchange(_ context.Context, _ string) (*UserInfo, error) {
+func (f *FakeProvider) Callback(w http.ResponseWriter, r *http.Request, onSuccess func(w http.ResponseWriter, r *http.Request, state string, info *UserInfo)) {
 	if f.User == nil {
-		return nil, fmt.Errorf("fake provider: no user configured")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
-	return f.User, nil
+	state := r.URL.Query().Get("state")
+	onSuccess(w, r, state, f.User)
 }

--- a/internal/upstream/oidc.go
+++ b/internal/upstream/oidc.go
@@ -2,6 +2,7 @@ package upstream
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
+	httphelper "github.com/zitadel/oidc/v3/pkg/http"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
 
@@ -22,9 +24,12 @@ type OIDCProvider struct {
 type Option func(*options)
 
 type options struct {
-	rpOpts      []rp.Option
-	internalURL string
-	httpTimeout time.Duration
+	rpOpts       []rp.Option
+	internalURL  string
+	httpTimeout  time.Duration
+	cookieSecret string
+	cookieSecure bool
+	cookieSet    bool
 }
 
 // WithRPOptions passes options to the underlying rp.NewRelyingPartyOIDC.
@@ -42,6 +47,17 @@ func WithInternalURL(internalURL string) Option {
 // WithHTTPTimeout sets outbound HTTP timeout for OIDC discovery/token/userinfo calls.
 func WithHTTPTimeout(timeout time.Duration) Option {
 	return func(o *options) { o.httpTimeout = timeout }
+}
+
+// WithCookieSecret enables the high-level state/PKCE cookie protection. The
+// secret seeds the cookie handler's hash and encryption keys (via SHA-256 with
+// domain separation). secure=false allows the cookie over plain HTTP (dev mode).
+func WithCookieSecret(secret string, secure bool) Option {
+	return func(o *options) {
+		o.cookieSecret = secret
+		o.cookieSecure = secure
+		o.cookieSet = true
+	}
 }
 
 // NewOIDCProvider creates a provider by performing OIDC Discovery on the issuer URL.
@@ -74,6 +90,25 @@ func NewOIDCProvider(ctx context.Context, issuerURL, clientID, clientSecret, red
 		o.rpOpts = append(o.rpOpts, rp.WithHTTPClient(client))
 	}
 
+	if o.cookieSet {
+		hashKey := sha256.Sum256([]byte("authgate.upstream.cookie.hash:" + o.cookieSecret))
+		encryptKey := sha256.Sum256([]byte("authgate.upstream.cookie.enc:" + o.cookieSecret))
+		chOpts := []httphelper.CookieHandlerOpt{httphelper.WithMaxAge(600)}
+		if !o.cookieSecure {
+			chOpts = append(chOpts, httphelper.WithUnsecure())
+		}
+		ch := httphelper.NewCookieHandler(hashKey[:], encryptKey[:], chOpts...)
+		o.rpOpts = append(o.rpOpts, rp.WithPKCE(ch))
+	}
+
+	// Sanitize the high-level handler's failure responses (invalid/missing
+	// state cookie, PKCE mismatch, code-exchange error). The library default
+	// echoes the internal error string back to the client; replace it with a
+	// generic message so upstream OAuth error detail is not disclosed.
+	o.rpOpts = append(o.rpOpts, rp.WithUnauthorizedHandler(func(w http.ResponseWriter, _ *http.Request, _ string, _ string) {
+		http.Error(w, "authentication failed", http.StatusUnauthorized)
+	}))
+
 	scopes := []string{"openid", "email", "profile"}
 	relyingParty, err := rp.NewRelyingPartyOIDC(ctx, issuerURL, clientID, clientSecret, redirectURI, scopes, o.rpOpts...)
 	if err != nil {
@@ -88,27 +123,32 @@ func NewOIDCProvider(ctx context.Context, issuerURL, clientID, clientSecret, red
 
 func (p *OIDCProvider) Name() string { return p.name }
 
-func (p *OIDCProvider) AuthURL(state string) string {
-	return rp.AuthURL(state, p.rp)
+// Redirect sends the user to the upstream IdP, binding state to a CSRF cookie
+// and (when PKCE is configured) a PKCE challenge cookie via the high-level
+// AuthURLHandler.
+func (p *OIDCProvider) Redirect(w http.ResponseWriter, r *http.Request, state string) {
+	rp.AuthURLHandler(func() string { return state }, p.rp).ServeHTTP(w, r)
 }
 
-func (p *OIDCProvider) Exchange(ctx context.Context, code string) (*UserInfo, error) {
-	tokens, err := rp.CodeExchange[*oidc.IDTokenClaims](ctx, code, p.rp)
-	if err != nil {
-		return nil, fmt.Errorf("code exchange: %w", err)
-	}
+// Callback verifies the state cookie + PKCE, exchanges the code, fetches
+// userinfo, and invokes onSuccess. On failure CodeExchangeHandler writes its
+// own error response and onSuccess is not called.
+func (p *OIDCProvider) Callback(w http.ResponseWriter, r *http.Request, onSuccess func(w http.ResponseWriter, r *http.Request, state string, info *UserInfo)) {
+	cb := rp.UserinfoCallback[*oidc.IDTokenClaims, *oidc.UserInfo](
+		func(w http.ResponseWriter, r *http.Request, tokens *oidc.Tokens[*oidc.IDTokenClaims], state string, _ rp.RelyingParty, info *oidc.UserInfo) {
+			onSuccess(w, r, state, mapUserInfo(info))
+		},
+	)
+	rp.CodeExchangeHandler[*oidc.IDTokenClaims](cb, p.rp).ServeHTTP(w, r)
+}
 
-	info, err := rp.Userinfo[*oidc.UserInfo](ctx, tokens.AccessToken, tokens.TokenType, tokens.IDTokenClaims.GetSubject(), p.rp)
-	if err != nil {
-		return nil, fmt.Errorf("userinfo: %w", err)
-	}
-
+func mapUserInfo(info *oidc.UserInfo) *UserInfo {
 	return &UserInfo{
 		Sub:           info.Subject,
 		Email:         info.Email,
 		EmailVerified: bool(info.EmailVerified),
 		Name:          info.Name,
-	}, nil
+	}
 }
 
 // hostRewriteTransport rewrites the host of outgoing HTTP requests.

--- a/internal/upstream/oidc_test.go
+++ b/internal/upstream/oidc_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -139,11 +140,62 @@ func newFakeIdP(t *testing.T) *fakeIdP {
 
 func (idp *fakeIdP) newProvider(t *testing.T) *OIDCProvider {
 	t.Helper()
-	p, err := NewOIDCProvider(context.Background(), idp.srv.URL, testClientID, testClientSecret, testRedirectURI)
+	p, err := NewOIDCProvider(context.Background(), idp.srv.URL, testClientID, testClientSecret, testRedirectURI,
+		WithCookieSecret("test-cookie-secret", false))
 	if err != nil {
 		t.Fatalf("NewOIDCProvider: %v", err)
 	}
 	return p
+}
+
+// authURLForTest drives p.Redirect and returns the upstream authorization URL
+// the high-level handler redirected to (the value of the Location header).
+func authURLForTest(t *testing.T, p *OIDCProvider, state string) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	p.Redirect(rec, req, state)
+	loc := rec.Result().Header.Get("Location")
+	if loc == "" {
+		t.Fatalf("Redirect did not set Location header (status %d)", rec.Code)
+	}
+	return loc
+}
+
+// exchangeForTest drives the full Redirect→Callback round-trip against the fake
+// IdP, replaying the state/PKCE cookies the redirect set, and returns the
+// UserInfo delivered to the onSuccess callback (or an error if onSuccess was
+// never invoked, mirroring the old Exchange error contract).
+func exchangeForTest(t *testing.T, p *OIDCProvider, code string) (*UserInfo, error) {
+	t.Helper()
+
+	// First leg: Redirect to capture the state + PKCE cookies.
+	redirectRec := httptest.NewRecorder()
+	redirectReq := httptest.NewRequest(http.MethodGet, "/login", nil)
+	p.Redirect(redirectRec, redirectReq, "test-state")
+
+	loc := redirectRec.Result().Header.Get("Location")
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse redirect location: %v", err)
+	}
+	state := u.Query().Get("state")
+
+	// Second leg: Callback with the captured cookies + the IdP-issued code/state.
+	cbReq := httptest.NewRequest(http.MethodGet, "/login/callback?code="+code+"&state="+state, nil)
+	for _, c := range redirectRec.Result().Cookies() {
+		cbReq.AddCookie(c)
+	}
+	cbRec := httptest.NewRecorder()
+
+	var got *UserInfo
+	p.Callback(cbRec, cbReq, func(_ http.ResponseWriter, _ *http.Request, _ string, info *UserInfo) {
+		got = info
+	})
+	if got == nil {
+		return nil, fmt.Errorf("callback did not succeed (status %d)", cbRec.Code)
+	}
+	return got, nil
 }
 
 // ── oidc-name-001~003: deriveProviderName ────────────────────────────────────
@@ -176,15 +228,16 @@ func TestDeriveProviderName_InvalidURL(t *testing.T) {
 
 func TestOIDCProvider_Discovery_Success(t *testing.T) {
 	idp := newFakeIdP(t)
-	p, err := NewOIDCProvider(context.Background(), idp.srv.URL, testClientID, testClientSecret, testRedirectURI)
+	p, err := NewOIDCProvider(context.Background(), idp.srv.URL, testClientID, testClientSecret, testRedirectURI,
+		WithCookieSecret("test-cookie-secret", false))
 	if err != nil {
 		t.Fatalf("NewOIDCProvider: %v", err)
 	}
 	if p.Name() == "" {
 		t.Error("Name() is empty after successful Discovery")
 	}
-	if p.AuthURL("state-001") == "" {
-		t.Error("AuthURL() is empty after successful Discovery")
+	if authURLForTest(t, p, "state-001") == "" {
+		t.Error("Redirect produced empty auth URL after successful Discovery")
 	}
 }
 
@@ -216,7 +269,7 @@ func TestOIDCProvider_Discovery_Non200(t *testing.T) {
 func TestOIDCProvider_AuthURL_ContainsRequiredParams(t *testing.T) {
 	idp := newFakeIdP(t)
 	p := idp.newProvider(t)
-	u := p.AuthURL("req-state-123")
+	u := authURLForTest(t, p, "req-state-123")
 	for _, param := range []string{"client_id", "redirect_uri", "response_type", "state"} {
 		if !strings.Contains(u, param) {
 			t.Errorf("AuthURL missing param %q: %s", param, u)
@@ -229,7 +282,7 @@ func TestOIDCProvider_AuthURL_ContainsRequiredParams(t *testing.T) {
 func TestOIDCProvider_Exchange_Success(t *testing.T) {
 	idp := newFakeIdP(t)
 	p := idp.newProvider(t)
-	info, err := p.Exchange(context.Background(), "fake-code")
+	info, err := exchangeForTest(t, p, "fake-code")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -250,7 +303,7 @@ func TestOIDCProvider_Exchange_TokenEndpointError(t *testing.T) {
 	idp := newFakeIdP(t)
 	idp.tokenStatus = http.StatusUnauthorized
 	p := idp.newProvider(t)
-	_, err := p.Exchange(context.Background(), "any-code")
+	_, err := exchangeForTest(t, p, "any-code")
 	if err == nil {
 		t.Error("expected error for token endpoint 401, got nil")
 	}
@@ -262,7 +315,7 @@ func TestOIDCProvider_Exchange_UserInfoError(t *testing.T) {
 	idp := newFakeIdP(t)
 	idp.userinfoStatus = http.StatusUnauthorized
 	p := idp.newProvider(t)
-	_, err := p.Exchange(context.Background(), "fake-code")
+	_, err := exchangeForTest(t, p, "fake-code")
 	if err == nil {
 		t.Error("expected error for userinfo endpoint 401, got nil")
 	}
@@ -279,7 +332,7 @@ func TestOIDCProvider_UserInfoMapping_AllFields(t *testing.T) {
 		"name":           "Map User",
 	}
 	p := idp.newProvider(t)
-	info, err := p.Exchange(context.Background(), "fake-code")
+	info, err := exchangeForTest(t, p, "fake-code")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -305,7 +358,7 @@ func TestOIDCProvider_EmailVerified_True(t *testing.T) {
 	idp := newFakeIdP(t)
 	idp.userInfoResp["email_verified"] = true
 	p := idp.newProvider(t)
-	info, err := p.Exchange(context.Background(), "fake-code")
+	info, err := exchangeForTest(t, p, "fake-code")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -320,7 +373,7 @@ func TestOIDCProvider_EmailVerified_False(t *testing.T) {
 	idp := newFakeIdP(t)
 	idp.userInfoResp["email_verified"] = false
 	p := idp.newProvider(t)
-	info, err := p.Exchange(context.Background(), "fake-code")
+	info, err := exchangeForTest(t, p, "fake-code")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -335,7 +388,7 @@ func TestOIDCProvider_EmailVerified_Absent(t *testing.T) {
 	idp := newFakeIdP(t)
 	delete(idp.userInfoResp, "email_verified")
 	p := idp.newProvider(t)
-	info, err := p.Exchange(context.Background(), "fake-code")
+	info, err := exchangeForTest(t, p, "fake-code")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -349,17 +402,18 @@ func TestOIDCProvider_EmailVerified_Absent(t *testing.T) {
 func TestOIDCProvider_FullPath(t *testing.T) {
 	idp := newFakeIdP(t)
 
-	p, err := NewOIDCProvider(context.Background(), idp.srv.URL, testClientID, testClientSecret, testRedirectURI)
+	p, err := NewOIDCProvider(context.Background(), idp.srv.URL, testClientID, testClientSecret, testRedirectURI,
+		WithCookieSecret("test-cookie-secret", false))
 	if err != nil {
 		t.Fatalf("Discovery: %v", err)
 	}
 
-	authURL := p.AuthURL("full-path-state")
+	authURL := authURLForTest(t, p, "full-path-state")
 	if !strings.Contains(authURL, "full-path-state") {
 		t.Errorf("AuthURL does not contain state: %s", authURL)
 	}
 
-	info, err := p.Exchange(context.Background(), "full-path-code")
+	info, err := exchangeForTest(t, p, "full-path-code")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -382,12 +436,13 @@ func TestOIDCProvider_MultiRedirectURIs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := NewOIDCProvider(context.Background(), idp.srv.URL, testClientID, testClientSecret, tt.redirectURI)
+			p, err := NewOIDCProvider(context.Background(), idp.srv.URL, testClientID, testClientSecret, tt.redirectURI,
+				WithCookieSecret("test-cookie-secret", false))
 			if err != nil {
 				t.Fatalf("NewOIDCProvider: %v", err)
 			}
 
-			authURL := p.AuthURL("state-" + tt.name)
+			authURL := authURLForTest(t, p, "state-"+tt.name)
 			u, err := url.Parse(authURL)
 			if err != nil {
 				t.Fatalf("parse authURL: %v", err)

--- a/internal/upstream/provider.go
+++ b/internal/upstream/provider.go
@@ -1,6 +1,6 @@
 package upstream
 
-import "context"
+import "net/http"
 
 // UserInfo holds identity data returned from the upstream IdP.
 type UserInfo struct {
@@ -11,13 +11,23 @@ type UserInfo struct {
 }
 
 // Provider abstracts the upstream OIDC IdP.
+//
+// Redirect and Callback own the (w, r) pair so the underlying library's
+// high-level handlers can manage the state cookie (CSRF) and PKCE challenge
+// cookie. The service layer stays HTTP-agnostic and receives the already
+// exchanged *UserInfo via the onSuccess callback.
 type Provider interface {
 	// Name returns the provider identifier stored in user_identities.provider.
 	Name() string
 
-	// AuthURL returns the URL to redirect the user to for authentication.
-	AuthURL(state string) string
+	// Redirect sends the user to the upstream IdP authorization endpoint,
+	// binding the given state value to a CSRF cookie (and PKCE challenge cookie
+	// when enabled).
+	Redirect(w http.ResponseWriter, r *http.Request, state string)
 
-	// Exchange trades an authorization code for user info.
-	Exchange(ctx context.Context, code string) (*UserInfo, error)
+	// Callback verifies the state cookie + PKCE, exchanges the authorization
+	// code, fetches userinfo, and invokes onSuccess with the resolved state and
+	// user identity. On verification or exchange failure it writes its own
+	// error response and does not call onSuccess.
+	Callback(w http.ResponseWriter, r *http.Request, onSuccess func(w http.ResponseWriter, r *http.Request, state string, info *UserInfo))
 }


### PR DESCRIPTION
## Summary
Fixes a **HIGH** login-CSRF / authorization-code-injection vulnerability on the upstream IdP leg.

The RP leg called zitadel's low-level `rp.AuthURL`/`rp.CodeExchange`, bypassing the library's state-cookie CSRF protection and PKCE. The OIDC `state` was only an unbound lookup key (authRequestID), so an attacker could inject their own authorization code into a victim's browser callback and land the victim in the **attacker's account** (session swap). All three channels (browser / device / mcp) shared the flaw.

## Fix
- Switch to high-level `rp.AuthURLHandler` + `rp.CodeExchangeHandler` with a `httphelper.CookieHandler` via `rp.WithPKCE(ch)` — binds `state` to an encrypted, browser-scoped cookie verified on callback, and adds upstream **PKCE (S256)**.
- Custom `UnauthorizedHandler` sanitizes failure responses (no internal error-string disclosure; replaces the old `upstream_error` path).
- Provider now exposes `Redirect`/`Callback` (HTTP-coupled), called from the handler layer; services stay HTTP-agnostic and receive the resolved `UserInfo`.
- **Same library, no new deps, no go.mod change.**

## Scope / follow-up
- Implemented: state-cookie binding + upstream PKCE (closes the HIGH).
- Deferred: id_token **nonce** verification — tracked as **GAP-SEC-001** in `docs/security/001-audit-evidence-matrix.md`.

## Docs
- `docs/spec/002-browser-login.md`: corrected the now-accurate state-cookie CSRF claim + upstream error rows (401 generic).
- `docs/security/001-audit-evidence-matrix.md`: added control **SOC2-CC6-003** (login-CSRF defense) + **GAP-SEC-001** (nonce).

## Test plan
- [x] `gofmt -l` clean
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`
- [x] `go test ./...` (unit, all ok)
- [ ] integration tests (`-tags=integration`, Docker) — CI. Note: integration harness uses `FakeProvider` (no cookie enforcement), so real state-cookie/PKCE behavior is covered by `internal/upstream/oidc_test.go`, not the integration flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)