### PR TITLE
fix(upstream): verify id_token nonce on IdP login

### DIFF
--- a/docs/security/001-audit-evidence-matrix.md
+++ b/docs/security/001-audit-evidence-matrix.md
@@ -83,7 +83,7 @@ audit_log
 | KR-COMM-001 | IP/UA 등 접속 메타데이터를 추적할 수 있는가 | `audit_log.ip_address`, `audit_log.user_agent` | `internal/storage/audit.go`, `internal/clientinfo/*` | `internal/clientinfo/clientinfo_test.go` | DONE |
 | SOC2-CC7-001 | 보안 이상징후를 탐지할 이벤트가 있는가 | inactive user access, refresh reuse detection, channel mismatch | `internal/service/*`, `internal/storage/storage_auth_tokens.go` | `internal/service/audit_test.go`, `internal/service/login_unit_test.go` | DONE |
 | SOC2-CC7-002 | abuse 방어가 있는가 | per-IP rate limit for auth/token/callback endpoints, CIMD failure rate limit | `internal/app/routes.go`, `internal/middleware/ratelimit.go`, `internal/adapter/mcp/cimd.go` | `internal/integration/integration_ratelimit_test.go`, `internal/adapter/mcp/*ratelimit*_test.go` | DONE |
-| SOC2-CC6-003 | 상위 IdP 로그인 CSRF/인가코드 인젝션을 방어하는가 | 상위 IdP 콜백에 암호화 state 쿠키 바인딩 + PKCE(S256) (browser/device/mcp 3채널) | `internal/upstream/oidc.go` (`rp.AuthURLHandler`/`CodeExchangeHandler`/`WithPKCE`) | `internal/upstream/oidc_test.go` | DONE |
+| SOC2-CC6-003 | 상위 IdP 로그인 CSRF/인가코드 인젝션/id_token 재생을 방어하는가 | 상위 IdP 콜백에 암호화 state 쿠키 바인딩 + PKCE(S256) + 요청별 nonce 검증 (browser/device/mcp 3채널) | `internal/upstream/oidc.go` (`rp.AuthURLHandler`/`CodeExchangeHandler`/`WithPKCE`/`WithNonce`) | `internal/upstream/oidc_test.go` | DONE |
 | SOC2-CC8-001 | 변경관리 evidence를 확보할 수 있는가 | GitHub PR, CI checks, vulnerability check | GitHub repository / Actions | PR checks | DONE |
 | SOC2-CC8-002 | dependency vulnerability evidence가 있는가 | `govulncheck` local/CI 실행 | GitHub Actions, PR body | CI `Vulnerability Check` | DONE |
 
@@ -129,7 +129,6 @@ audit_log
 | GAP | 설명 | 다음 작업 후보 |
 |-----|------|----------------|
 | GAP-OPS-001 | SOC 2 운영 evidence(PR 리뷰, access review, backup restore test)는 GitHub/운영 시스템에 존재해야 하며 authgate DB에는 저장하지 않는다. | 운영 evidence export/checklist 문서 |
-| GAP-SEC-001 | 상위 IdP id_token의 `nonce` 검증 미적용. state 쿠키 + PKCE로 로그인 CSRF는 차단했으나 id_token 재생 바인딩은 별도. | `rp.WithVerifierOpts(rp.WithNonce(...))` + 요청별 nonce 저장 후속 PR |
 
 ## 완료 기준
 

--- a/docs/spec/002-browser-login.md
+++ b/docs/spec/002-browser-login.md
@@ -193,7 +193,8 @@ RecoverUser 자체는 원자적이다 (단일 UPDATE).
 
 - 모든 `/authorize` 요청에서 PKCE S256 필수 (plain 불허, code_challenge 누락 불허)
 - 상위 IdP 로그인 CSRF 방어: `state`(authRequestID)를 암호화된 state 쿠키에 바인딩하고 콜백에서 대조 (`rp.AuthURLHandler` / `rp.CodeExchangeHandler`). 콜백을 시작한 브라우저만 완료 가능 → 인가코드 인젝션/세션 스왑 차단
-- 상위 IdP 교환에 PKCE(S256) 적용 (`rp.WithPKCE`). nonce 검증은 후속 작업 (아래 GAP 참조)
+- 상위 IdP 교환에 PKCE(S256) 적용 (`rp.WithPKCE`)
+- 상위 IdP id_token `nonce` 검증: 로그인 시작 시 요청별 nonce를 생성해 nonce 쿠키 + authorize 파라미터로 보내고, 콜백에서 id_token의 nonce와 대조 (`rp.WithNonce`) → id_token 재생/주입 차단
 - confidential 클라이언트: client_secret bcrypt 검증
 - public 클라이언트: client_secret 없음, PKCE가 유일한 보호
 - 세션 쿠키: `HttpOnly`, `SameSite=Strict`, `Secure=!DevMode`

--- a/internal/upstream/oidc.go
+++ b/internal/upstream/oidc.go
@@ -2,7 +2,9 @@ package upstream
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -14,10 +16,17 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
 
+// nonceCtxKey carries the expected id_token nonce from the callback request
+// into the RP's nonce verifier (registered via WithVerifierOpts/WithNonce).
+type nonceCtxKey struct{}
+
 // OIDCProvider uses zitadel/oidc RelyingParty for OIDC Discovery, token exchange, and userinfo.
 type OIDCProvider struct {
 	name string
 	rp   rp.RelyingParty
+	// ch is the cookie handler used for the state/PKCE cookies and the
+	// per-login nonce cookie. nil when no cookie secret was configured.
+	ch *httphelper.CookieHandler
 }
 
 // Option configures OIDCProvider construction.
@@ -90,6 +99,7 @@ func NewOIDCProvider(ctx context.Context, issuerURL, clientID, clientSecret, red
 		o.rpOpts = append(o.rpOpts, rp.WithHTTPClient(client))
 	}
 
+	var ch *httphelper.CookieHandler
 	if o.cookieSet {
 		hashKey := sha256.Sum256([]byte("authgate.upstream.cookie.hash:" + o.cookieSecret))
 		encryptKey := sha256.Sum256([]byte("authgate.upstream.cookie.enc:" + o.cookieSecret))
@@ -97,8 +107,15 @@ func NewOIDCProvider(ctx context.Context, issuerURL, clientID, clientSecret, red
 		if !o.cookieSecure {
 			chOpts = append(chOpts, httphelper.WithUnsecure())
 		}
-		ch := httphelper.NewCookieHandler(hashKey[:], encryptKey[:], chOpts...)
+		ch = httphelper.NewCookieHandler(hashKey[:], encryptKey[:], chOpts...)
 		o.rpOpts = append(o.rpOpts, rp.WithPKCE(ch))
+		// Verify the id_token nonce against the per-login value stashed in the
+		// request context by Callback (read from the nonce cookie). Binds the
+		// id_token to this specific login request (replay/injection defense).
+		o.rpOpts = append(o.rpOpts, rp.WithVerifierOpts(rp.WithNonce(func(ctx context.Context) string {
+			n, _ := ctx.Value(nonceCtxKey{}).(string)
+			return n
+		})))
 	}
 
 	// Sanitize the high-level handler's failure responses (invalid/missing
@@ -118,28 +135,54 @@ func NewOIDCProvider(ctx context.Context, issuerURL, clientID, clientSecret, red
 	return &OIDCProvider{
 		name: deriveProviderName(relyingParty.Issuer()),
 		rp:   relyingParty,
+		ch:   ch,
 	}, nil
 }
 
 func (p *OIDCProvider) Name() string { return p.name }
 
-// Redirect sends the user to the upstream IdP, binding state to a CSRF cookie
-// and (when PKCE is configured) a PKCE challenge cookie via the high-level
-// AuthURLHandler.
+// Redirect sends the user to the upstream IdP, binding state to a CSRF cookie,
+// a PKCE challenge cookie, and a per-login nonce cookie (its value is also sent
+// as the OIDC `nonce` parameter) via the high-level AuthURLHandler.
 func (p *OIDCProvider) Redirect(w http.ResponseWriter, r *http.Request, state string) {
-	rp.AuthURLHandler(func() string { return state }, p.rp).ServeHTTP(w, r)
+	var urlParams []rp.URLParamOpt
+	if p.ch != nil {
+		if nonce, err := generateNonce(); err == nil {
+			if err := p.ch.SetCookie(w, "nonce", nonce); err == nil {
+				urlParams = append(urlParams, rp.WithURLParam("nonce", nonce))
+			}
+		}
+	}
+	rp.AuthURLHandler(func() string { return state }, p.rp, urlParams...).ServeHTTP(w, r)
 }
 
-// Callback verifies the state cookie + PKCE, exchanges the code, fetches
-// userinfo, and invokes onSuccess. On failure CodeExchangeHandler writes its
-// own error response and onSuccess is not called.
+// Callback verifies the state cookie + PKCE + id_token nonce, exchanges the
+// code, fetches userinfo, and invokes onSuccess. On failure CodeExchangeHandler
+// writes its own error response and onSuccess is not called.
 func (p *OIDCProvider) Callback(w http.ResponseWriter, r *http.Request, onSuccess func(w http.ResponseWriter, r *http.Request, state string, info *UserInfo)) {
+	if p.ch != nil {
+		// Pass the per-login nonce from its cookie into the verifier (via ctx),
+		// then drop the cookie so it cannot be replayed.
+		if nonce, err := p.ch.CheckCookie(r, "nonce"); err == nil {
+			r = r.WithContext(context.WithValue(r.Context(), nonceCtxKey{}, nonce))
+			p.ch.DeleteCookie(w, "nonce")
+		}
+	}
 	cb := rp.UserinfoCallback[*oidc.IDTokenClaims, *oidc.UserInfo](
 		func(w http.ResponseWriter, r *http.Request, tokens *oidc.Tokens[*oidc.IDTokenClaims], state string, _ rp.RelyingParty, info *oidc.UserInfo) {
 			onSuccess(w, r, state, mapUserInfo(info))
 		},
 	)
 	rp.CodeExchangeHandler[*oidc.IDTokenClaims](cb, p.rp).ServeHTTP(w, r)
+}
+
+// generateNonce returns a 128-bit URL-safe random nonce.
+func generateNonce() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
 func mapUserInfo(info *oidc.UserInfo) *UserInfo {

--- a/internal/upstream/oidc_test.go
+++ b/internal/upstream/oidc_test.go
@@ -30,8 +30,9 @@ type fakeIdP struct {
 	key            *rsa.PrivateKey
 	keyID          string
 	userInfoResp   map[string]any
-	tokenStatus    int // non-zero overrides token endpoint HTTP status
-	userinfoStatus int // non-zero overrides userinfo endpoint HTTP status
+	tokenStatus    int    // non-zero overrides token endpoint HTTP status
+	userinfoStatus int    // non-zero overrides userinfo endpoint HTTP status
+	nonce          string // echoed into the id_token's nonce claim (set by the test from the authorize request)
 }
 
 func newFakeIdP(t *testing.T) *fakeIdP {
@@ -102,11 +103,12 @@ func newFakeIdP(t *testing.T) *fakeIdP {
 		sub, _ := idp.userInfoResp["sub"].(string)
 		now := time.Now()
 		idToken, err := jwt.Signed(sig).Claims(map[string]any{
-			"iss": srvURL,
-			"sub": sub,
-			"aud": testClientID,
-			"exp": now.Add(5 * time.Minute).Unix(),
-			"iat": now.Unix(),
+			"iss":   srvURL,
+			"sub":   sub,
+			"aud":   testClientID,
+			"exp":   now.Add(5 * time.Minute).Unix(),
+			"iat":   now.Unix(),
+			"nonce": idp.nonce,
 		}).Serialize()
 		if err != nil {
 			http.Error(w, "sign error", http.StatusInternalServerError)
@@ -166,10 +168,10 @@ func authURLForTest(t *testing.T, p *OIDCProvider, state string) string {
 // IdP, replaying the state/PKCE cookies the redirect set, and returns the
 // UserInfo delivered to the onSuccess callback (or an error if onSuccess was
 // never invoked, mirroring the old Exchange error contract).
-func exchangeForTest(t *testing.T, p *OIDCProvider, code string) (*UserInfo, error) {
+func exchangeForTest(t *testing.T, idp *fakeIdP, p *OIDCProvider, code string) (*UserInfo, error) {
 	t.Helper()
 
-	// First leg: Redirect to capture the state + PKCE cookies.
+	// First leg: Redirect to capture the state + PKCE + nonce cookies.
 	redirectRec := httptest.NewRecorder()
 	redirectReq := httptest.NewRequest(http.MethodGet, "/login", nil)
 	p.Redirect(redirectRec, redirectReq, "test-state")
@@ -180,6 +182,9 @@ func exchangeForTest(t *testing.T, p *OIDCProvider, code string) (*UserInfo, err
 		t.Fatalf("parse redirect location: %v", err)
 	}
 	state := u.Query().Get("state")
+	// The IdP echoes the authorize-request nonce into the id_token; mirror that
+	// so the RP's nonce verifier sees a matching value.
+	idp.nonce = u.Query().Get("nonce")
 
 	// Second leg: Callback with the captured cookies + the IdP-issued code/state.
 	cbReq := httptest.NewRequest(http.MethodGet, "/login/callback?code="+code+"&state="+state, nil)
@@ -282,7 +287,7 @@ func TestOIDCProvider_AuthURL_ContainsRequiredParams(t *testing.T) {
 func TestOIDCProvider_Exchange_Success(t *testing.T) {
 	idp := newFakeIdP(t)
 	p := idp.newProvider(t)
-	info, err := exchangeForTest(t, p, "fake-code")
+	info, err := exchangeForTest(t, idp, p, "fake-code")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -303,7 +308,7 @@ func TestOIDCProvider_Exchange_TokenEndpointError(t *testing.T) {
 	idp := newFakeIdP(t)
 	idp.tokenStatus = http.StatusUnauthorized
 	p := idp.newProvider(t)
-	_, err := exchangeForTest(t, p, "any-code")
+	_, err := exchangeForTest(t, idp, p, "any-code")
 	if err == nil {
 		t.Error("expected error for token endpoint 401, got nil")
 	}
@@ -315,7 +320,7 @@ func TestOIDCProvider_Exchange_UserInfoError(t *testing.T) {
 	idp := newFakeIdP(t)
 	idp.userinfoStatus = http.StatusUnauthorized
 	p := idp.newProvider(t)
-	_, err := exchangeForTest(t, p, "fake-code")
+	_, err := exchangeForTest(t, idp, p, "fake-code")
 	if err == nil {
 		t.Error("expected error for userinfo endpoint 401, got nil")
 	}
@@ -332,7 +337,7 @@ func TestOIDCProvider_UserInfoMapping_AllFields(t *testing.T) {
 		"name":           "Map User",
 	}
 	p := idp.newProvider(t)
-	info, err := exchangeForTest(t, p, "fake-code")
+	info, err := exchangeForTest(t, idp, p, "fake-code")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -358,7 +363,7 @@ func TestOIDCProvider_EmailVerified_True(t *testing.T) {
 	idp := newFakeIdP(t)
 	idp.userInfoResp["email_verified"] = true
 	p := idp.newProvider(t)
-	info, err := exchangeForTest(t, p, "fake-code")
+	info, err := exchangeForTest(t, idp, p, "fake-code")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -373,7 +378,7 @@ func TestOIDCProvider_EmailVerified_False(t *testing.T) {
 	idp := newFakeIdP(t)
 	idp.userInfoResp["email_verified"] = false
 	p := idp.newProvider(t)
-	info, err := exchangeForTest(t, p, "fake-code")
+	info, err := exchangeForTest(t, idp, p, "fake-code")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -388,7 +393,7 @@ func TestOIDCProvider_EmailVerified_Absent(t *testing.T) {
 	idp := newFakeIdP(t)
 	delete(idp.userInfoResp, "email_verified")
 	p := idp.newProvider(t)
-	info, err := exchangeForTest(t, p, "fake-code")
+	info, err := exchangeForTest(t, idp, p, "fake-code")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -413,12 +418,45 @@ func TestOIDCProvider_FullPath(t *testing.T) {
 		t.Errorf("AuthURL does not contain state: %s", authURL)
 	}
 
-	info, err := exchangeForTest(t, p, "full-path-code")
+	info, err := exchangeForTest(t, idp, p, "full-path-code")
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
 	if info.Sub == "" || info.Email == "" {
 		t.Errorf("incomplete UserInfo after full path: sub=%q email=%q", info.Sub, info.Email)
+	}
+}
+
+// ── oidc-nonce-001: id_token nonce mismatch is rejected ──────────────────────
+// Proves the per-login nonce binding: an id_token whose nonce does not match
+// the value bound to this login (cookie) must fail verification.
+func TestOIDCProvider_NonceMismatch_Rejected(t *testing.T) {
+	idp := newFakeIdP(t)
+	p := idp.newProvider(t)
+
+	// Drive Redirect to set the state/PKCE/nonce cookies.
+	redirectRec := httptest.NewRecorder()
+	p.Redirect(redirectRec, httptest.NewRequest(http.MethodGet, "/login", nil), "test-state")
+	u, err := url.Parse(redirectRec.Result().Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect location: %v", err)
+	}
+	state := u.Query().Get("state")
+
+	// Tamper: make the IdP issue an id_token with a DIFFERENT nonce than the
+	// one bound to this login.
+	idp.nonce = "attacker-supplied-nonce"
+
+	cbReq := httptest.NewRequest(http.MethodGet, "/login/callback?code=fake-code&state="+state, nil)
+	for _, c := range redirectRec.Result().Cookies() {
+		cbReq.AddCookie(c)
+	}
+	cbRec := httptest.NewRecorder()
+
+	called := false
+	p.Callback(cbRec, cbReq, func(http.ResponseWriter, *http.Request, string, *UserInfo) { called = true })
+	if called {
+		t.Error("onSuccess invoked despite id_token nonce mismatch — replay/injection not rejected")
 	}
 }
 


### PR DESCRIPTION
## Summary
Completes the upstream-leg hardening started in #261. state cookie + PKCE closed login CSRF / code injection; this adds **id_token nonce verification** so the id_token is bound to the specific login request (defends against id_token replay / injection).

## Fix
- `Redirect`: generate a per-login random nonce, store it in an encrypted cookie, and send it as the OIDC `nonce` authorize parameter.
- `Callback`: read the nonce cookie into the request context (then drop it) and verify the id_token `nonce` claim via `rp.WithVerifierOpts(rp.WithNonce(...))`.
- Applies to all three channels (browser / device / mcp) — they share the provider.
- Same library, no new deps.

Resolves **GAP-SEC-001**.

## Verification
- Unit: `TestOIDCProvider_NonceMismatch_Rejected` — a mismatched id_token nonce is rejected (onSuccess not invoked); happy-path exchange tests updated so the fake IdP echoes the authorize nonce.
- **End-to-end** against docker-compose mock Google OIDC: authgate now bakes a `nonce` cookie alongside `state`/`pkce`; full browser login completes (`/api/me` → authenticated), confirming the mock IdP echoes nonce and verification passes.

## Test plan
- [x] `gofmt -l` clean
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`
- [x] `go test ./...`
- [x] docker-compose live login (happy path) + nonce-mismatch unit test (rejection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)