### PR TITLE
fix(op): rebind id_token at_hash after access_token typ rewrite

### DIFF
--- a/docs/spec/005-token-lifecycle.md
+++ b/docs/spec/005-token-lifecycle.md
@@ -29,6 +29,19 @@ authgate가 발급한 토큰의 갱신, 검증, 폐기 흐름.
 | id_token | JWT (RS256) | 1시간 | 사용자 식별 확인 | 안 함 |
 | refresh_token | opaque (UUID) | 30일 (REFRESH_TOKEN_TTL) | access_token 갱신 | SHA-256 해시로 저장 |
 
+### JWT 프로파일 (at+jwt) 와 at_hash 바인딩
+
+zitadel 라이브러리는 access_token·id_token을 모두 `typ=JWT`로 서명한다.
+RFC 9068 §2.1은 JWT access_token이 `typ=at+jwt`를 갖도록 요구하므로,
+`/oauth/token` 응답은 미들웨어(`storage.WrapAccessTokenJWTType`)에서
+access_token을 `typ=at+jwt`로 **재서명**한다 (id_token은 `typ=JWT` 유지).
+
+access_token 문자열이 재서명으로 바뀌면 id_token의 `at_hash`
+(OIDC Core 1.0 §3.1.3.6, access_token 문자열에 종속)가 옛 값으로 남는다.
+따라서 미들웨어는 재서명된 access_token으로 `at_hash`를 다시 계산해
+**id_token도 재서명**한다. 이로써 엄격한 OIDC 클라이언트의 at_hash 검증을
+통과한다. id_token에 `at_hash`가 없으면 재서명하지 않는다.
+
 ## 토큰 갱신 (Refresh)
 
 ```mermaid

--- a/internal/integration/integration_at_jwt_test.go
+++ b/internal/integration/integration_at_jwt_test.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+
 	"github.com/kangheeyong/authgate/internal/storage"
 )
 
@@ -116,6 +119,123 @@ func TestDeviceGrant_AccessTokenTypIsAtJWT(t *testing.T) {
 	if got := jwtTyp(t, "device-grant access_token", result.AccessToken); got != "at+jwt" {
 		t.Errorf("device-grant access_token typ = %q, want at+jwt", got)
 	}
+}
+
+// #265-followup: the access_token is re-signed (typ=at+jwt) after zitadel
+// computes the id_token's at_hash over the original token string. If the
+// id_token isn't re-bound, at_hash hashes the stale token and strict OIDC
+// clients (OIDC Core 1.0 §3.1.3.6) reject the response on at_hash mismatch.
+func TestIDTokenAtHashMatchesRewrittenAccessToken(t *testing.T) {
+	ts := SetupTestServer(t)
+	ctx := context.Background()
+
+	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
+		Email: "athash@test.com", EmailVerified: true, Name: "AT Hash",
+		Provider: "google", ProviderUserID: "test-google-sub",
+	}); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	client := NewOAuthClient(t, ts.BaseURL)
+	code := completeLoginFlowToCode(t, ts, client)
+	tokens := client.ExchangeCode(code)
+	if tokens.StatusCode != http.StatusOK {
+		t.Fatalf("token exchange failed: status=%d body=%s", tokens.StatusCode, tokens.RawBody)
+	}
+
+	assertAtHashBinds(t, tokens.IDToken, tokens.AccessToken)
+}
+
+// TestRefreshGrant_IDTokenAtHashMatches guards the same invariant on the
+// refresh_token grant, which also returns an id_token through the rewrite.
+func TestRefreshGrant_IDTokenAtHashMatches(t *testing.T) {
+	ts := SetupTestServer(t)
+	ctx := context.Background()
+
+	if _, err := ts.Store.CreateUserWithIdentity(ctx, storage.CreateUserWithIdentityInput{
+		Email: "athash-refresh@test.com", EmailVerified: true, Name: "AT Hash Refresh",
+		Provider: "google", ProviderUserID: "test-google-sub",
+	}); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	client := NewOAuthClient(t, ts.BaseURL)
+	code := completeLoginFlowToCode(t, ts, client)
+	first := client.ExchangeCode(code)
+	if first.StatusCode != http.StatusOK || first.RefreshToken == "" {
+		t.Fatalf("first exchange: status=%d body=%s", first.StatusCode, first.RawBody)
+	}
+
+	refreshed := client.RefreshToken(first.RefreshToken)
+	if refreshed.StatusCode != http.StatusOK {
+		t.Fatalf("refresh: status=%d body=%s", refreshed.StatusCode, refreshed.RawBody)
+	}
+	if refreshed.IDToken == "" {
+		t.Skip("refresh response carried no id_token; nothing to bind")
+	}
+	assertAtHashBinds(t, refreshed.IDToken, refreshed.AccessToken)
+}
+
+// assertAtHashBinds fails unless the id_token carries an at_hash claim that
+// equals oidc.ClaimHash(accessToken) under the id_token's signing alg.
+func assertAtHashBinds(t *testing.T, idToken, accessToken string) {
+	t.Helper()
+	if idToken == "" || accessToken == "" {
+		t.Fatalf("missing tokens: id_token empty=%v access_token empty=%v", idToken == "", accessToken == "")
+	}
+
+	alg := jose.SignatureAlgorithm(jwtAlg(t, idToken))
+	want, err := oidc.ClaimHash(accessToken, alg)
+	if err != nil {
+		t.Fatalf("compute expected at_hash: %v", err)
+	}
+
+	claims := jwtPayloadMap(t, idToken)
+	got, ok := claims["at_hash"].(string)
+	if !ok {
+		t.Fatalf("id_token has no at_hash claim (claims: %v)", claims)
+	}
+	if got != want {
+		t.Errorf("id_token at_hash = %q, want %q (must bind the rewritten access_token)", got, want)
+	}
+}
+
+// jwtAlg returns the alg JOSE header of a compact JWS.
+func jwtAlg(t *testing.T, token string) string {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("token is not a compact JWS (got %d segments)", len(parts))
+	}
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("decode header: %v", err)
+	}
+	var header struct {
+		Alg string `json:"alg"`
+	}
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		t.Fatalf("parse header: %v", err)
+	}
+	return header.Alg
+}
+
+// jwtPayloadMap decodes and returns the payload claims of a compact JWS.
+func jwtPayloadMap(t *testing.T, token string) map[string]any {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("token is not a compact JWS (got %d segments)", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	return claims
 }
 
 // jwtTyp decodes the JOSE header of a compact JWS and returns the typ

--- a/internal/storage/access_token_typ.go
+++ b/internal/storage/access_token_typ.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	jose "github.com/go-jose/go-jose/v4"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"github.com/zitadel/oidc/v3/pkg/op"
 )
 
 // WrapAccessTokenJWTType wraps the OIDC token endpoint and normalizes the
@@ -23,8 +25,11 @@ import (
 // exposes no public hook to override this for a single token type. This
 // middleware captures the JSON response on the way out, re-signs the
 // access_token JWT with our same key but the correct profile typ, and
-// passes the response on. The id_token is left untouched per OIDC Core
-// 1.0 (§2 keeps `typ=JWT` for id_tokens).
+// passes the response on. The id_token keeps `typ=JWT` per OIDC Core 1.0
+// (§2), but because re-signing the access_token changes its string and the
+// id_token's `at_hash` is bound to that string (§3.1.3.6), the id_token is
+// re-signed with a recomputed `at_hash` so strict OIDC clients don't reject
+// the response.
 //
 // On any error during the rewrite, the original response body is
 // preserved unchanged so the rewrite cannot make the endpoint less
@@ -117,21 +122,7 @@ func upgradeAccessTokenTyp(ctx context.Context, store *Storage, body []byte) ([]
 	if err != nil {
 		return nil, err
 	}
-	signer, err := jose.NewSigner(jose.SigningKey{
-		Algorithm: sk.SignatureAlgorithm(),
-		Key: &jose.JSONWebKey{
-			Key:   sk.Key(),
-			KeyID: sk.ID(),
-		},
-	}, (&jose.SignerOptions{}).WithType("at+jwt"))
-	if err != nil {
-		return nil, err
-	}
-	signed, err := signer.Sign(payload)
-	if err != nil {
-		return nil, err
-	}
-	rewritten, err := signed.CompactSerialize()
+	rewritten, err := signJWS(sk, payload, "at+jwt")
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +132,88 @@ func upgradeAccessTokenTyp(ctx context.Context, store *Storage, body []byte) ([]
 		return nil, err
 	}
 	resp["access_token"] = encoded
+
+	// Re-signing the access_token changed its string, so the id_token's
+	// at_hash (which zitadel computed over the pre-rewrite token) is stale.
+	// Recompute it over the rewritten token and re-sign the id_token, else
+	// strict OIDC clients reject the response on at_hash mismatch.
+	if err := rebindIDTokenAtHash(sk, resp, rewritten); err != nil {
+		return nil, err
+	}
+
 	return json.Marshal(resp)
+}
+
+// rebindIDTokenAtHash recomputes the id_token's at_hash claim against the
+// rewritten access_token and re-signs the id_token (preserving typ=JWT and
+// every other claim). It is a no-op when the response has no id_token or the
+// id_token carries no at_hash claim. The body is only mutated on success.
+func rebindIDTokenAtHash(sk op.SigningKey, resp map[string]json.RawMessage, accessToken string) error {
+	rawIDT, ok := resp["id_token"]
+	if !ok {
+		return nil
+	}
+	var idToken string
+	if err := json.Unmarshal(rawIDT, &idToken); err != nil {
+		return err
+	}
+	parts := strings.Split(idToken, ".")
+	if len(parts) != 3 {
+		return nil
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return err
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return err
+	}
+	if _, ok := claims["at_hash"]; !ok {
+		return nil
+	}
+
+	atHash, err := oidc.ClaimHash(accessToken, sk.SignatureAlgorithm())
+	if err != nil {
+		return err
+	}
+	claims["at_hash"] = atHash
+
+	repacked, err := json.Marshal(claims)
+	if err != nil {
+		return err
+	}
+	resigned, err := signJWS(sk, repacked, "JWT")
+	if err != nil {
+		return err
+	}
+	encoded, err := json.Marshal(resigned)
+	if err != nil {
+		return err
+	}
+	resp["id_token"] = encoded
+	return nil
+}
+
+// signJWS signs a JWT payload with the storage signing key under the given
+// JOSE typ header and returns the compact serialization.
+func signJWS(sk op.SigningKey, payload []byte, typ string) (string, error) {
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: sk.SignatureAlgorithm(),
+		Key: &jose.JSONWebKey{
+			Key:   sk.Key(),
+			KeyID: sk.ID(),
+		},
+	}, (&jose.SignerOptions{}).WithType(jose.ContentType(typ)))
+	if err != nil {
+		return "", err
+	}
+	signed, err := signer.Sign(payload)
+	if err != nil {
+		return "", err
+	}
+	return signed.CompactSerialize()
 }
 
 func withScopeClaim(payload []byte, tokenResponse map[string]json.RawMessage) ([]byte, error) {


### PR DESCRIPTION
## Summary

A strict OIDC client (Rust `openidconnect`) was rejecting authgate's token response on an `at_hash` mismatch. Root cause is an authgate bug, not client pedantry.

- zitadel's signer hardcodes `typ=JWT` for both access_token and id_token with no per-type override (`op/signer.go`), so authgate post-processes the `/oauth/token` response to re-sign the access_token as `typ=at+jwt` per RFC 9068 (`storage.WrapAccessTokenJWTType`).
- zitadel computes the id_token's `at_hash` over the **pre-rewrite** access_token (`op/token.go` `CreateIDToken`).
- The rewrite changes the access_token string, leaving `at_hash` bound to the old token. Per OIDC Core 1.0 §3.1.3.6 a client that verifies `at_hash` (when present) correctly rejects the response.

## Fix

In the same middleware, after re-signing the access_token, recompute `at_hash` over the rewritten token and re-sign the id_token (preserving `typ=JWT` and every other claim). No-op when the id_token has no `at_hash`. This keeps both RFC 9068 (`at+jwt`) and the `at_hash` integrity binding without forking zitadel.

Applies to code, refresh, and device grants wherever an id_token with `at_hash` is returned.

## Tests

- New integration tests assert `id_token.at_hash == ClaimHash(received access_token)` for the code-exchange and refresh grants (`internal/integration/integration_at_jwt_test.go`).
- Verified the new test **fails without the fix** (at_hash = old token) and passes with it.
- Existing typ-separation tests (`at+jwt` vs `JWT`) still pass.

## Test plan

- [x] `go test ./...`
- [x] `go test -tags=integration ./internal/integration/ -run 'AtHash|AtJWT|IDTokenAtHash'`
- [x] Negative check: at_hash test fails on `main`, passes on this branch
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)