### PR TITLE
refactor: remove unused identity metadata persistence

### DIFF
--- a/docs/spec/001-signup.md
+++ b/docs/spec/001-signup.md
@@ -109,7 +109,6 @@ user_identities:
   user_id:          위 users.id
   provider:         'google'
   provider_user_id: IdP sub (불변 식별자, 조회 기준)
-  provider_email:   IdP 이메일 (가입 시점 기록)
 ```
 
 상세 스키마는 [Spec 007 데이터 모델](007-data-model.md)을 참조.

--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -31,8 +31,6 @@ erDiagram
         uuid user_id FK "NOT NULL, CASCADE"
         text provider "NOT NULL, OIDC issuer에서 파생 (예: google, mock 등)"
         text provider_user_id "NOT NULL, UNIQUE(provider, provider_user_id)"
-        text provider_email "nullable"
-        jsonb provider_raw "nullable"
         timestamptz created_at "NOT NULL, DEFAULT NOW()"
     }
 

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -3,8 +3,8 @@ INSERT INTO users (id, email, email_verified, name, status, created_at, updated_
 VALUES ($1, $2, $3, $4, 'active', $5, $5);
 
 -- name: InsertUserIdentity :exec
-INSERT INTO user_identities (id, user_id, provider, provider_user_id, provider_email, created_at)
-VALUES ($1, $2, $3, $4, $5, $6);
+INSERT INTO user_identities (id, user_id, provider, provider_user_id, created_at)
+VALUES ($1, $2, $3, $4, $5);
 
 -- name: GetUserByProviderIdentity :one
 SELECT u.id, u.email, u.email_verified, u.name, u.status,

--- a/internal/db/storeq/models.go
+++ b/internal/db/storeq/models.go
@@ -94,7 +94,5 @@ type UserIdentity struct {
 	UserID         string
 	Provider       string
 	ProviderUserID string
-	ProviderEmail  sql.NullString
-	ProviderRaw    pqtype.NullRawMessage
 	CreatedAt      time.Time
 }

--- a/internal/db/storeq/users.sql.go
+++ b/internal/db/storeq/users.sql.go
@@ -270,8 +270,8 @@ func (q *Queries) InsertUser(ctx context.Context, arg InsertUserParams) error {
 }
 
 const insertUserIdentity = `-- name: InsertUserIdentity :exec
-INSERT INTO user_identities (id, user_id, provider, provider_user_id, provider_email, created_at)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO user_identities (id, user_id, provider, provider_user_id, created_at)
+VALUES ($1, $2, $3, $4, $5)
 `
 
 type InsertUserIdentityParams struct {
@@ -279,7 +279,6 @@ type InsertUserIdentityParams struct {
 	UserID         string
 	Provider       string
 	ProviderUserID string
-	ProviderEmail  sql.NullString
 	CreatedAt      time.Time
 }
 
@@ -289,7 +288,6 @@ func (q *Queries) InsertUserIdentity(ctx context.Context, arg InsertUserIdentity
 		arg.UserID,
 		arg.Provider,
 		arg.ProviderUserID,
-		arg.ProviderEmail,
 		arg.CreatedAt,
 	)
 	return err

--- a/internal/integration/integration_account_deletion_test.go
+++ b/internal/integration/integration_account_deletion_test.go
@@ -25,7 +25,6 @@ func TestAccountDeletion_IdempotentAndSessionAlive(t *testing.T) {
 		Name:           "Deletion Test",
 		Provider:       "google",
 		ProviderUserID: "deletion-idempotent-sub",
-		ProviderEmail:  "deletion-idempotent@test.com",
 	})
 	if err != nil {
 		t.Fatalf("create user: %v", err)

--- a/internal/integration/integration_account_test.go
+++ b/internal/integration/integration_account_test.go
@@ -18,7 +18,7 @@ func TestIntegration_DeleteAccount_WrongOrigin_Rejected(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user + get session
-	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "origin-test@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "o@test.com"})
+	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "origin-test@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "test-google-sub"})
 	sessionID, _ := ts.Store.CreateSession(ctx, user.ID, 24*3600*1e9)
 
 	req, _ := http.NewRequest("DELETE", ts.BaseURL+"/account", nil)
@@ -51,7 +51,7 @@ func TestIntegration_DeleteAccount_InactiveUser_Rejected(t *testing.T) {
 			ts := SetupTestServer(t)
 			ctx := context.Background()
 
-			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "inactive-delete-" + tt.name + "@test.com", EmailVerified: true, Name: "Inactive Delete", Provider: "google", ProviderUserID: "inactive-delete-sub-" + tt.name, ProviderEmail: "inactive-delete-" + tt.name + "@test.com"})
+			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "inactive-delete-" + tt.name + "@test.com", EmailVerified: true, Name: "Inactive Delete", Provider: "google", ProviderUserID: "inactive-delete-sub-" + tt.name})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}
@@ -95,7 +95,7 @@ func TestIntegration_DeleteAccount_ResponseShape(t *testing.T) {
 	ts := SetupTestServer(t)
 	ctx := context.Background()
 
-	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "shape@test.com", EmailVerified: true, Name: "Shape", Provider: "google", ProviderUserID: "shape-sub", ProviderEmail: "shape@test.com"})
+	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "shape@test.com", EmailVerified: true, Name: "Shape", Provider: "google", ProviderUserID: "shape-sub"})
 	sessionID, _ := ts.Store.CreateSession(ctx, user.ID, 24*3600*1e9)
 
 	req, _ := http.NewRequest(http.MethodDelete, ts.BaseURL+"/account", nil)

--- a/internal/integration/integration_at_jwt_test.go
+++ b/internal/integration/integration_at_jwt_test.go
@@ -26,7 +26,6 @@ func TestAccessToken_TypIsAtJWTAndIDTokenStaysJWT(t *testing.T) {
 	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
 		Email: "atjwt@test.com", EmailVerified: true, Name: "AT JWT",
 		Provider: "google", ProviderUserID: "test-google-sub",
-		ProviderEmail: "atjwt@test.com",
 	}); err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -66,7 +65,6 @@ func TestRefreshGrant_AccessTokenTypIsAtJWT(t *testing.T) {
 	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
 		Email: "atjwt-refresh@test.com", EmailVerified: true, Name: "AT JWT Refresh",
 		Provider: "google", ProviderUserID: "test-google-sub",
-		ProviderEmail: "atjwt-refresh@test.com",
 	}); err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -99,7 +97,6 @@ func TestDeviceGrant_AccessTokenTypIsAtJWT(t *testing.T) {
 	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
 		Email: "atjwt-device@test.com", EmailVerified: true, Name: "AT JWT Device",
 		Provider: "google", ProviderUserID: "test-google-sub",
-		ProviderEmail: "atjwt-device@test.com",
 	})
 	if err != nil {
 		t.Fatalf("create user: %v", err)

--- a/internal/integration/integration_device_test.go
+++ b/internal/integration/integration_device_test.go
@@ -48,7 +48,7 @@ func TestIntegration_DeviceCallback_PendingDeletion_Rejected(t *testing.T) {
 	ts := SetupTestServer(t)
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-pending@test.com", EmailVerified: true, Name: "Device Pending", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-pending@test.com"})
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-pending@test.com", EmailVerified: true, Name: "Device Pending", Provider: "google", ProviderUserID: "test-google-sub"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestIntegration_DeviceConsumed_RePolling(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user and approve device code
-	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-consumed@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-consumed-sub", ProviderEmail: "dc@test.com"})
+	user, _ := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-consumed@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-consumed-sub"})
 	_ = user
 
 	// Store a device code and approve it
@@ -115,7 +115,7 @@ func TestIntegration_DeviceFullFlow_TokenIssued(t *testing.T) {
 	ts := SetupTestServer(t)
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-ok@test.com", EmailVerified: true, Name: "Device OK", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-ok@test.com"})
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-ok@test.com", EmailVerified: true, Name: "Device OK", Provider: "google", ProviderUserID: "test-google-sub"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestIntegration_DeviceConcurrentPolling_ExactlyOneSuccess(t *testing.T) {
 	ts := SetupTestServer(t)
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-race@test.com", EmailVerified: true, Name: "Device Race", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-race@test.com"})
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-race@test.com", EmailVerified: true, Name: "Device Race", Provider: "google", ProviderUserID: "test-google-sub"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -200,7 +200,7 @@ func TestIntegration_DevicePolling_RechecksUserStatus(t *testing.T) {
 
 			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
 				Email: "device-" + tc.flipStatus + "@test.com", EmailVerified: true, Name: "Flipped Mid-Flow",
-				Provider: "google", ProviderUserID: "test-google-sub-" + tc.flipStatus, ProviderEmail: "device-" + tc.flipStatus + "@test.com",
+				Provider: "google", ProviderUserID: "test-google-sub-" + tc.flipStatus,
 			})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
@@ -291,7 +291,7 @@ func TestIntegration_DevicePolling_SlowDownThenApprove_Succeeds(t *testing.T) {
 
 	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
 		Email: "device-slow-then-approve@test.com", EmailVerified: true, Name: "Slow Then Approve",
-		Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "device-slow-then-approve@test.com",
+		Provider: "google", ProviderUserID: "test-google-sub",
 	})
 	if err != nil {
 		t.Fatalf("create user: %v", err)

--- a/internal/integration/integration_mcp_resource_test.go
+++ b/internal/integration/integration_mcp_resource_test.go
@@ -59,7 +59,6 @@ func TestMCPResourceBinding(t *testing.T) {
 		if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
 			Email: "mcp-resource-ok@test.com", EmailVerified: true, Name: "MCP Resource OK",
 			Provider: "google", ProviderUserID: "test-google-sub",
-			ProviderEmail: "mcp-resource-ok@test.com",
 		}); err != nil {
 			t.Fatalf("create user: %v", err)
 		}
@@ -180,7 +179,6 @@ func TestMCPResourceBinding(t *testing.T) {
 		if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
 			Email: "mcp-resource-mismatch@test.com", EmailVerified: true, Name: "MCP Resource Mismatch",
 			Provider: "google", ProviderUserID: "test-google-sub",
-			ProviderEmail: "mcp-resource-mismatch@test.com",
 		}); err != nil {
 			t.Fatalf("create user: %v", err)
 		}

--- a/internal/integration/integration_mcp_test.go
+++ b/internal/integration/integration_mcp_test.go
@@ -18,7 +18,7 @@ func TestIntegration_MCPTokenExchange_NoPKCE_Rejected(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-pkce@test.com", EmailVerified: true, Name: "MCP PKCE", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-pkce@test.com"})
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-pkce@test.com", EmailVerified: true, Name: "MCP PKCE", Provider: "google", ProviderUserID: "test-google-sub"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestIntegration_MCPTokenExchange_MissingResource_Rejected(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-missing-resource@test.com", EmailVerified: true, Name: "MCP Missing Resource", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-missing-resource@test.com"}); err != nil {
+	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-missing-resource@test.com", EmailVerified: true, Name: "MCP Missing Resource", Provider: "google", ProviderUserID: "test-google-sub"}); err != nil {
 		t.Fatalf("create user: %v", err)
 	}
 
@@ -73,7 +73,7 @@ func TestIntegration_MCPRefresh_MismatchedResource_Rejected(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-refresh-resource@test.com", EmailVerified: true, Name: "MCP Refresh Resource", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-refresh-resource@test.com"}); err != nil {
+	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-refresh-resource@test.com", EmailVerified: true, Name: "MCP Refresh Resource", Provider: "google", ProviderUserID: "test-google-sub"}); err != nil {
 		t.Fatalf("create user: %v", err)
 	}
 
@@ -98,7 +98,7 @@ func TestIntegration_MCPAccessToken_AudienceBoundToResource(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-audience@test.com", EmailVerified: true, Name: "MCP Audience", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-audience@test.com"}); err != nil {
+	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-audience@test.com", EmailVerified: true, Name: "MCP Audience", Provider: "google", ProviderUserID: "test-google-sub"}); err != nil {
 		t.Fatalf("create user: %v", err)
 	}
 
@@ -144,7 +144,7 @@ func TestIntegration_MCPCodeExchange_StateChange_InvalidGrant(t *testing.T) {
 			client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 
 			ctx := context.Background()
-			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-token-state@test.com", EmailVerified: true, Name: "MCP Token", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-token-state@test.com"})
+			user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-token-state@test.com", EmailVerified: true, Name: "MCP Token", Provider: "google", ProviderUserID: "test-google-sub"})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}
@@ -195,7 +195,7 @@ func TestIntegration_MCPCallback_PendingDeletion_Rejected(t *testing.T) {
 	client := NewOAuthClientFor(t, ts.BaseURL, "mcp-client", "/mcp/callback")
 	ctx := context.Background()
 
-	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-callback-pending@test.com", EmailVerified: true, Name: "MCP Callback Pending", Provider: "google", ProviderUserID: "test-google-sub", ProviderEmail: "mcp-callback-pending@test.com"})
+	user, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-callback-pending@test.com", EmailVerified: true, Name: "MCP Callback Pending", Provider: "google", ProviderUserID: "test-google-sub"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}

--- a/internal/service/account_test.go
+++ b/internal/service/account_test.go
@@ -52,7 +52,7 @@ func setupAccountTest(t *testing.T) *accountFixture {
 func createUserWithSession(t *testing.T, store *storage.Storage, email, sub string) (string, string) {
 	t.Helper()
 	ctx := context.Background()
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: sub, ProviderEmail: email})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: sub})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestAccount004_PendingDeletion_DeviceRejected(t *testing.T) {
 	fx := setupGapTest(t)
 	ctx := context.Background()
 
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pd-device@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "pd@test.com"})
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pd-device@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "gap-sub"})
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 	insertDeviceCode(t, fx.Store, "PD-CODE", fx.Clock)
 
@@ -232,7 +232,7 @@ func TestAccount004b_PendingDeletion_MCPRejected(t *testing.T) {
 	fx := setupGapTest(t)
 	ctx := context.Background()
 
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pd-mcp@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "pdm@test.com"})
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pd-mcp@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "gap-sub"})
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	arID, _ := fx.Store.CreateTestAuthRequestWithResource(ctx, "pd-mcp", "http://localhost/mcp")

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -92,7 +92,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		svc, store, fakeUser := setupBrowserExtTest(t)
 		ctx := context.Background()
 
-		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-browser@test.com", EmailVerified: true, Name: "Browser", Provider: "google", ProviderUserID: "browser-ext-sub", ProviderEmail: "audit-browser@test.com"})
+		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-browser@test.com", EmailVerified: true, Name: "Browser", Provider: "google", ProviderUserID: "browser-ext-sub"})
 		if err != nil {
 			t.Fatalf("create user: %v", err)
 		}
@@ -113,7 +113,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		svc, store, clk, fakeUser := setupDeviceExtTest(t, "audit-device-sub")
 		ctx := context.Background()
 
-		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device@test.com", EmailVerified: true, Name: "Device", Provider: "google", ProviderUserID: "audit-device-sub", ProviderEmail: "audit-device@test.com"})
+		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device@test.com", EmailVerified: true, Name: "Device", Provider: "google", ProviderUserID: "audit-device-sub"})
 		if err != nil {
 			t.Fatalf("create user: %v", err)
 		}
@@ -134,7 +134,7 @@ func TestAudit002_LoginChannels(t *testing.T) {
 		svc, store, fakeUser := setupMCPExtTest(t, "audit-mcp-sub")
 		ctx := context.Background()
 
-		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "audit-mcp-sub", ProviderEmail: "audit-mcp@test.com"})
+		user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "audit-mcp-sub"})
 		if err != nil {
 			t.Fatalf("create user: %v", err)
 		}
@@ -160,7 +160,7 @@ func TestAudit_ReusedSession_AuthLoginRecorded(t *testing.T) {
 	svc, store, _ := setupBrowserExtTest(t)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-reuse@test.com", EmailVerified: true, Name: "Reuse", Provider: "google", ProviderUserID: "browser-ext-sub", ProviderEmail: "audit-reuse@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-reuse@test.com", EmailVerified: true, Name: "Reuse", Provider: "google", ProviderUserID: "browser-ext-sub"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestAudit_ReusedSession_MCP_AuthLoginRecorded(t *testing.T) {
 	svc, store, _ := setupMCPExtTest(t, "audit-mcp-reuse-sub")
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp-reuse@test.com", EmailVerified: true, Name: "MCP Reuse", Provider: "google", ProviderUserID: "audit-mcp-reuse-sub", ProviderEmail: "audit-mcp-reuse@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp-reuse@test.com", EmailVerified: true, Name: "MCP Reuse", Provider: "google", ProviderUserID: "audit-mcp-reuse-sub"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestAudit004_DeviceApproved(t *testing.T) {
 	svc, store, clk, _ := setupDeviceService(t)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-approve@test.com", EmailVerified: true, Name: "Approve", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "audit-approve@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-approve@test.com", EmailVerified: true, Name: "Approve", Provider: "google", ProviderUserID: "device-sub-123"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestAudit005_DeviceDenied(t *testing.T) {
 	svc, store, clk, _ := setupDeviceService(t)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-deny@test.com", EmailVerified: true, Name: "Deny", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "audit-deny@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-deny@test.com", EmailVerified: true, Name: "Deny", Provider: "google", ProviderUserID: "device-sub-123"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestAudit007_DeletionCancelled(t *testing.T) {
 	svc, store, fakeUser := setupLoginService(t)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-recover@test.com", EmailVerified: true, Name: "Recover", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "audit-recover@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-recover@test.com", EmailVerified: true, Name: "Recover", Provider: "google", ProviderUserID: "google-sub-123"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -370,7 +370,7 @@ func TestAudit009_InactiveUser(t *testing.T) {
 			svc, store, fakeUser := setupLoginService(t)
 			ctx := context.Background()
 
-			user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-inactive-" + tt.name + "@test.com", EmailVerified: true, Name: "Inactive", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "audit-inactive@test.com"})
+			user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-inactive-" + tt.name + "@test.com", EmailVerified: true, Name: "Inactive", Provider: "google", ProviderUserID: "google-sub-123"})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}
@@ -399,7 +399,7 @@ func TestAuditSecurity003_DeviceInactiveUser(t *testing.T) {
 	svc, store, clk, fakeUser := setupDeviceExtTest(t, "audit-device-inactive-sub")
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-inactive@test.com", EmailVerified: true, Name: "Inactive Device", Provider: "google", ProviderUserID: "audit-device-inactive-sub", ProviderEmail: "audit-device-inactive@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-inactive@test.com", EmailVerified: true, Name: "Inactive Device", Provider: "google", ProviderUserID: "audit-device-inactive-sub"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -423,7 +423,7 @@ func TestAuditSecurity_DevicePendingDeletionInactiveUser(t *testing.T) {
 	svc, store, clk, fakeUser := setupDeviceExtTest(t, "audit-device-pending-sub")
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-pending@test.com", EmailVerified: true, Name: "Pending Device", Provider: "google", ProviderUserID: "audit-device-pending-sub", ProviderEmail: "audit-device-pending@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-device-pending@test.com", EmailVerified: true, Name: "Pending Device", Provider: "google", ProviderUserID: "audit-device-pending-sub"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -461,7 +461,7 @@ func TestAuditSecurity_MCPInactiveUser_Metadata(t *testing.T) {
 			svc, store, fakeUser := setupMCPExtTest(t, "audit-mcp-"+tt.name+"-sub")
 			ctx := context.Background()
 
-			user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp-" + tt.name + "@test.com", EmailVerified: true, Name: "MCP Inactive", Provider: "google", ProviderUserID: "audit-mcp-" + tt.name + "-sub", ProviderEmail: "audit-mcp-" + tt.name + "@test.com"})
+			user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "audit-mcp-" + tt.name + "@test.com", EmailVerified: true, Name: "MCP Inactive", Provider: "google", ProviderUserID: "audit-mcp-" + tt.name + "-sub"})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}

--- a/internal/service/cleanup_test.go
+++ b/internal/service/cleanup_test.go
@@ -31,7 +31,7 @@ func TestCleanup_ExpiredSessions(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user + expired session
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "cleanup-session@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "cleanup-session-sub", ProviderEmail: "c@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "cleanup-session@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "cleanup-session-sub"})
 	db.ExecContext(ctx,
 		`INSERT INTO sessions (id, user_id, expires_at, created_at) VALUES (uuid_generate_v4(), $1, $2, $3)`,
 		user.ID, clk.Now().Add(-1*time.Hour), clk.Now().Add(-25*time.Hour), // expired 1 hour ago
@@ -86,7 +86,7 @@ func TestCleanup_DeletionPIIScrub(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user, then set to pending_deletion with past scheduled date
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "delete-me@test.com", EmailVerified: true, Name: "Delete Me", Provider: "google", ProviderUserID: "delete-sub", ProviderEmail: "d@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "delete-me@test.com", EmailVerified: true, Name: "Delete Me", Provider: "google", ProviderUserID: "delete-sub"})
 	db.ExecContext(ctx,
 		`UPDATE users SET status = 'pending_deletion', deletion_scheduled_at = $1 WHERE id = $2`,
 		clk.Now().Add(-1*time.Hour), user.ID, // scheduled in the past
@@ -143,7 +143,7 @@ func TestE2E8_CleanupRollback(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user set for deletion
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "rollback@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "rollback-sub", ProviderEmail: "rb@test.com"})
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "rollback@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "rollback-sub"})
 	fx.DB.ExecContext(ctx, `UPDATE users SET status='pending_deletion', deletion_scheduled_at=$1 WHERE id=$2`,
 		fx.Clock.Now().Add(-1*time.Hour), user.ID)
 
@@ -200,7 +200,7 @@ func TestCleanup_DeletionPIIScrub_Idempotent(t *testing.T) {
 	db, store, clk := setupCleanupTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "cleanup-idem@test.com", EmailVerified: true, Name: "Idem", Provider: "google", ProviderUserID: "cleanup-idem-sub", ProviderEmail: "cleanup-idem@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "cleanup-idem@test.com", EmailVerified: true, Name: "Idem", Provider: "google", ProviderUserID: "cleanup-idem-sub"})
 	db.ExecContext(ctx,
 		`UPDATE users SET status = 'pending_deletion', deletion_scheduled_at = $1 WHERE id = $2`,
 		clk.Now().Add(-1*time.Hour), user.ID,
@@ -249,7 +249,7 @@ func TestCleanup_DeletionRaceWithRecovery(t *testing.T) {
 
 	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
 		Email: "race-recover@test.com", EmailVerified: true, Name: "Race",
-		Provider: "google", ProviderUserID: "race-recover-sub", ProviderEmail: "race@test.com",
+		Provider: "google", ProviderUserID: "race-recover-sub",
 	})
 	if err != nil {
 		t.Fatalf("create user: %v", err)

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -82,7 +82,7 @@ func TestDevicePage_ValidCode_WithSession_ShowApprove(t *testing.T) {
 	ctx := context.Background()
 
 	// Create active user and session
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-approve@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-approve-sub", ProviderEmail: "d@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-approve@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-approve-sub"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 
 	insertDeviceCode(t, store, "APPR-CODE", clk)
@@ -98,7 +98,7 @@ func TestDevicePage_InactiveUser_Rejected(t *testing.T) {
 	ctx := context.Background()
 
 	// Create disabled user
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-inactive@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-inactive-sub", ProviderEmail: "di@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-inactive@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-inactive-sub"})
 	store.DisableUser(ctx, user.ID)
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 
@@ -117,7 +117,7 @@ func TestDeviceApprove_Allow(t *testing.T) {
 	svc, store, clk, _ := setupDeviceService(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-allow@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-allow-sub", ProviderEmail: "da@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-allow@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-allow-sub"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 
 	insertDeviceCode(t, store, "ALLW-CODE", clk)
@@ -132,7 +132,7 @@ func TestDeviceApprove_Deny(t *testing.T) {
 	svc, store, clk, _ := setupDeviceService(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-deny@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-deny-sub", ProviderEmail: "dd@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-deny@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-deny-sub"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 
 	insertDeviceCode(t, store, "DENY-CODE", clk)
@@ -176,7 +176,7 @@ func TestDeviceCallback_ExistingUser_RedirectBack(t *testing.T) {
 	svc, store, clk, fakeUser := setupDeviceService(t)
 	ctx := context.Background()
 
-	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-cb@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-sub-123", ProviderEmail: "dc@test.com"})
+	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "device-cb@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "device-sub-123"})
 	insertDeviceCode(t, store, "RDIR-CODE", clk)
 
 	result := svc.CompleteDeviceLogin(ctx, "RDIR-CODE", fakeUser, "127.0.0.1", "test")
@@ -196,7 +196,7 @@ func TestDevice005_RecoverableCallback_Rejected(t *testing.T) {
 	svc, store, clk, fakeUser := setupDeviceExtTest(t, "dev-recover-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-recover@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-recover-sub", ProviderEmail: "drc@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-recover@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-recover-sub"})
 	store.SetUserStatus(ctx, user.ID, "pending_deletion")
 	insertDeviceCode(t, store, "RECV-CODE", clk)
 
@@ -214,7 +214,7 @@ func TestDevice006_InactiveCallback_Rejected(t *testing.T) {
 	svc, store, clk, fakeUser := setupDeviceExtTest(t, "dev-inactive-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-inactive@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-inactive-sub", ProviderEmail: "di@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-inactive@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-inactive-sub"})
 	store.DisableUser(ctx, user.ID)
 	insertDeviceCode(t, store, "INAC-CODE", clk)
 
@@ -232,7 +232,7 @@ func TestDeviceCallback_DeletedUser_Rejected(t *testing.T) {
 	svc, store, clk, fakeUser := setupDeviceExtTest(t, "dev-deleted-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-deleted@test.com", EmailVerified: true, Name: "Deleted", Provider: "google", ProviderUserID: "dev-deleted-sub", ProviderEmail: "dev-deleted@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-deleted@test.com", EmailVerified: true, Name: "Deleted", Provider: "google", ProviderUserID: "dev-deleted-sub"})
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
 	insertDeviceCode(t, store, "DELD-CODE", clk)
 
@@ -250,7 +250,7 @@ func TestDevice011_ApproveAfterDisable(t *testing.T) {
 	svc, store, clk, _ := setupDeviceExtTest(t, "dev-approve-dis-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-dis@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-approve-dis-sub", ProviderEmail: "dad@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-dis@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-approve-dis-sub"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 	insertDeviceCode(t, store, "ADIS-CODE", clk)
 
@@ -281,7 +281,7 @@ func TestDeviceApprove_AfterStatusTransition_Rejected(t *testing.T) {
 			svc, store, clk, _ := setupDeviceExtTest(t, "dev-approve-"+tt.status)
 			ctx := context.Background()
 
-			user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-" + tt.status + "@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-approve-" + tt.status, ProviderEmail: "dev-approve-" + tt.status + "@test.com"})
+			user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "dev-approve-" + tt.status + "@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "dev-approve-" + tt.status})
 			sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 			insertDeviceCode(t, store, "ASTA-"+tt.status, clk)
 

--- a/internal/service/e2e_test.go
+++ b/internal/service/e2e_test.go
@@ -157,7 +157,7 @@ func TestE2E4_DeleteThenRecoverFullCycle(t *testing.T) {
 	fx := setupE2ETest(t)
 	ctx := context.Background()
 
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "e2e4-full@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "e2e-sub", ProviderEmail: "e2e4-full@test.com"})
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "e2e4-full@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "e2e-sub"})
 	sessionID, _ := fx.Store.CreateSession(ctx, user.ID, 24*time.Hour)
 	refreshToken := createRefreshTokenForUser(t, ctx, fx.Store, user.ID)
 
@@ -225,7 +225,7 @@ func TestE2E5_RecoveryThenAuthRequestRetry(t *testing.T) {
 	fx := setupE2ETest(t)
 	ctx := context.Background()
 
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "e2e5-retry@test.com", EmailVerified: true, Name: "Retry User", Provider: "google", ProviderUserID: "e2e-sub", ProviderEmail: "e2e5-retry@test.com"})
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "e2e5-retry@test.com", EmailVerified: true, Name: "Retry User", Provider: "google", ProviderUserID: "e2e-sub"})
 	sessionID, _ := fx.Store.CreateSession(ctx, user.ID, 24*time.Hour)
 
 	// 1) pending_deletion 전환

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -266,7 +266,6 @@ func (s *LoginService) signupBrowserUser(ctx context.Context, providerName strin
 		Name:           userInfo.Name,
 		Provider:       providerName,
 		ProviderUserID: userInfo.Sub,
-		ProviderEmail:  userInfo.Email,
 	})
 	if errors.Is(err, storage.ErrEmailConflict) {
 		return nil, &CallbackResult{Action: ActionError, Error: "email_conflict", ErrorCode: http.StatusConflict}

--- a/internal/service/login_test.go
+++ b/internal/service/login_test.go
@@ -87,7 +87,7 @@ func TestHandleCallback_ExistingUser_AutoApprove(t *testing.T) {
 	ctx := context.Background()
 
 	// Pre-create user
-	_, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "existing@example.com", EmailVerified: true, Name: "Existing", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "existing@example.com"})
+	_, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "existing@example.com", EmailVerified: true, Name: "Existing", Provider: "google", ProviderUserID: "google-sub-123"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestHandleCallback_PendingDeletion_RecoveryAutoApprove(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user, then set to pending_deletion
-	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pending@example.com", EmailVerified: true, Name: "Pending", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "pending@example.com"})
+	user, err := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "pending@example.com", EmailVerified: true, Name: "Pending", Provider: "google", ProviderUserID: "google-sub-123"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestHandleCallback_InactiveUser_Error(t *testing.T) {
 	ctx := context.Background()
 
 	// Create disabled user
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "disabled@example.com", EmailVerified: true, Name: "Disabled", Provider: "google", ProviderUserID: "google-sub-123", ProviderEmail: "disabled@example.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "disabled@example.com", EmailVerified: true, Name: "Disabled", Provider: "google", ProviderUserID: "google-sub-123"})
 	store.DisableUser(ctx, user.ID)
 	arID, err := store.CreateTestAuthRequest(ctx, "req-disabled")
 	if err != nil {
@@ -169,7 +169,7 @@ func TestBrowser007_RecoveryRetryIdempotent(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user, then set to pending_deletion
-	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "retry@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "gap-sub", ProviderEmail: "r@test.com"})
+	user, _ := fx.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "retry@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "gap-sub"})
 	fx.Store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	// First attempt: callback with bogus authRequestID is rejected before

--- a/internal/service/mcp_test.go
+++ b/internal/service/mcp_test.go
@@ -37,7 +37,7 @@ func TestMCP_CompleteUser_AutoApprove(t *testing.T) {
 	svc, store, fakeUser := setupMCPTest(t)
 	ctx := context.Background()
 
-	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-ok@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "mcp-sub-123", ProviderEmail: "mcp@test.com"})
+	store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-ok@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "mcp-sub-123"})
 	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-ok", "http://localhost/mcp")
 
 	result := svc.CompleteMCPLogin(ctx, arID, fakeUser, "127.0.0.1", "mcp-client")
@@ -66,7 +66,7 @@ func TestMCP_DisabledUser_Rejected(t *testing.T) {
 	svc, store, fakeUser := setupMCPTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-dis@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "mcp-sub-123", ProviderEmail: "mcp@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-dis@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "mcp-sub-123"})
 	store.DisableUser(ctx, user.ID)
 
 	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-dis", "http://localhost/mcp")
@@ -85,7 +85,7 @@ func TestMCP005_Recoverable_Rejected(t *testing.T) {
 	svc, store, fakeUser := setupMCPExtTest(t, "mcp-005-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-recover@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "mcp-005-sub", ProviderEmail: "mrc@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-recover@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "mcp-005-sub"})
 	store.SetUserStatus(ctx, user.ID, "pending_deletion")
 
 	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-005", "http://localhost/mcp")
@@ -104,7 +104,7 @@ func TestMCPLogin_PendingDeletionSession_Rejected(t *testing.T) {
 	svc, store, _ := setupMCPTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-login-pending@test.com", EmailVerified: true, Name: "MCP Pending", Provider: "google", ProviderUserID: "mcp-login-pending-sub", ProviderEmail: "mcp-login-pending@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-login-pending@test.com", EmailVerified: true, Name: "MCP Pending", Provider: "google", ProviderUserID: "mcp-login-pending-sub"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 	_ = store.SetUserStatus(ctx, user.ID, "pending_deletion")
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-login-pending")
@@ -129,7 +129,7 @@ func TestMCPLogin_DeletedSession_Rejected(t *testing.T) {
 	svc, store, _ := setupMCPTest(t)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-login-deleted@test.com", EmailVerified: true, Name: "MCP Deleted", Provider: "google", ProviderUserID: "mcp-login-deleted-sub", ProviderEmail: "mcp-login-deleted@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-login-deleted@test.com", EmailVerified: true, Name: "MCP Deleted", Provider: "google", ProviderUserID: "mcp-login-deleted-sub"})
 	sessionID, _ := store.CreateSession(ctx, user.ID, 24*time.Hour)
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
 	arID, _ := store.CreateTestAuthRequest(ctx, "mcp-login-deleted")
@@ -154,7 +154,7 @@ func TestMCP_DeletedUser_Rejected(t *testing.T) {
 	svc, store, fakeUser := setupMCPExtTest(t, "mcp-deleted-sub")
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-deleted@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "mcp-deleted-sub", ProviderEmail: "mcp-deleted@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{Email: "mcp-deleted@test.com", EmailVerified: true, Name: "MCP", Provider: "google", ProviderUserID: "mcp-deleted-sub"})
 	_ = store.SetUserStatus(ctx, user.ID, "deleted")
 	arID, _ := store.CreateTestAuthRequestWithResource(ctx, "mcp-deleted", "http://localhost/mcp")
 

--- a/internal/storage/audit_test.go
+++ b/internal/storage/audit_test.go
@@ -23,7 +23,7 @@ func TestAudit010And011_RefreshReuseAndFamilyRevoke(t *testing.T) {
 	store := New(db, clk, gen, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "audit-refresh@test.com", EmailVerified: true, Name: "Refresh Audit", Provider: "google", ProviderUserID: "audit-refresh-sub", ProviderEmail: "audit-refresh@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "audit-refresh@test.com", EmailVerified: true, Name: "Refresh Audit", Provider: "google", ProviderUserID: "audit-refresh-sub"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestAuditLog_AppendOnlyGuardAllowsPIIRedactionOnly(t *testing.T) {
 	store := New(db, clk, idgen.CryptoGenerator{}, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
 	ctx := context.Background()
 
-	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "audit-guard@test.com", EmailVerified: true, Name: "Audit Guard", Provider: "google", ProviderUserID: "audit-guard-sub", ProviderEmail: "audit-guard@test.com"})
+	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "audit-guard@test.com", EmailVerified: true, Name: "Audit Guard", Provider: "google", ProviderUserID: "audit-guard-sub"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}

--- a/internal/storage/expiry_test.go
+++ b/internal/storage/expiry_test.go
@@ -53,7 +53,7 @@ func TestAuthRequestByCode_Expired_Rejected(t *testing.T) {
 
 	// Create auth request + complete + save code
 	arID, _ := store.CreateTestAuthRequest(ctx, "code-expiry")
-	user, _ := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "code-expiry@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "code-expiry-sub", ProviderEmail: "ce@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "code-expiry@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "code-expiry-sub"})
 	store.CompleteAuthRequest(ctx, arID, user.ID)
 	store.SaveAuthCode(ctx, arID, "test-code-expiry")
 

--- a/internal/storage/refresh_state_test.go
+++ b/internal/storage/refresh_state_test.go
@@ -23,7 +23,7 @@ func TestRefreshReuseDetection_FamilyRevoke(t *testing.T) {
 	store := New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
 	ctx := context.Background()
 
-	user, _ := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "reuse@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "reuse-sub", ProviderEmail: "ru@test.com"})
+	user, _ := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "reuse@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "reuse-sub"})
 	_ = user
 
 	// Insert two tokens in the same family
@@ -116,7 +116,7 @@ func TestRefreshStateCheck_AllStates(t *testing.T) {
 			email := fmt.Sprintf("refresh-state-%d@test.com", i)
 			sub := fmt.Sprintf("refresh-state-sub-%d", i)
 
-			user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: sub, ProviderEmail: email})
+			user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: sub})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}
@@ -204,7 +204,7 @@ func TestAuthCodeStateCheck_AllStates(t *testing.T) {
 			email := fmt.Sprintf("authcode-state-%d@test.com", i)
 			sub := fmt.Sprintf("authcode-state-sub-%d", i)
 
-			user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: sub, ProviderEmail: email})
+			user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: email, EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: sub})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
 			}

--- a/internal/storage/storage_integration_test.go
+++ b/internal/storage/storage_integration_test.go
@@ -28,7 +28,7 @@ func TestCreateUserWithIdentity_Atomic(t *testing.T) {
 	s := testStorage(t)
 	ctx := context.Background()
 
-	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "atomic@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "atomic-sub-1", ProviderEmail: "atomic@test.com"})
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "atomic@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "atomic-sub-1"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestCreateUserWithIdentity_Atomic(t *testing.T) {
 	}
 
 	// Duplicate email should fail
-	_, err = s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "atomic@test.com", EmailVerified: true, Name: "Test2", Provider: "google", ProviderUserID: "atomic-sub-2", ProviderEmail: "dup@test.com"})
+	_, err = s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "atomic@test.com", EmailVerified: true, Name: "Test2", Provider: "google", ProviderUserID: "atomic-sub-2"})
 	if err == nil {
 		t.Fatal("expected error for duplicate email")
 	}
@@ -67,7 +67,7 @@ func TestRefreshTokenRotation_Atomicity(t *testing.T) {
 	ctx := context.Background()
 
 	// Setup: create user
-	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "refresh@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "refresh-sub", ProviderEmail: "r@test.com"})
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "refresh@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "refresh-sub"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestSession_CreateAndValidate(t *testing.T) {
 	s := testStorage(t)
 	ctx := context.Background()
 
-	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "session@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "session-sub", ProviderEmail: "s@test.com"})
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "session@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "session-sub"})
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestSession_StatusFilter(t *testing.T) {
 
 			user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
 				Email: tc.name + "@test.com", EmailVerified: true, Name: "Test",
-				Provider: "google", ProviderUserID: "filter-" + tc.name, ProviderEmail: tc.name + "@test.com",
+				Provider: "google", ProviderUserID: "filter-" + tc.name,
 			})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
@@ -258,7 +258,7 @@ func TestRequestDeletion_RejectsClosedAccount(t *testing.T) {
 			s := testStorage(t)
 			user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
 				Email: "del-" + tc.flipStatus + "@test.com", EmailVerified: true, Name: "Del " + tc.flipStatus,
-				Provider: "google", ProviderUserID: "del-sub-" + tc.flipStatus, ProviderEmail: "del-" + tc.flipStatus + "@test.com",
+				Provider: "google", ProviderUserID: "del-sub-" + tc.flipStatus,
 			})
 			if err != nil {
 				t.Fatalf("create user: %v", err)
@@ -303,7 +303,7 @@ func TestRequestDeletion_PendingDeletionIsIdempotent(t *testing.T) {
 
 	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
 		Email: "del-idem@test.com", EmailVerified: true, Name: "Del Idem",
-		Provider: "google", ProviderUserID: "del-idem-sub", ProviderEmail: "del-idem@test.com",
+		Provider: "google", ProviderUserID: "del-idem-sub",
 	})
 	if err != nil {
 		t.Fatalf("create user: %v", err)

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -16,7 +16,6 @@ type CreateUserWithIdentityInput struct {
 	Name           string
 	Provider       string
 	ProviderUserID string
-	ProviderEmail  string
 }
 
 func (s *Storage) CreateUserWithIdentity(ctx context.Context, input CreateUserWithIdentityInput) (*User, error) {
@@ -73,7 +72,6 @@ func (s *Storage) insertIdentityForSignup(ctx context.Context, qtx *storeq.Queri
 		UserID:         userID,
 		Provider:       input.Provider,
 		ProviderUserID: input.ProviderUserID,
-		ProviderEmail:  sql.NullString{String: input.ProviderEmail, Valid: true},
 		CreatedAt:      now,
 	})
 }

--- a/migrations/001_init.up.sql
+++ b/migrations/001_init.up.sql
@@ -23,8 +23,6 @@ CREATE TABLE user_identities (
     user_id          UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     provider         TEXT NOT NULL,
     provider_user_id TEXT NOT NULL,
-    provider_email   TEXT,
-    provider_raw     JSONB,
     created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     UNIQUE (provider, provider_user_id)
 );

--- a/migrations/006_drop_user_identities_provider_email.down.sql
+++ b/migrations/006_drop_user_identities_provider_email.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE user_identities
+    ADD COLUMN IF NOT EXISTS provider_email TEXT,
+    ADD COLUMN IF NOT EXISTS provider_raw JSONB;

--- a/migrations/006_drop_user_identities_provider_email.up.sql
+++ b/migrations/006_drop_user_identities_provider_email.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE user_identities
+    DROP COLUMN IF EXISTS provider_email,
+    DROP COLUMN IF EXISTS provider_raw;


### PR DESCRIPTION
## Summary
- Remove unused `provider_email` and `provider_raw` columns from `user_identities`.
- Add migration 006 for existing deployments and keep the initial schema aligned.
- Stop carrying provider email through signup persistence and regenerate sqlc outputs/specs/tests.

## Why
`provider_email` duplicates `users.email`, and `provider_raw` is not written or read by the current login flow. Removing both reduces unnecessary identity/PII storage while preserving the `provider + provider_user_id` login mapping.

## Validation
- `sqlc generate`
- `sqlc vet`
- `go test ./...`
- `go test -tags=integration ./internal/... -run '^$'`
- `git diff --check`
