### PR TITLE
fix(account): gate self-service deletion behind config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Authgate is a pure authentication service. Business logic such as terms of servi
 | `/oauth/device/authorize` | Device authorization (RFC 8628) |
 | `/end_session` | RP-Initiated Logout |
 | `/userinfo` | UserInfo endpoint |
-| `/account` | Account deletion (DELETE) |
+| `/account` | Account deletion request (DELETE, disabled unless `ENABLE_ACCOUNT_DELETION=true`) |
 | `/health` | Liveness check |
 | `/ready` | Readiness check (DB ping) |
 
@@ -157,6 +157,7 @@ go run ./cmd/authgate
 | `SHUTDOWN_TIMEOUT_SEC` | `10` | graceful shutdown timeout in seconds before forced close |
 | `METRICS_ADDR` | empty | Optional internal metrics listener address. Empty disables metrics; when set, only Go runtime/process Prometheus metrics are exposed on this separate listener. |
 | `ENABLE_MCP` | `true` | enable MCP optional adapter routes/policies (`/mcp/*`, CIMD/resource binding) |
+| `ENABLE_ACCOUNT_DELETION` | `false` | enable self-service account deletion via `DELETE /account`; keep disabled unless Authgate-owned confirmation UX/policy is ready |
 | `CLIENT_CONFIG` | `/etc/authgate/clients.yaml` | YAML path for client metadata preload |
 
 `ENABLE_MCP=false`일 때는 `clients.yaml`의 `login_channel: mcp` 클라이언트가 허용되지 않으며 서버 시작 시 실패합니다.

--- a/docs/security/001-audit-evidence-matrix.md
+++ b/docs/security/001-audit-evidence-matrix.md
@@ -122,7 +122,7 @@ audit_log
 | `GET /device` | Device 코드 입력/승인 화면 | 없음 | auth limiter | DONE |
 | `GET /device/auth/callback` | Device 로그인 완료 | `auth.login`, `auth.inactive_user` | auth limiter | DONE |
 | `POST /device/approve` | Device 승인/거부 | `auth.device_approved`, `auth.device_denied`, `auth.inactive_user` | token limiter | DONE |
-| `DELETE /account` | 계정 삭제 요청 | `auth.deletion_requested`, inactive user block | auth limiter | DONE |
+| `DELETE /account` | 계정 삭제 요청 (`ENABLE_ACCOUNT_DELETION=true`에서만 활성) | `auth.deletion_requested`, inactive user block | auth limiter + default-disabled gate | DONE |
 
 ## 남은 GAP
 

--- a/docs/spec/006-account-lifecycle.md
+++ b/docs/spec/006-account-lifecycle.md
@@ -15,7 +15,7 @@ authgate 계정의 생성부터 삭제까지 전체 상태 전이와 각 상태�
 
 | Method | Path | 내부 처리 | 설명 |
 |--------|------|----------|------|
-| DELETE | `/account` | authgate 핸들러 | 계정 삭제 요청 (30일 유예) |
+| DELETE | `/account` | authgate 핸들러 | 계정 삭제 요청 (30일 유예). 기본 비활성화, `ENABLE_ACCOUNT_DELETION=true`일 때만 사용 가능 |
 | GET | `/health` | authgate 핸들러 | liveness 체크 |
 | GET | `/ready` | authgate 핸들러 | readiness 체크 (DB 포함) |
 
@@ -29,7 +29,7 @@ authgate 계정의 생성부터 삭제까지 전체 상태 전이와 각 상태�
 stateDiagram-v2
     [*] --> active: 계정 생성 (Spec 001)
 
-    active --> pending_deletion: DELETE /account
+    active --> pending_deletion: DELETE /account<br/>ENABLE_ACCOUNT_DELETION=true
     active --> disabled: 운영자 조치 (Spec 009)
 
     pending_deletion --> active: 30일 내 브라우저 로그인 (자동 복구)
@@ -62,7 +62,7 @@ sequenceDiagram
     participant AG as authgate
     participant DB as PostgreSQL
 
-    U->>AG: DELETE /account (세션 쿠키 + Origin 필요)
+    U->>AG: DELETE /account (ENABLE_ACCOUNT_DELETION=true, 세션 쿠키 + Origin 필요)
     AG->>AG: Origin == PUBLIC_URL 확인
     AG->>AG: getSessionUser → 유저 확인
     AG->>DB: BEGIN
@@ -72,6 +72,9 @@ sequenceDiagram
     AG->>AG: audit: auth.deletion_requested
     AG-->>U: 200 {"status": "pending_deletion", "message": "Account scheduled for deletion in 30 days. Login to cancel."}
 ```
+
+`ENABLE_ACCOUNT_DELETION=false`(기본값)이면 `DELETE /account`는 404 `account deletion disabled`를 반환하고 상태를 변경하지 않는다.
+연결된 서비스/클라이언트가 authgate 전역 계정 삭제를 유발하지 않도록, Authgate가 소유한 명시적 확인 UX와 운영 정책이 준비된 배포에서만 활성화한다.
 
 **삭제 요청 즉시 refresh_token 전부 revoke.** 기존 access_token은 만료(15분)를 기다린다.
 
@@ -162,6 +165,7 @@ authgate는 2종의 account cleanup을 별도 lifecycle로 관리한다:
 
 | 상황 | 에러 코드 | HTTP | 설명 |
 |------|----------|------|------|
+| 삭제 기능 비활성화 | `account deletion disabled` | 404 | 기본값. `ENABLE_ACCOUNT_DELETION=true`에서만 실제 삭제 요청 처리 |
 | Origin 누락/불일치 | `origin mismatch` | 403 | destructive action CSRF 방어. `Origin`은 `PUBLIC_URL`과 정확히 일치해야 함 |
 | 비로그인 상태 삭제 요청 | `unauthorized` | 401 | 세션 쿠키 필요. Origin 검사를 통과한 뒤 세션이 없을 때 |
 | 이미 pending_deletion | — | 200 | 멱등 (재요청 무시) |
@@ -174,7 +178,7 @@ authgate는 2종의 account cleanup을 별도 lifecycle로 관리한다:
 
 | 이벤트 | 시점 | 설명 |
 |--------|------|------|
-| `auth.deletion_requested` | DELETE /account | 삭제 요청 + refresh_token 즉시 revoke |
+| `auth.deletion_requested` | DELETE /account (`ENABLE_ACCOUNT_DELETION=true`) | 삭제 요청 + refresh_token 즉시 revoke |
 | `auth.deletion_cancelled` | 유예 중 브라우저 로그인 | 자동 복구 |
 | `auth.deletion_completed` | cleanup 고루틴 PII 스크러빙 완료 | TX 커밋 이후 best-effort 기록 |
 | `auth.inactive_user` | pending_deletion/disabled/deleted 로그인 시도 차단 | status, channel 포함 |

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -71,6 +71,7 @@ authgate를 처음 배포할 때 필요한 것:
 | `METRICS_ADDR` | X | — | 별도 metrics listener 주소. 비워두면 disabled. 설정 시 Go runtime/process Prometheus metrics만 노출. 운영에서는 `127.0.0.1:9090` 또는 private network address 사용. |
 | `DEV_MODE` | X | `false` | true 시: insecure 허용, cookie Secure=false |
 | `ENABLE_MCP` | X | `true` | MCP optional adapter 활성화 여부 (`/mcp/*`, CIMD/resource binding) |
+| `ENABLE_ACCOUNT_DELETION` | X | `false` | self-service 계정 삭제 API(`DELETE /account`) 활성화 여부. 연결된 서비스가 전체 authgate 계정 삭제를 유발하지 않도록 기본 비활성화. Authgate 소유 확인 UX/운영 정책이 준비된 경우에만 `true`로 설정 |
 | `CLIENT_CONFIG` | X | `/etc/authgate/clients.yaml` | 클라이언트 설정 YAML 파일 경로 (없으면 무시) |
 | `MIGRATIONS_PATH` | X | `/migrations` | golang-migrate 마이그레이션 디렉터리 경로 (Docker 이미지 기본, 로컬 개발은 `./migrations`) |
 | `BRAND_NAME` | X | `authgate` | 디바이스 플로우 및 에러 페이지 좌측 상단에 표시되는 브랜드 이름 |

--- a/docs/tests/002-channel-flows.md
+++ b/docs/tests/002-channel-flows.md
@@ -62,7 +62,8 @@ Browser / Device / MCP / Refresh / Delete 각 채널이 공통 상태기계를 �
 
 | ID | 초기 상태 | 입력 | 기대 결과 | 검증 포인트 |
 |----|----------|------|----------|-------------|
-| `account-001` | `active` | `DELETE /account` | `pending_deletion` | 상태 전이 |
+| `account-000` | `active` | `DELETE /account` with `ENABLE_ACCOUNT_DELETION=false` | 404 `account deletion disabled` | 기본 비활성화 |
+| `account-001` | `active` | `DELETE /account` with `ENABLE_ACCOUNT_DELETION=true` | `pending_deletion` | 상태 전이 |
 | `account-002` | `pending_deletion` | `DELETE /account` | 200 멱등 | 재요청 무시 |
 | `account-003` | `pending_deletion` | Browser 로그인 | active 복구 | 복구 경로 |
 | `account-004` | `pending_deletion` | Device/MCP 로그인 | `account_inactive` | Browser만 복구 |

--- a/docs/tests/003-e2e-cycles.md
+++ b/docs/tests/003-e2e-cycles.md
@@ -13,7 +13,7 @@ authgate의 핵심 철학인 "가입 → 사용 → 탈퇴 → 복구/삭제 →
    v
 [active]
    |
-   | DELETE /account
+   | DELETE /account (`ENABLE_ACCOUNT_DELETION=true`)
    v
 [pending_deletion]
    |
@@ -51,7 +51,7 @@ authgate의 핵심 철학인 "가입 → 사용 → 탈퇴 → 복구/삭제 →
 
 | 단계 | 입력 | 기대 결과 | 검증 포인트 |
 |------|------|----------|-------------|
-| 1 | `active` 사용자 | `DELETE /account` | `pending_deletion` |
+| 1 | `active` 사용자 | `DELETE /account` (`ENABLE_ACCOUNT_DELETION=true`) | `pending_deletion` |
 | 2 | Refresh 시도 | `invalid_grant` | 즉시 차단 |
 | 3 | Device/MCP 로그인 시도 | `account_inactive` | Browser만 복구 가능 |
 | 4 | Browser 로그인 | active 복구 + 새 세션 | 복구 성공 |
@@ -61,7 +61,7 @@ authgate의 핵심 철학인 "가입 → 사용 → 탈퇴 → 복구/삭제 →
 
 | 단계 | 입력 | 기대 결과 | 검증 포인트 |
 |------|------|----------|-------------|
-| 1 | `active` 사용자 | `DELETE /account` | `pending_deletion` |
+| 1 | `active` 사용자 | `DELETE /account` (`ENABLE_ACCOUNT_DELETION=true`) | `pending_deletion` |
 | 2 | 30일 경과 + deletion cleanup | `user_identities/sessions/refresh_tokens` 삭제 + `users.status='deleted'` | 명시적 cleanup |
 | 3 | 같은 IdP 계정으로 Browser 로그인 | `GetUserByProviderIdentity -> ErrNotFound` | 기존 계정 아님 |
 | 4 | Spec 001 신규 가입 서브플로우 진입 | 새 `user_id` 발급 | deleted row와 분리 |

--- a/docs/tests/004-audit-events.md
+++ b/docs/tests/004-audit-events.md
@@ -21,7 +21,7 @@
 | `audit-002` | Browser/MCP/Device 로그인 성공 | `auth.login` | `metadata.channel`이 `browser/device/mcp` 중 하나로 기록 |
 | `audit-003` | Device 승인 | `auth.device_approved` | 승인 시 1회 기록, `metadata.client_id` + `metadata.client_name` 포함 (#205) |
 | `audit-004` | Device 거부 | `auth.device_denied` | 거부 시 1회 기록, `metadata.client_id` + `metadata.client_name` 포함 (#205) |
-| `audit-005` | DELETE /account | `auth.deletion_requested` | 삭제 요청 시 즉시 기록. `metadata.channel`, `session_id`, `client_id`, `client_name` 포함 (#211) |
+| `audit-005` | DELETE /account (`ENABLE_ACCOUNT_DELETION=true`) | `auth.deletion_requested` | 삭제 요청 시 즉시 기록. `metadata.channel`, `session_id`, `client_id`, `client_name` 포함 (#211) |
 | `audit-006` | pending_deletion Browser 복구 | `auth.deletion_cancelled` | 자동 복구 시 기록. `metadata.channel`, `session_id`, `client_id`, `client_name` 포함 (#211) |
 | `audit-007` | deletion cleanup 완료 | `auth.deletion_completed` | PII 스크러빙 완료 시 기록. `metadata.reason=pending_deletion_expired` 포함 (#211) |
 | `audit-008` | pending_deletion/disabled/deleted 로그인 시도 | `auth.inactive_user` | `metadata.status` 포함 |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -58,7 +58,7 @@ func Run() {
 	// Handler layer
 	loginHandler := handler.NewLoginHandler(loginService, browserProvider, cfg.DevMode, cfg.BrandName)
 	deviceHandler := handler.NewDeviceHandler(deviceService, deviceProvider, cfg.DevMode, cfg.BrandName)
-	accountHandler := handler.NewAccountHandler(accountService, cfg.PublicURL)
+	accountHandler := handler.NewAccountHandler(accountService, cfg.PublicURL, cfg.EnableAccountDeletion)
 
 	var mcpLoginHandler *handler.MCPLoginHandler
 	if cfg.EnableMCP {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	AuditLogPIIRetention    time.Duration
 	DevMode                 bool
 	EnableMCP               bool
+	EnableAccountDeletion   bool
 	ClientConfigPath        string
 	MigrationsPath          string
 	SigningKeyPath          string
@@ -85,6 +86,7 @@ func Load() (*Config, error) {
 		AuditLogPIIRetention:    time.Duration(envInt("AUDIT_LOG_PII_RETENTION_DAYS", 1095)) * 24 * time.Hour,
 		DevMode:                 envBool("DEV_MODE", false),
 		EnableMCP:               envBool("ENABLE_MCP", true),
+		EnableAccountDeletion:   envBool("ENABLE_ACCOUNT_DELETION", false),
 		ClientConfigPath:        envDefault("CLIENT_CONFIG", "/etc/authgate/clients.yaml"),
 		MigrationsPath:          envDefault("MIGRATIONS_PATH", "/migrations"),
 		SigningKeyPath:          envDefault("SIGNING_KEY_PATH", "signing_key.pem"),
@@ -208,7 +210,7 @@ func validateParseableEnv() error {
 			}
 		}
 	}
-	for _, key := range []string{"DEV_MODE", "ENABLE_MCP"} {
+	for _, key := range []string{"DEV_MODE", "ENABLE_MCP", "ENABLE_ACCOUNT_DELETION"} {
 		if v := os.Getenv(key); v != "" {
 			if _, err := strconv.ParseBool(v); err != nil {
 				return fmt.Errorf("%s must be a boolean", key)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,7 +13,7 @@ func clearEnv() {
 		"OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET",
 		"OIDC_HTTP_TIMEOUT_SEC",
 		"SESSION_TTL", "ACCESS_TOKEN_TTL", "REFRESH_TOKEN_TTL", "AUDIT_LOG_PII_RETENTION_DAYS",
-		"DEV_MODE", "ENABLE_MCP",
+		"DEV_MODE", "ENABLE_MCP", "ENABLE_ACCOUNT_DELETION",
 		"SIGNING_KEY_PATH",
 		"DB_MAX_OPEN_CONNS", "DB_MAX_IDLE_CONNS",
 		"DB_CONN_MAX_LIFETIME_SEC", "DB_CONN_MAX_IDLE_TIME_SEC",
@@ -154,6 +154,9 @@ func TestLoad_Defaults(t *testing.T) {
 	if !cfg.EnableMCP {
 		t.Error("EnableMCP = false, want true by default")
 	}
+	if cfg.EnableAccountDeletion {
+		t.Error("EnableAccountDeletion = true, want false by default")
+	}
 	if cfg.HTTPReadHeaderTimeout.Seconds() != 5 {
 		t.Errorf("HTTPReadHeaderTimeout = %v, want 5s", cfg.HTTPReadHeaderTimeout)
 	}
@@ -229,16 +232,20 @@ func TestLoad_InvalidNumericEnvFails(t *testing.T) {
 }
 
 func TestLoad_InvalidBoolEnvFails(t *testing.T) {
-	clearEnv()
-	setMinimal()
-	os.Setenv("ENABLE_MCP", "sometimes")
+	for _, key := range []string{"ENABLE_MCP", "ENABLE_ACCOUNT_DELETION"} {
+		t.Run(key, func(t *testing.T) {
+			clearEnv()
+			setMinimal()
+			os.Setenv(key, "sometimes")
 
-	_, err := Load()
-	if err == nil {
-		t.Fatal("expected error for invalid ENABLE_MCP")
-	}
-	if !strings.Contains(err.Error(), "ENABLE_MCP") {
-		t.Errorf("error = %v, want one mentioning ENABLE_MCP", err)
+			_, err := Load()
+			if err == nil {
+				t.Fatalf("expected error for invalid %s", key)
+			}
+			if !strings.Contains(err.Error(), key) {
+				t.Errorf("error = %v, want one mentioning %s", err, key)
+			}
+		})
 	}
 }
 
@@ -354,6 +361,20 @@ func TestLoad_EnableMCPFalse(t *testing.T) {
 	}
 	if cfg.EnableMCP {
 		t.Fatal("EnableMCP should be false")
+	}
+}
+
+func TestLoad_EnableAccountDeletionTrue(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("ENABLE_ACCOUNT_DELETION", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.EnableAccountDeletion {
+		t.Fatal("EnableAccountDeletion should be true")
 	}
 }
 

--- a/internal/handler/account.go
+++ b/internal/handler/account.go
@@ -9,18 +9,30 @@ import (
 )
 
 type AccountHandler struct {
-	accountService *service.AccountService
-	publicURL      string
+	accountService         *service.AccountService
+	publicURL              string
+	accountDeletionEnabled bool
 }
 
-func NewAccountHandler(accountService *service.AccountService, publicURL string) *AccountHandler {
-	return &AccountHandler{accountService: accountService, publicURL: publicURL}
+func NewAccountHandler(accountService *service.AccountService, publicURL string, accountDeletionEnabled ...bool) *AccountHandler {
+	enabled := true
+	if len(accountDeletionEnabled) > 0 {
+		enabled = accountDeletionEnabled[0]
+	}
+	return &AccountHandler{accountService: accountService, publicURL: publicURL, accountDeletionEnabled: enabled}
 }
 
 // HandleDeleteAccount handles DELETE /account
 func (h *AccountHandler) HandleDeleteAccount(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
 		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	if !h.accountDeletionEnabled {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "account deletion disabled"})
 		return
 	}
 

--- a/internal/handler/account_test.go
+++ b/internal/handler/account_test.go
@@ -30,6 +30,26 @@ func TestDeleteAccount_NonDelete_MethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestDeleteAccount_Disabled_ReturnsNotFoundBeforeOriginCheck(t *testing.T) {
+	h := NewAccountHandler(nil, "http://authgate.example.com", false)
+	req := httptest.NewRequest(http.MethodDelete, "/account", nil)
+	req.Header.Set("Origin", "http://evil.example.com")
+	w := httptest.NewRecorder()
+
+	h.HandleDeleteAccount(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+	if body["error"] != "account deletion disabled" {
+		t.Fatalf("error = %q, want account deletion disabled", body["error"])
+	}
+}
+
 // ── Origin guard ──────────────────────────────────────────────────────────────
 
 // Origin이 publicURL과 다르면 403 + JSON error body를 반환해야 한다.


### PR DESCRIPTION
## Summary
- Add `ENABLE_ACCOUNT_DELETION` config with a default of `false`.
- Return `404 {"error":"account deletion disabled"}` from `DELETE /account` unless the feature is explicitly enabled.
- Keep the existing Origin/session deletion safeguards for deployments that opt in.
- Update README/spec/test docs and add config/handler coverage.

## Why
Authgate account deletion is global across connected clients. Keeping self-service deletion disabled by default prevents a connected service from accidentally triggering whole-account deletion before an Authgate-owned confirmation UX and operating policy are ready.

## Validation
- `go test ./...`
- `go test -tags=integration ./internal/... -run '^$'`
- `git diff --check`
