### PR TITLE
[codex] add slack audit notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,19 @@ go run ./cmd/authgate
 | `ENABLE_MCP` | `true` | enable MCP optional adapter routes/policies (`/mcp/*`, CIMD/resource binding) |
 | `ENABLE_ACCOUNT_DELETION` | `false` | enable self-service account deletion via `DELETE /account`; keep disabled unless Authgate-owned confirmation UX/policy is ready |
 | `CLIENT_CONFIG` | `/etc/authgate/clients.yaml` | YAML path for client metadata preload |
+| `SLACK_NOTIFICATIONS_ENABLED` | `false` | Enables Slack webhook delivery for selected audit events via the notification outbox. |
+| `SLACK_WEBHOOK_URL` | empty | Slack incoming webhook URL. Required when Slack notifications or weekly reports are enabled. |
+| `SLACK_IMMEDIATE_EVENTS` | `auth.signup,auth.deletion_requested,auth.refresh_reuse_detected` | Comma-separated audit event types that should enqueue immediate Slack notifications. |
+| `SLACK_WEEKLY_REPORT_ENABLED` | `false` | Enables the weekly Slack report worker. |
+| `SLACK_WORKER_INTERVAL_SEC` | `60` | Notification worker polling interval. Every pod starts the worker; Postgres advisory locks ensure one active sender per tick. |
+| `SLACK_WEEKLY_REPORT_WEEKDAY` | `MONDAY` | Weekday for the weekly report schedule. |
+| `SLACK_WEEKLY_REPORT_HOUR` | `9` | Local hour (`0`-`23`) for the weekly report schedule. |
+| `SLACK_REPORT_TIMEZONE` | `Asia/Seoul` | IANA timezone used to calculate the weekly report period boundary. |
+| `SLACK_REPORT_LOOKBACK_HOURS` | `168` | Time window included in the weekly report. |
 
 `ENABLE_MCP=false`일 때는 `clients.yaml`의 `login_channel: mcp` 클라이언트가 허용되지 않으며 서버 시작 시 실패합니다.
+
+Slack notifications are isolated behind `notification_outbox` and `notification_report_runs`. The outbox worker uses PostgreSQL advisory locks for multi-pod single-sender behavior, while report run rows prevent duplicate weekly reports after pod restarts.
 
 Production guards when `DEV_MODE=false`:
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,20 @@
+# Architecture Notes
+
+이 디렉토리는 authgate 내부 패키지 경계와 책임 변경을 기록한다.
+
+## Notification Package
+
+`internal/notification`은 Slack 알림과 주간 리포트를 소유한다.
+
+책임:
+- 선택된 `audit_log` 이벤트를 `notification_outbox`에 적재
+- PostgreSQL advisory lock으로 멀티 replica 단일 sender 실행
+- Slack incoming webhook 전송 및 실패 재시도 상태 관리
+- `notification_report_runs`로 주간 리포트 중복 발송 방지
+
+비책임:
+- 인증/인가 결정
+- audit event의 source-of-truth 역할
+- Prometheus/Alertmanager 기반 장애 알림
+
+`internal/storage`는 Slack을 import하지 않는다. storage는 `AuditHook` 인터페이스만 제공하고, app wiring에서 notification enqueuer를 주입한다. Slack 알림을 제거하려면 app wiring, `internal/notification`, notification 마이그레이션만 제거하면 인증 도메인 로직은 남는다.

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -15,6 +15,7 @@ authgate를 처음 배포할 때 필요한 것:
    → 마이그레이션은 authgate가 시작 시 자동 실행
      (golang-migrate, migrations/*.up.sql 순차 적용, schema_migrations 테이블로 상태 추적)
      여러 replica가 동시에 시작해도 Postgres advisory lock으로 안전
+   → notification outbox/report run 테이블도 같은 마이그레이션 경로로 생성됨
 
 2. OIDC IdP 자격증명 발급
    → IdP(예: Google Cloud Console)에서 OAuth 2.0 Client ID/Secret 생성
@@ -79,9 +80,44 @@ authgate를 처음 배포할 때 필요한 것:
 | `RATE_LIMIT_TOKEN_BURST` | X | `60` | 토큰 엔드포인트 버스트 허용 요청 수 (최솟값: 1) |
 | `RATE_LIMIT_AUTH_RPS` | X | `10` | 인증/계정 엔드포인트 (`/authorize`, `/login`, `/login/callback`, `/mcp/*`, `/account`, `/device`, `/device/auth/callback`) 초당 허용 요청 수 |
 | `RATE_LIMIT_AUTH_BURST` | X | `20` | 인증 엔드포인트 버스트 허용 요청 수 (최솟값: 1) |
+| `SLACK_NOTIFICATIONS_ENABLED` | X | `false` | Slack webhook 즉시 알림 활성화. 활성화 시 선택된 audit event가 `notification_outbox`에 적재되고 notification worker가 전송 |
+| `SLACK_WEBHOOK_URL` | X | — | Slack incoming webhook URL. `SLACK_NOTIFICATIONS_ENABLED=true` 또는 `SLACK_WEEKLY_REPORT_ENABLED=true`일 때 필수 |
+| `SLACK_IMMEDIATE_EVENTS` | X | `auth.signup,auth.deletion_requested,auth.refresh_reuse_detected` | 즉시 Slack 알림 대상으로 삼을 audit event 목록 |
+| `SLACK_WEEKLY_REPORT_ENABLED` | X | `false` | 주간 Slack 운영 리포트 활성화 |
+| `SLACK_WORKER_INTERVAL_SEC` | X | `60` | notification worker polling 간격. 모든 replica가 worker를 시작하지만 Postgres advisory lock을 잡은 replica만 전송 |
+| `SLACK_WEEKLY_REPORT_WEEKDAY` | X | `MONDAY` | 주간 리포트 기준 요일 (`MONDAY` 또는 `MON` 형식 허용) |
+| `SLACK_WEEKLY_REPORT_HOUR` | X | `9` | `SLACK_REPORT_TIMEZONE` 기준 리포트 기준 시각 (`0`-`23`) |
+| `SLACK_REPORT_TIMEZONE` | X | `Asia/Seoul` | 주간 리포트 period boundary 계산에 사용할 IANA timezone |
+| `SLACK_REPORT_LOOKBACK_HOURS` | X | `168` | 주간 리포트 집계 기간 |
 | `TRUSTED_PROXIES` | X | — | 프록시 hop으로 신뢰할 CIDR 목록 (콤마 구분). 직전 hop이 이 범위에 속할 때만 클라이언트 IP 추정에 (1) `X-Envoy-External-Address` 헤더 (envoy/istio 가 직접 계산하므로 spoof 불가), (2) `X-Forwarded-For` rightmost-untrusted walk 폴백을 사용한다. 비워두면 모든 프록시 헤더 무시. 예: `10.244.0.0/16,127.0.0.1/32`. istio ingressgateway 등 reverse proxy 뒤에서 운영할 때만 설정. |
 
 `ENABLE_MCP=false`인 경우 `clients.yaml`에 `login_channel: mcp` 항목이 있으면 서버 시작을 거부한다.
+
+### Slack 알림 운영
+
+Slack 알림은 인증 요청 path에서 직접 webhook을 호출하지 않는다.
+
+```text
+AuditLog(selected event)
+  → notification_outbox insert
+  → notification worker가 Slack webhook 전송
+  → sent_at / attempt_count / last_error 기록
+```
+
+즉시 알림 기본 대상:
+- `auth.signup`
+- `auth.deletion_requested`
+- `auth.refresh_reuse_detected`
+
+주간 리포트는 `users`와 `audit_log`에서 집계한다:
+- 전체/active 사용자 수
+- 기간 내 가입/삭제 요청/삭제 완료 수
+- channel별 로그인 수
+- refresh token reuse / channel mismatch 수
+
+멀티 replica에서는 모든 replica가 notification worker를 시작해도 된다. worker는 실행 tick마다 PostgreSQL advisory lock을 획득한 replica만 outbox/reports를 처리한다. 주간 리포트는 `notification_report_runs`의 `(report_type, period_start, period_end)` unique key로 파드 재시작 후 중복 발송을 방지한다.
+
+Slack webhook은 idempotency key를 지원하지 않으므로, 전송 성공 후 DB 업데이트가 실패하는 극단적 경우에는 중복 메시지가 발생할 수 있다. 운영 보장 수준은 at-least-once + DB 상태 기반 중복 최소화다.
 
 ### 프로덕션 필수 조건
 

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -41,9 +41,10 @@
 문서 = 테스트 설계
 코드 = internal/*_test.go
 
-- config/clock/idgen 일부는 일반 unit test로 바로 실행 가능
-- service/storage/integration 테스트 다수는 `//go:build integration`
-- integration 테스트는 testcontainers-go를 사용하므로 Docker 접근 권한이 필요
+	- config/clock/idgen 일부는 일반 unit test로 바로 실행 가능
+	- notification unit test는 Slack webhook client의 429 handling과 report period 계산/메시지 포맷을 검증
+	- service/storage/integration 테스트 다수는 `//go:build integration`
+	- integration 테스트는 testcontainers-go를 사용하므로 Docker 접근 권한이 필요
 ```
 
 ## 테스트 원칙
@@ -53,3 +54,4 @@
 3. Browser / Device / MCP / Refresh는 서로 다른 구현이 아니라 **동일 상태기계의 다른 진입점**으로 검증한다.
 4. `pending_deletion`은 Browser에서만 복구 가능함을 반드시 검증한다.
 5. `deleted`는 종단 상태이며, 재가입은 반드시 신규 가입으로 다시 시작해야 한다.
+6. 운영 알림 테스트는 Slack 외부 서비스에 의존하지 않고 `httptest.Server`와 고정 시간 계산으로 검증한다.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kangheeyong/authgate/internal/handler"
 	"github.com/kangheeyong/authgate/internal/idgen"
 	"github.com/kangheeyong/authgate/internal/middleware"
+	"github.com/kangheeyong/authgate/internal/notification"
 	"github.com/kangheeyong/authgate/internal/service"
 )
 
@@ -38,6 +39,8 @@ func Run() {
 	clk := clock.RealClock{}
 	gen := idgen.CryptoGenerator{}
 	store := mustBuildStore(cfg, db, clk, gen)
+	notificationStore := notification.NewStore(db, clk)
+	configureSlackAuditHook(cfg, store, notificationStore)
 	provider := mustBuildOIDCProvider(cfg, store)
 
 	// Upstream IdP (OIDC Discovery)
@@ -92,11 +95,13 @@ func Run() {
 
 	cleanupCancel := startCleanupService(db, clk, cfg.AuditLogPIIRetention)
 	metricsCancel := startMetricsServer(cfg)
+	notificationCancel := startNotificationService(cfg, notificationStore)
 	var stopOnce sync.Once
 	stopBackground := func() {
 		stopOnce.Do(func() {
 			cleanupCancel()
 			metricsCancel()
+			notificationCancel()
 		})
 	}
 	defer stopBackground()

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kangheeyong/authgate/internal/clock"
 	"github.com/kangheeyong/authgate/internal/config"
+	"github.com/kangheeyong/authgate/internal/notification"
 	"github.com/kangheeyong/authgate/internal/service"
 	"github.com/kangheeyong/authgate/internal/storage"
 	"github.com/kangheeyong/authgate/internal/telemetry"
@@ -78,6 +79,33 @@ func startMetricsServer(cfg *config.Config) context.CancelFunc {
 			slog.Error("metrics server shutdown failed", "error", err)
 		}
 	}
+}
+
+func startNotificationService(cfg *config.Config, store *notification.Store) context.CancelFunc {
+	if !cfg.SlackNotificationsEnabled && !cfg.SlackWeeklyReportEnabled {
+		return func() {}
+	}
+	loc, err := time.LoadLocation(cfg.SlackReportTimezone)
+	if err != nil {
+		log.Fatalf("notification config: report timezone: %v", err)
+	}
+	worker := notification.NewWorker(
+		store,
+		notification.NewSlackClient(cfg.SlackWebhookURL, nil),
+		notification.WorkerConfig{
+			OutboxEnabled:        cfg.SlackNotificationsEnabled,
+			WeeklyReportEnabled:  cfg.SlackWeeklyReportEnabled,
+			Interval:             cfg.SlackWorkerInterval,
+			ReportWeekday:        cfg.SlackWeeklyReportWeekday,
+			ReportHour:           cfg.SlackWeeklyReportHour,
+			ReportLocation:       loc,
+			ReportLookback:       cfg.SlackReportLookback,
+			InterMessageInterval: time.Second,
+		},
+	)
+	notificationCtx, notificationCancel := context.WithCancel(context.Background())
+	go worker.Start(notificationCtx)
+	return notificationCancel
 }
 
 func installGracefulShutdown(srv *http.Server, cfg *config.Config, inflightRequests *int64, cleanupCancel context.CancelFunc, isShuttingDown *atomic.Bool) {

--- a/internal/app/storage_wiring.go
+++ b/internal/app/storage_wiring.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kangheeyong/authgate/internal/config"
 	"github.com/kangheeyong/authgate/internal/idgen"
 	"github.com/kangheeyong/authgate/internal/middleware"
+	"github.com/kangheeyong/authgate/internal/notification"
 	"github.com/kangheeyong/authgate/internal/storage"
 )
 
@@ -75,4 +76,11 @@ func configureMCPPoliciesIfEnabled(cfg *config.Config, store *storage.Storage) {
 	clientPolicy := mcpadapter.NewClientResolutionPolicy(storage.NewCoreClientResolutionPolicy(store), cimdFetcher)
 	store.SetClientResolutionPolicy(clientPolicy)
 	store.SetResourceBindingPolicy(mcpadapter.NewResourceBindingPolicy(storage.NewCoreResourceBindingPolicy(), clientPolicy))
+}
+
+func configureSlackAuditHook(cfg *config.Config, store *storage.Storage, notificationStore *notification.Store) {
+	if !cfg.SlackNotificationsEnabled {
+		return
+	}
+	store.SetAuditHook(notification.NewAuditEnqueuer(notificationStore, cfg.SlackImmediateEvents, true))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,32 +28,41 @@ type Config struct {
 	// compatibility, but operators are encouraged to set this in production to
 	// fail-fast on misconfigured/compromised env vars that would otherwise
 	// redirect every login through an attacker-controlled IdP.
-	OIDCIssuerHostAllowlist []string
-	OIDCInternalURL         string // optional: internal base URL for server-to-server OIDC calls (Docker/K8s)
-	OIDCHTTPTimeout         time.Duration
-	OIDCClientID            string
-	OIDCClientSecret        string
-	SessionTTL              time.Duration
-	AccessTokenTTL          time.Duration
-	RefreshTokenTTL         time.Duration
-	AuditLogPIIRetention    time.Duration
-	DevMode                 bool
-	EnableMCP               bool
-	EnableAccountDeletion   bool
-	ClientConfigPath        string
-	MigrationsPath          string
-	SigningKeyPath          string
-	BrandName               string
-	HTTPReadHeaderTimeout   time.Duration
-	HTTPReadTimeout         time.Duration
-	HTTPWriteTimeout        time.Duration
-	HTTPIdleTimeout         time.Duration
-	ShutdownTimeout         time.Duration
-	MetricsAddr             string
-	RateLimitTokenRPS       float64
-	RateLimitTokenBurst     int
-	RateLimitAuthRPS        float64
-	RateLimitAuthBurst      int
+	OIDCIssuerHostAllowlist   []string
+	OIDCInternalURL           string // optional: internal base URL for server-to-server OIDC calls (Docker/K8s)
+	OIDCHTTPTimeout           time.Duration
+	OIDCClientID              string
+	OIDCClientSecret          string
+	SessionTTL                time.Duration
+	AccessTokenTTL            time.Duration
+	RefreshTokenTTL           time.Duration
+	AuditLogPIIRetention      time.Duration
+	DevMode                   bool
+	EnableMCP                 bool
+	EnableAccountDeletion     bool
+	ClientConfigPath          string
+	MigrationsPath            string
+	SigningKeyPath            string
+	BrandName                 string
+	HTTPReadHeaderTimeout     time.Duration
+	HTTPReadTimeout           time.Duration
+	HTTPWriteTimeout          time.Duration
+	HTTPIdleTimeout           time.Duration
+	ShutdownTimeout           time.Duration
+	MetricsAddr               string
+	RateLimitTokenRPS         float64
+	RateLimitTokenBurst       int
+	RateLimitAuthRPS          float64
+	RateLimitAuthBurst        int
+	SlackNotificationsEnabled bool
+	SlackWebhookURL           string
+	SlackImmediateEvents      []string
+	SlackWeeklyReportEnabled  bool
+	SlackWorkerInterval       time.Duration
+	SlackWeeklyReportWeekday  time.Weekday
+	SlackWeeklyReportHour     int
+	SlackReportTimezone       string
+	SlackReportLookback       time.Duration
 	// TrustedProxies is a comma-separated list of CIDRs whose source addresses
 	// are allowed to set X-Forwarded-For. Empty means no proxy is trusted —
 	// the safe default for a deployment without an explicitly configured edge.
@@ -66,42 +75,55 @@ func Load() (*Config, error) {
 	}
 
 	c := &Config{
-		Port:                    envInt("PORT", 8080),
-		DatabaseURL:             os.Getenv("DATABASE_URL"),
-		DBMaxOpenConns:          envInt("DB_MAX_OPEN_CONNS", 25),
-		DBMaxIdleConns:          envInt("DB_MAX_IDLE_CONNS", 25),
-		DBConnMaxLifetime:       time.Duration(envInt("DB_CONN_MAX_LIFETIME_SEC", 300)) * time.Second,
-		DBConnMaxIdleTime:       time.Duration(envInt("DB_CONN_MAX_IDLE_TIME_SEC", 120)) * time.Second,
-		SessionSecret:           os.Getenv("SESSION_SECRET"),
-		PublicURL:               os.Getenv("PUBLIC_URL"),
-		OIDCIssuerURL:           envDefault("OIDC_ISSUER_URL", "http://localhost:8082"),
-		OIDCIssuerHostAllowlist: envCommaList("OIDC_ISSUER_HOST_ALLOWLIST"),
-		OIDCInternalURL:         os.Getenv("OIDC_INTERNAL_URL"),
-		OIDCHTTPTimeout:         time.Duration(envInt("OIDC_HTTP_TIMEOUT_SEC", 10)) * time.Second,
-		OIDCClientID:            envDefault("OIDC_CLIENT_ID", "authgate"),
-		OIDCClientSecret:        os.Getenv("OIDC_CLIENT_SECRET"),
-		SessionTTL:              time.Duration(envInt("SESSION_TTL", 86400)) * time.Second,
-		AccessTokenTTL:          time.Duration(envInt("ACCESS_TOKEN_TTL", 900)) * time.Second,
-		RefreshTokenTTL:         time.Duration(envInt("REFRESH_TOKEN_TTL", 2592000)) * time.Second,
-		AuditLogPIIRetention:    time.Duration(envInt("AUDIT_LOG_PII_RETENTION_DAYS", 1095)) * 24 * time.Hour,
-		DevMode:                 envBool("DEV_MODE", false),
-		EnableMCP:               envBool("ENABLE_MCP", true),
-		EnableAccountDeletion:   envBool("ENABLE_ACCOUNT_DELETION", false),
-		ClientConfigPath:        envDefault("CLIENT_CONFIG", "/etc/authgate/clients.yaml"),
-		MigrationsPath:          envDefault("MIGRATIONS_PATH", "/migrations"),
-		SigningKeyPath:          envDefault("SIGNING_KEY_PATH", "signing_key.pem"),
-		BrandName:               envDefault("BRAND_NAME", "authgate"),
-		HTTPReadHeaderTimeout:   time.Duration(envInt("HTTP_READ_HEADER_TIMEOUT_SEC", 5)) * time.Second,
-		HTTPReadTimeout:         time.Duration(envInt("HTTP_READ_TIMEOUT_SEC", 15)) * time.Second,
-		HTTPWriteTimeout:        time.Duration(envInt("HTTP_WRITE_TIMEOUT_SEC", 30)) * time.Second,
-		HTTPIdleTimeout:         time.Duration(envInt("HTTP_IDLE_TIMEOUT_SEC", 60)) * time.Second,
-		ShutdownTimeout:         time.Duration(envInt("SHUTDOWN_TIMEOUT_SEC", 10)) * time.Second,
-		MetricsAddr:             os.Getenv("METRICS_ADDR"),
-		RateLimitTokenRPS:       envFloat("RATE_LIMIT_TOKEN_RPS", 30),
-		RateLimitTokenBurst:     envInt("RATE_LIMIT_TOKEN_BURST", 60),
-		RateLimitAuthRPS:        envFloat("RATE_LIMIT_AUTH_RPS", 10),
-		RateLimitAuthBurst:      envInt("RATE_LIMIT_AUTH_BURST", 20),
-		TrustedProxies:          os.Getenv("TRUSTED_PROXIES"),
+		Port:                      envInt("PORT", 8080),
+		DatabaseURL:               os.Getenv("DATABASE_URL"),
+		DBMaxOpenConns:            envInt("DB_MAX_OPEN_CONNS", 25),
+		DBMaxIdleConns:            envInt("DB_MAX_IDLE_CONNS", 25),
+		DBConnMaxLifetime:         time.Duration(envInt("DB_CONN_MAX_LIFETIME_SEC", 300)) * time.Second,
+		DBConnMaxIdleTime:         time.Duration(envInt("DB_CONN_MAX_IDLE_TIME_SEC", 120)) * time.Second,
+		SessionSecret:             os.Getenv("SESSION_SECRET"),
+		PublicURL:                 os.Getenv("PUBLIC_URL"),
+		OIDCIssuerURL:             envDefault("OIDC_ISSUER_URL", "http://localhost:8082"),
+		OIDCIssuerHostAllowlist:   envCommaList("OIDC_ISSUER_HOST_ALLOWLIST"),
+		OIDCInternalURL:           os.Getenv("OIDC_INTERNAL_URL"),
+		OIDCHTTPTimeout:           time.Duration(envInt("OIDC_HTTP_TIMEOUT_SEC", 10)) * time.Second,
+		OIDCClientID:              envDefault("OIDC_CLIENT_ID", "authgate"),
+		OIDCClientSecret:          os.Getenv("OIDC_CLIENT_SECRET"),
+		SessionTTL:                time.Duration(envInt("SESSION_TTL", 86400)) * time.Second,
+		AccessTokenTTL:            time.Duration(envInt("ACCESS_TOKEN_TTL", 900)) * time.Second,
+		RefreshTokenTTL:           time.Duration(envInt("REFRESH_TOKEN_TTL", 2592000)) * time.Second,
+		AuditLogPIIRetention:      time.Duration(envInt("AUDIT_LOG_PII_RETENTION_DAYS", 1095)) * 24 * time.Hour,
+		DevMode:                   envBool("DEV_MODE", false),
+		EnableMCP:                 envBool("ENABLE_MCP", true),
+		EnableAccountDeletion:     envBool("ENABLE_ACCOUNT_DELETION", false),
+		ClientConfigPath:          envDefault("CLIENT_CONFIG", "/etc/authgate/clients.yaml"),
+		MigrationsPath:            envDefault("MIGRATIONS_PATH", "/migrations"),
+		SigningKeyPath:            envDefault("SIGNING_KEY_PATH", "signing_key.pem"),
+		BrandName:                 envDefault("BRAND_NAME", "authgate"),
+		HTTPReadHeaderTimeout:     time.Duration(envInt("HTTP_READ_HEADER_TIMEOUT_SEC", 5)) * time.Second,
+		HTTPReadTimeout:           time.Duration(envInt("HTTP_READ_TIMEOUT_SEC", 15)) * time.Second,
+		HTTPWriteTimeout:          time.Duration(envInt("HTTP_WRITE_TIMEOUT_SEC", 30)) * time.Second,
+		HTTPIdleTimeout:           time.Duration(envInt("HTTP_IDLE_TIMEOUT_SEC", 60)) * time.Second,
+		ShutdownTimeout:           time.Duration(envInt("SHUTDOWN_TIMEOUT_SEC", 10)) * time.Second,
+		MetricsAddr:               os.Getenv("METRICS_ADDR"),
+		RateLimitTokenRPS:         envFloat("RATE_LIMIT_TOKEN_RPS", 30),
+		RateLimitTokenBurst:       envInt("RATE_LIMIT_TOKEN_BURST", 60),
+		RateLimitAuthRPS:          envFloat("RATE_LIMIT_AUTH_RPS", 10),
+		RateLimitAuthBurst:        envInt("RATE_LIMIT_AUTH_BURST", 20),
+		SlackNotificationsEnabled: envBool("SLACK_NOTIFICATIONS_ENABLED", false),
+		SlackWebhookURL:           os.Getenv("SLACK_WEBHOOK_URL"),
+		SlackImmediateEvents: envCommaListDefault("SLACK_IMMEDIATE_EVENTS", []string{
+			"auth.signup",
+			"auth.deletion_requested",
+			"auth.refresh_reuse_detected",
+		}),
+		SlackWeeklyReportEnabled: envBool("SLACK_WEEKLY_REPORT_ENABLED", false),
+		SlackWorkerInterval:      time.Duration(envInt("SLACK_WORKER_INTERVAL_SEC", 60)) * time.Second,
+		SlackWeeklyReportWeekday: envWeekday("SLACK_WEEKLY_REPORT_WEEKDAY", time.Monday),
+		SlackWeeklyReportHour:    envInt("SLACK_WEEKLY_REPORT_HOUR", 9),
+		SlackReportTimezone:      envDefault("SLACK_REPORT_TIMEZONE", "Asia/Seoul"),
+		SlackReportLookback:      time.Duration(envInt("SLACK_REPORT_LOOKBACK_HOURS", 168)) * time.Hour,
+		TrustedProxies:           os.Getenv("TRUSTED_PROXIES"),
 	}
 
 	if c.DatabaseURL == "" {
@@ -148,6 +170,21 @@ func Load() (*Config, error) {
 	}
 	if c.DBMaxOpenConns > 0 && c.DBMaxIdleConns > c.DBMaxOpenConns {
 		c.DBMaxIdleConns = c.DBMaxOpenConns
+	}
+	if (c.SlackNotificationsEnabled || c.SlackWeeklyReportEnabled) && c.SlackWebhookURL == "" {
+		return nil, fmt.Errorf("SLACK_WEBHOOK_URL is required when Slack notifications or reports are enabled")
+	}
+	if c.SlackWorkerInterval <= 0 {
+		return nil, fmt.Errorf("SLACK_WORKER_INTERVAL_SEC must be > 0")
+	}
+	if c.SlackWeeklyReportHour < 0 || c.SlackWeeklyReportHour > 23 {
+		return nil, fmt.Errorf("SLACK_WEEKLY_REPORT_HOUR must be between 0 and 23")
+	}
+	if c.SlackReportLookback <= 0 {
+		return nil, fmt.Errorf("SLACK_REPORT_LOOKBACK_HOURS must be > 0")
+	}
+	if _, err := time.LoadLocation(c.SlackReportTimezone); err != nil {
+		return nil, fmt.Errorf("SLACK_REPORT_TIMEZONE is invalid: %w", err)
 	}
 	if c.MetricsAddr != "" {
 		if _, _, err := net.SplitHostPort(c.MetricsAddr); err != nil {
@@ -203,6 +240,9 @@ func validateParseableEnv() error {
 		"SHUTDOWN_TIMEOUT_SEC",
 		"RATE_LIMIT_TOKEN_BURST",
 		"RATE_LIMIT_AUTH_BURST",
+		"SLACK_WORKER_INTERVAL_SEC",
+		"SLACK_WEEKLY_REPORT_HOUR",
+		"SLACK_REPORT_LOOKBACK_HOURS",
 	} {
 		if v := os.Getenv(key); v != "" {
 			if _, err := strconv.Atoi(v); err != nil {
@@ -210,7 +250,7 @@ func validateParseableEnv() error {
 			}
 		}
 	}
-	for _, key := range []string{"DEV_MODE", "ENABLE_MCP", "ENABLE_ACCOUNT_DELETION"} {
+	for _, key := range []string{"DEV_MODE", "ENABLE_MCP", "ENABLE_ACCOUNT_DELETION", "SLACK_NOTIFICATIONS_ENABLED", "SLACK_WEEKLY_REPORT_ENABLED"} {
 		if v := os.Getenv(key); v != "" {
 			if _, err := strconv.ParseBool(v); err != nil {
 				return fmt.Errorf("%s must be a boolean", key)
@@ -224,7 +264,20 @@ func validateParseableEnv() error {
 			}
 		}
 	}
+	if v := os.Getenv("SLACK_WEEKLY_REPORT_WEEKDAY"); v != "" {
+		if _, ok := parseWeekday(v); !ok {
+			return fmt.Errorf("SLACK_WEEKLY_REPORT_WEEKDAY must be a weekday name")
+		}
+	}
 	return nil
+}
+
+func envCommaListDefault(key string, fallback []string) []string {
+	values := envCommaList(key)
+	if values == nil {
+		return fallback
+	}
+	return values
 }
 
 func envDefault(key, fallback string) string {
@@ -286,4 +339,32 @@ func envFloat(key string, fallback float64) float64 {
 		return fallback
 	}
 	return f
+}
+
+func envWeekday(key string, fallback time.Weekday) time.Weekday {
+	if parsed, ok := parseWeekday(os.Getenv(key)); ok {
+		return parsed
+	}
+	return fallback
+}
+
+func parseWeekday(v string) (time.Weekday, bool) {
+	switch strings.TrimSpace(strings.ToUpper(v)) {
+	case "SUNDAY", "SUN":
+		return time.Sunday, true
+	case "MONDAY", "MON":
+		return time.Monday, true
+	case "TUESDAY", "TUE":
+		return time.Tuesday, true
+	case "WEDNESDAY", "WED":
+		return time.Wednesday, true
+	case "THURSDAY", "THU":
+		return time.Thursday, true
+	case "FRIDAY", "FRI":
+		return time.Friday, true
+	case "SATURDAY", "SAT":
+		return time.Saturday, true
+	default:
+		return 0, false
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,11 @@ func clearEnv() {
 		"HTTP_READ_HEADER_TIMEOUT_SEC", "HTTP_READ_TIMEOUT_SEC",
 		"HTTP_WRITE_TIMEOUT_SEC", "HTTP_IDLE_TIMEOUT_SEC",
 		"SHUTDOWN_TIMEOUT_SEC", "METRICS_ADDR",
+		"SLACK_NOTIFICATIONS_ENABLED", "SLACK_WEBHOOK_URL",
+		"SLACK_IMMEDIATE_EVENTS", "SLACK_WEEKLY_REPORT_ENABLED",
+		"SLACK_WORKER_INTERVAL_SEC", "SLACK_WEEKLY_REPORT_WEEKDAY",
+		"SLACK_WEEKLY_REPORT_HOUR", "SLACK_REPORT_TIMEZONE",
+		"SLACK_REPORT_LOOKBACK_HOURS",
 	} {
 		os.Unsetenv(key)
 	}
@@ -187,6 +192,30 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.DBConnMaxIdleTime.Seconds() != 120 {
 		t.Errorf("DBConnMaxIdleTime = %v, want 120s", cfg.DBConnMaxIdleTime)
 	}
+	if cfg.SlackNotificationsEnabled {
+		t.Error("SlackNotificationsEnabled = true, want false default")
+	}
+	if cfg.SlackWeeklyReportEnabled {
+		t.Error("SlackWeeklyReportEnabled = true, want false default")
+	}
+	if cfg.SlackWebhookURL != "" {
+		t.Errorf("SlackWebhookURL = %q, want empty default", cfg.SlackWebhookURL)
+	}
+	if cfg.SlackWorkerInterval.Seconds() != 60 {
+		t.Errorf("SlackWorkerInterval = %v, want 60s", cfg.SlackWorkerInterval)
+	}
+	if cfg.SlackWeeklyReportWeekday.String() != "Monday" {
+		t.Errorf("SlackWeeklyReportWeekday = %v, want Monday", cfg.SlackWeeklyReportWeekday)
+	}
+	if cfg.SlackWeeklyReportHour != 9 {
+		t.Errorf("SlackWeeklyReportHour = %d, want 9", cfg.SlackWeeklyReportHour)
+	}
+	if cfg.SlackReportTimezone != "Asia/Seoul" {
+		t.Errorf("SlackReportTimezone = %q, want Asia/Seoul", cfg.SlackReportTimezone)
+	}
+	if cfg.SlackReportLookback.Hours() != 168 {
+		t.Errorf("SlackReportLookback = %v, want 168h", cfg.SlackReportLookback)
+	}
 }
 
 func TestLoad_MetricsAddrOptIn(t *testing.T) {
@@ -232,7 +261,7 @@ func TestLoad_InvalidNumericEnvFails(t *testing.T) {
 }
 
 func TestLoad_InvalidBoolEnvFails(t *testing.T) {
-	for _, key := range []string{"ENABLE_MCP", "ENABLE_ACCOUNT_DELETION"} {
+	for _, key := range []string{"ENABLE_MCP", "ENABLE_ACCOUNT_DELETION", "SLACK_NOTIFICATIONS_ENABLED", "SLACK_WEEKLY_REPORT_ENABLED"} {
 		t.Run(key, func(t *testing.T) {
 			clearEnv()
 			setMinimal()
@@ -246,6 +275,60 @@ func TestLoad_InvalidBoolEnvFails(t *testing.T) {
 				t.Errorf("error = %v, want one mentioning %s", err, key)
 			}
 		})
+	}
+}
+
+func TestLoad_SlackEnabledRequiresWebhook(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("SLACK_NOTIFICATIONS_ENABLED", "true")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for Slack notifications without webhook URL")
+	}
+	if !strings.Contains(err.Error(), "SLACK_WEBHOOK_URL") {
+		t.Errorf("error = %v, want one mentioning SLACK_WEBHOOK_URL", err)
+	}
+}
+
+func TestLoad_SlackOptions(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("SLACK_NOTIFICATIONS_ENABLED", "true")
+	os.Setenv("SLACK_WEEKLY_REPORT_ENABLED", "true")
+	os.Setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/services/test")
+	os.Setenv("SLACK_IMMEDIATE_EVENTS", "auth.signup,auth.deletion_requested")
+	os.Setenv("SLACK_WORKER_INTERVAL_SEC", "30")
+	os.Setenv("SLACK_WEEKLY_REPORT_WEEKDAY", "FRI")
+	os.Setenv("SLACK_WEEKLY_REPORT_HOUR", "17")
+	os.Setenv("SLACK_REPORT_TIMEZONE", "UTC")
+	os.Setenv("SLACK_REPORT_LOOKBACK_HOURS", "24")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.SlackNotificationsEnabled || !cfg.SlackWeeklyReportEnabled {
+		t.Fatal("Slack flags not enabled")
+	}
+	if got := strings.Join(cfg.SlackImmediateEvents, ","); got != "auth.signup,auth.deletion_requested" {
+		t.Fatalf("SlackImmediateEvents = %q", got)
+	}
+	if cfg.SlackWorkerInterval.Seconds() != 30 {
+		t.Fatalf("SlackWorkerInterval = %v, want 30s", cfg.SlackWorkerInterval)
+	}
+	if cfg.SlackWeeklyReportWeekday.String() != "Friday" {
+		t.Fatalf("SlackWeeklyReportWeekday = %v, want Friday", cfg.SlackWeeklyReportWeekday)
+	}
+	if cfg.SlackWeeklyReportHour != 17 {
+		t.Fatalf("SlackWeeklyReportHour = %d, want 17", cfg.SlackWeeklyReportHour)
+	}
+	if cfg.SlackReportTimezone != "UTC" {
+		t.Fatalf("SlackReportTimezone = %q, want UTC", cfg.SlackReportTimezone)
+	}
+	if cfg.SlackReportLookback.Hours() != 24 {
+		t.Fatalf("SlackReportLookback = %v, want 24h", cfg.SlackReportLookback)
 	}
 }
 

--- a/internal/notification/audit.go
+++ b/internal/notification/audit.go
@@ -1,0 +1,39 @@
+package notification
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/kangheeyong/authgate/internal/storage"
+)
+
+type AuditEnqueuer struct {
+	store   *Store
+	events  map[string]struct{}
+	enabled bool
+}
+
+func NewAuditEnqueuer(store *Store, eventTypes []string, enabled bool) *AuditEnqueuer {
+	events := make(map[string]struct{}, len(eventTypes))
+	for _, eventType := range eventTypes {
+		if eventType != "" {
+			events[eventType] = struct{}{}
+		}
+	}
+	return &AuditEnqueuer{store: store, events: events, enabled: enabled}
+}
+
+func (e *AuditEnqueuer) OnAuditLog(ctx context.Context, event storage.AuditEvent) {
+	if !e.enabled {
+		return
+	}
+	if _, ok := e.events[event.EventType]; !ok {
+		return
+	}
+	if err := e.store.EnqueueAuditEvent(ctx, event); err != nil {
+		slog.ErrorContext(ctx, "notification outbox: enqueue audit event",
+			"event_type", event.EventType,
+			"error", err,
+		)
+	}
+}

--- a/internal/notification/format.go
+++ b/internal/notification/format.go
@@ -1,0 +1,106 @@
+package notification
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+func FormatOutboxEvent(event OutboxEvent) string {
+	switch event.EventType {
+	case "auth.signup":
+		return fmt.Sprintf("Authgate signup\nuser_id: %s\nclient: %s", emptyDash(event.UserID), clientLabel(event.Metadata))
+	case "auth.deletion_requested":
+		return fmt.Sprintf("Authgate account deletion requested\nuser_id: %s\nclient: %s", emptyDash(event.UserID), clientLabel(event.Metadata))
+	case "auth.refresh_reuse_detected":
+		return fmt.Sprintf("Authgate security alert: refresh token reuse detected\nuser_id: %s\nfamily_id: %s\nrelated refresh token family was revoked by authgate", emptyDash(event.UserID), metadataString(event.Metadata, "family_id"))
+	default:
+		return fmt.Sprintf("Authgate audit event\n event_type: %s\nuser_id: %s", event.EventType, emptyDash(event.UserID))
+	}
+}
+
+func FormatWeeklyReport(periodStart, periodEnd time.Time, summary Summary) string {
+	loginTotal := int64(0)
+	channels := make([]string, 0, len(summary.LoginByChannel))
+	for channel, count := range summary.LoginByChannel {
+		loginTotal += count
+		channels = append(channels, channel)
+	}
+	sort.Strings(channels)
+
+	var loginLines []string
+	for _, channel := range channels {
+		loginLines = append(loginLines, fmt.Sprintf("  - %s: %d", channel, summary.LoginByChannel[channel]))
+	}
+	if len(loginLines) == 0 {
+		loginLines = append(loginLines, "  - none: 0")
+	}
+
+	return fmt.Sprintf(`Authgate weekly report
+period: %s - %s
+
+Users
+- total: %d
+- active: %d
+
+Events
+- signups: %d
+- deletion requested: %d
+- deletion completed: %d
+
+Logins
+- total: %d
+%s
+
+Security
+- refresh token reuse detected: %d
+- channel mismatch: %d`,
+		periodStart.Format(time.RFC3339),
+		periodEnd.Format(time.RFC3339),
+		summary.TotalUsers,
+		summary.ActiveUsers,
+		summary.SignupCount,
+		summary.DeletionRequested,
+		summary.DeletionCompleted,
+		loginTotal,
+		strings.Join(loginLines, "\n"),
+		summary.RefreshReuse,
+		summary.ChannelMismatch,
+	)
+}
+
+func clientLabel(metadata map[string]any) string {
+	name := metadataString(metadata, "client_name")
+	id := metadataString(metadata, "client_id")
+	switch {
+	case name != "-" && id != "-":
+		return name + " (" + id + ")"
+	case name != "-":
+		return name
+	default:
+		return id
+	}
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	if len(metadata) == 0 {
+		return "-"
+	}
+	v, ok := metadata[key]
+	if !ok || v == nil {
+		return "-"
+	}
+	s := fmt.Sprint(v)
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}
+
+func emptyDash(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "-"
+	}
+	return v
+}

--- a/internal/notification/format_test.go
+++ b/internal/notification/format_test.go
@@ -1,0 +1,42 @@
+package notification
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatOutboxEvent_RefreshReuseMentionsFamilyRevoked(t *testing.T) {
+	msg := FormatOutboxEvent(OutboxEvent{
+		UserID:    "user-1",
+		EventType: "auth.refresh_reuse_detected",
+		Metadata:  map[string]any{"family_id": "family-1"},
+	})
+
+	for _, want := range []string{"refresh token reuse detected", "family-1", "family was revoked"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("message = %q, want substring %q", msg, want)
+		}
+	}
+}
+
+func TestLatestReportEnd(t *testing.T) {
+	loc, err := time.LoadLocation("Asia/Seoul")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, loc)
+	got := LatestReportEnd(now, time.Monday, 9, loc)
+	want := time.Date(2026, 6, 1, 9, 0, 0, 0, loc).UTC()
+	if !got.Equal(want) {
+		t.Fatalf("LatestReportEnd = %s, want %s", got, want)
+	}
+
+	beforeThisWeekSchedule := time.Date(2026, 6, 1, 8, 59, 0, 0, loc)
+	got = LatestReportEnd(beforeThisWeekSchedule, time.Monday, 9, loc)
+	want = time.Date(2026, 5, 25, 9, 0, 0, 0, loc).UTC()
+	if !got.Equal(want) {
+		t.Fatalf("LatestReportEnd before schedule = %s, want %s", got, want)
+	}
+}

--- a/internal/notification/slack.go
+++ b/internal/notification/slack.go
@@ -1,0 +1,67 @@
+package notification
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type SlackClient struct {
+	webhookURL string
+	client     *http.Client
+}
+
+type RateLimitError struct {
+	RetryAfter time.Duration
+}
+
+func (e *RateLimitError) Error() string {
+	return fmt.Sprintf("slack rate limited; retry after %s", e.RetryAfter)
+}
+
+func NewSlackClient(webhookURL string, client *http.Client) *SlackClient {
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &SlackClient{webhookURL: webhookURL, client: client}
+}
+
+func (c *SlackClient) Post(ctx context.Context, text string) error {
+	body, err := json.Marshal(map[string]string{"text": text})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return &RateLimitError{RetryAfter: retryAfter(resp.Header.Get("Retry-After"))}
+	}
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	return fmt.Errorf("slack webhook returned %d: %s", resp.StatusCode, string(raw))
+}
+
+func retryAfter(v string) time.Duration {
+	seconds, err := strconv.Atoi(v)
+	if err != nil || seconds < 1 {
+		return time.Minute
+	}
+	return time.Duration(seconds) * time.Second
+}

--- a/internal/notification/slack_test.go
+++ b/internal/notification/slack_test.go
@@ -1,0 +1,26 @@
+package notification
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestSlackClientPost_RateLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "7")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	err := NewSlackClient(srv.URL, srv.Client()).Post(context.Background(), "hello")
+	rateErr, ok := err.(*RateLimitError)
+	if !ok {
+		t.Fatalf("err = %T %[1]v, want *RateLimitError", err)
+	}
+	if rateErr.RetryAfter != 7*time.Second {
+		t.Fatalf("RetryAfter = %v, want 7s", rateErr.RetryAfter)
+	}
+}

--- a/internal/notification/store.go
+++ b/internal/notification/store.go
@@ -1,0 +1,305 @@
+package notification
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/kangheeyong/authgate/internal/clock"
+	"github.com/kangheeyong/authgate/internal/storage"
+)
+
+const (
+	workerLockKey int64 = 0x617574686e6f7469 // "authnoti"
+)
+
+type Store struct {
+	db    *sql.DB
+	clock clock.Clock
+}
+
+type OutboxEvent struct {
+	ID           int64
+	UserID       string
+	EventType    string
+	Metadata     map[string]any
+	CreatedAt    time.Time
+	AttemptCount int
+}
+
+type Summary struct {
+	TotalUsers        int64
+	ActiveUsers       int64
+	SignupCount       int64
+	DeletionRequested int64
+	DeletionCompleted int64
+	RefreshReuse      int64
+	ChannelMismatch   int64
+	LoginByChannel    map[string]int64
+}
+
+func NewStore(db *sql.DB, clk clock.Clock) *Store {
+	return &Store{db: db, clock: clk}
+}
+
+func (s *Store) EnqueueAuditEvent(ctx context.Context, event storage.AuditEvent) error {
+	rawMetadata, err := marshalMetadata(event.Metadata)
+	if err != nil {
+		return err
+	}
+	userID := ""
+	if event.UserID != nil {
+		userID = *event.UserID
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO notification_outbox (user_id, event_type, metadata, available_at, created_at)
+VALUES (NULLIF($1, '')::uuid, $2, $3::jsonb, $4, $4)
+`, userID, event.EventType, rawMetadata, event.CreatedAt)
+	return err
+}
+
+func (s *Store) WithWorkerLock(ctx context.Context, fn func(context.Context) error) (bool, error) {
+	return s.withExclusiveLock(ctx, workerLockKey, fn)
+}
+
+func (s *Store) withExclusiveLock(ctx context.Context, lockKey int64, fn func(context.Context) error) (bool, error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	var acquired bool
+	if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, lockKey).Scan(&acquired); err != nil {
+		return false, err
+	}
+	if !acquired {
+		return false, nil
+	}
+
+	runErr := fn(ctx)
+	var released bool
+	unlockErr := conn.QueryRowContext(ctx, `SELECT pg_advisory_unlock($1)`, lockKey).Scan(&released)
+	if runErr != nil {
+		return true, runErr
+	}
+	if unlockErr != nil {
+		return true, unlockErr
+	}
+	if !released {
+		return true, fmt.Errorf("notification advisory unlock failed")
+	}
+	return true, nil
+}
+
+func (s *Store) PendingOutboxEvents(ctx context.Context, limit int) ([]OutboxEvent, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id, COALESCE(user_id::text, ''), event_type, metadata, created_at, attempt_count
+FROM notification_outbox
+WHERE sent_at IS NULL AND available_at <= $1
+ORDER BY id
+LIMIT $2
+`, s.clock.Now(), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var events []OutboxEvent
+	for rows.Next() {
+		var event OutboxEvent
+		var rawMetadata []byte
+		if err := rows.Scan(&event.ID, &event.UserID, &event.EventType, &rawMetadata, &event.CreatedAt, &event.AttemptCount); err != nil {
+			return nil, err
+		}
+		event.Metadata, err = unmarshalMetadata(rawMetadata)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	return events, rows.Err()
+}
+
+func (s *Store) MarkOutboxSent(ctx context.Context, id int64) error {
+	_, err := s.db.ExecContext(ctx, `
+UPDATE notification_outbox
+SET sent_at = $1, last_error = NULL
+WHERE id = $2
+`, s.clock.Now(), id)
+	return err
+}
+
+func (s *Store) MarkOutboxFailed(ctx context.Context, id int64, nextAttempt time.Time, sendErr error) error {
+	_, err := s.db.ExecContext(ctx, `
+UPDATE notification_outbox
+SET attempt_count = attempt_count + 1,
+    available_at = $1,
+    last_error = $2
+WHERE id = $3
+`, nextAttempt, truncateError(sendErr), id)
+	return err
+}
+
+func (s *Store) ClaimReportRun(ctx context.Context, reportType string, periodStart, periodEnd time.Time) (int64, bool, error) {
+	var id int64
+	err := s.db.QueryRowContext(ctx, `
+INSERT INTO notification_report_runs (
+    report_type, period_start, period_end, status, created_at, updated_at
+) VALUES ($1, $2, $3, 'pending', $4, $4)
+ON CONFLICT (report_type, period_start, period_end) DO UPDATE
+SET status = 'pending',
+    updated_at = EXCLUDED.updated_at
+WHERE notification_report_runs.status <> 'sent'
+RETURNING id
+`, reportType, periodStart, periodEnd, s.clock.Now()).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return id, true, nil
+}
+
+func (s *Store) MarkReportSent(ctx context.Context, id int64) error {
+	now := s.clock.Now()
+	_, err := s.db.ExecContext(ctx, `
+UPDATE notification_report_runs
+SET status = 'sent',
+    sent_at = $1,
+    updated_at = $1,
+    last_error = NULL
+WHERE id = $2
+`, now, id)
+	return err
+}
+
+func (s *Store) MarkReportFailed(ctx context.Context, id int64, sendErr error) error {
+	_, err := s.db.ExecContext(ctx, `
+UPDATE notification_report_runs
+SET status = 'failed',
+    attempt_count = attempt_count + 1,
+    last_error = $1,
+    updated_at = $2
+WHERE id = $3
+`, truncateError(sendErr), s.clock.Now(), id)
+	return err
+}
+
+func (s *Store) WeeklySummary(ctx context.Context, periodStart, periodEnd time.Time) (Summary, error) {
+	var summary Summary
+	err := s.db.QueryRowContext(ctx, `
+SELECT
+    COUNT(*),
+    COUNT(*) FILTER (WHERE status = 'active')
+FROM users
+`).Scan(&summary.TotalUsers, &summary.ActiveUsers)
+	if err != nil {
+		return Summary{}, err
+	}
+
+	counts, err := s.auditCounts(ctx, periodStart, periodEnd)
+	if err != nil {
+		return Summary{}, err
+	}
+	summary.SignupCount = counts["auth.signup"]
+	summary.DeletionRequested = counts["auth.deletion_requested"]
+	summary.DeletionCompleted = counts["auth.deletion_completed"]
+	summary.RefreshReuse = counts["auth.refresh_reuse_detected"]
+	summary.ChannelMismatch = counts["auth.channel_mismatch"]
+
+	summary.LoginByChannel, err = s.loginCountsByChannel(ctx, periodStart, periodEnd)
+	if err != nil {
+		return Summary{}, err
+	}
+	return summary, nil
+}
+
+func (s *Store) auditCounts(ctx context.Context, periodStart, periodEnd time.Time) (map[string]int64, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT event_type, COUNT(*)
+FROM audit_log
+WHERE created_at >= $1 AND created_at < $2
+  AND event_type IN (
+    'auth.signup',
+    'auth.deletion_requested',
+    'auth.deletion_completed',
+    'auth.refresh_reuse_detected',
+    'auth.channel_mismatch'
+  )
+GROUP BY event_type
+`, periodStart, periodEnd)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	counts := map[string]int64{}
+	for rows.Next() {
+		var eventType string
+		var count int64
+		if err := rows.Scan(&eventType, &count); err != nil {
+			return nil, err
+		}
+		counts[eventType] = count
+	}
+	return counts, rows.Err()
+}
+
+func (s *Store) loginCountsByChannel(ctx context.Context, periodStart, periodEnd time.Time) (map[string]int64, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT COALESCE(NULLIF(metadata->>'channel', ''), 'unknown') AS channel, COUNT(*)
+FROM audit_log
+WHERE created_at >= $1 AND created_at < $2
+  AND event_type = 'auth.login'
+GROUP BY channel
+`, periodStart, periodEnd)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	counts := map[string]int64{}
+	for rows.Next() {
+		var channel string
+		var count int64
+		if err := rows.Scan(&channel, &count); err != nil {
+			return nil, err
+		}
+		counts[channel] = count
+	}
+	return counts, rows.Err()
+}
+
+func marshalMetadata(metadata map[string]any) ([]byte, error) {
+	if len(metadata) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(metadata)
+}
+
+func unmarshalMetadata(raw []byte) (map[string]any, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		return nil, err
+	}
+	return metadata, nil
+}
+
+func truncateError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if len(msg) <= 1000 {
+		return msg
+	}
+	return msg[:1000]
+}

--- a/internal/notification/worker.go
+++ b/internal/notification/worker.go
@@ -1,0 +1,176 @@
+package notification
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+)
+
+const weeklyReportType = "weekly"
+
+type WorkerConfig struct {
+	OutboxEnabled        bool
+	WeeklyReportEnabled  bool
+	Interval             time.Duration
+	BatchSize            int
+	RetryBaseDelay       time.Duration
+	ReportWeekday        time.Weekday
+	ReportHour           int
+	ReportLocation       *time.Location
+	ReportLookback       time.Duration
+	InterMessageInterval time.Duration
+}
+
+type Worker struct {
+	store  *Store
+	slack  *SlackClient
+	config WorkerConfig
+}
+
+func NewWorker(store *Store, slack *SlackClient, cfg WorkerConfig) *Worker {
+	if cfg.Interval <= 0 {
+		cfg.Interval = time.Minute
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = 20
+	}
+	if cfg.RetryBaseDelay <= 0 {
+		cfg.RetryBaseDelay = time.Minute
+	}
+	if cfg.ReportLocation == nil {
+		cfg.ReportLocation = time.UTC
+	}
+	if cfg.ReportLookback <= 0 {
+		cfg.ReportLookback = 7 * 24 * time.Hour
+	}
+	if cfg.InterMessageInterval <= 0 {
+		cfg.InterMessageInterval = time.Second
+	}
+	return &Worker{store: store, slack: slack, config: cfg}
+}
+
+func (w *Worker) Start(ctx context.Context) {
+	w.run(ctx)
+
+	ticker := time.NewTicker(w.config.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("notification worker stopped")
+			return
+		case <-ticker.C:
+			w.run(ctx)
+		}
+	}
+}
+
+func (w *Worker) run(ctx context.Context) {
+	if !w.config.OutboxEnabled && !w.config.WeeklyReportEnabled {
+		return
+	}
+	if acquired, err := w.store.WithWorkerLock(ctx, func(ctx context.Context) error {
+		var runErr error
+		if w.config.OutboxEnabled {
+			if err := w.processOutbox(ctx); err != nil {
+				runErr = errors.Join(runErr, err)
+			}
+		}
+		if w.config.WeeklyReportEnabled {
+			if err := w.processWeeklyReport(ctx); err != nil {
+				runErr = errors.Join(runErr, err)
+			}
+		}
+		return runErr
+	}); err != nil {
+		slog.ErrorContext(ctx, "notification worker run failed", "error", err)
+	} else if !acquired {
+		slog.DebugContext(ctx, "notification worker skipped: advisory lock not acquired")
+	}
+}
+
+func (w *Worker) processOutbox(ctx context.Context) error {
+	events, err := w.store.PendingOutboxEvents(ctx, w.config.BatchSize)
+	if err != nil {
+		return err
+	}
+	for i, event := range events {
+		if err := w.slack.Post(ctx, FormatOutboxEvent(event)); err != nil {
+			nextAttempt := w.nextAttemptAt(event.AttemptCount, err)
+			if markErr := w.store.MarkOutboxFailed(ctx, event.ID, nextAttempt, err); markErr != nil {
+				return errors.Join(err, markErr)
+			}
+			continue
+		}
+		if err := w.store.MarkOutboxSent(ctx, event.ID); err != nil {
+			return err
+		}
+		if i < len(events)-1 {
+			if err := sleepContext(ctx, w.config.InterMessageInterval); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (w *Worker) processWeeklyReport(ctx context.Context) error {
+	periodEnd := LatestReportEnd(w.store.clock.Now(), w.config.ReportWeekday, w.config.ReportHour, w.config.ReportLocation)
+	periodStart := periodEnd.Add(-w.config.ReportLookback)
+
+	runID, claimed, err := w.store.ClaimReportRun(ctx, weeklyReportType, periodStart, periodEnd)
+	if err != nil {
+		return err
+	}
+	if !claimed {
+		return nil
+	}
+
+	summary, err := w.store.WeeklySummary(ctx, periodStart, periodEnd)
+	if err != nil {
+		_ = w.store.MarkReportFailed(ctx, runID, err)
+		return err
+	}
+	if err := w.slack.Post(ctx, FormatWeeklyReport(periodStart, periodEnd, summary)); err != nil {
+		if markErr := w.store.MarkReportFailed(ctx, runID, err); markErr != nil {
+			return errors.Join(err, markErr)
+		}
+		return err
+	}
+	return w.store.MarkReportSent(ctx, runID)
+}
+
+func (w *Worker) nextAttemptAt(attemptCount int, err error) time.Time {
+	if rateLimited := (&RateLimitError{}); errors.As(err, &rateLimited) {
+		return w.store.clock.Now().Add(rateLimited.RetryAfter)
+	}
+	multiplier := 1 << min(attemptCount, 5)
+	return w.store.clock.Now().Add(time.Duration(multiplier) * w.config.RetryBaseDelay)
+}
+
+func LatestReportEnd(now time.Time, weekday time.Weekday, hour int, loc *time.Location) time.Time {
+	if loc == nil {
+		loc = time.UTC
+	}
+	localNow := now.In(loc)
+	y, m, d := localNow.Date()
+	candidate := time.Date(y, m, d, hour, 0, 0, 0, loc)
+	daysSince := (int(localNow.Weekday()) - int(weekday) + 7) % 7
+	candidate = candidate.AddDate(0, 0, -daysSince)
+	if candidate.After(localNow) {
+		candidate = candidate.AddDate(0, 0, -7)
+	}
+	return candidate.UTC()
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -197,13 +197,14 @@ func (s *Storage) AuditLog(ctx context.Context, userID *string, eventType, ipAdd
 		metaJSON = marshaled
 	}
 
+	createdAt := s.clock.Now()
 	if err := storeq.New(s.db).InsertAuditLog(ctx, storeq.InsertAuditLogParams{
 		UserID:    userIDLogValue(userID),
 		EventType: eventType,
 		IpAddress: nilIfEmpty(ipAddress),
 		UserAgent: nilIfEmpty(userAgent),
 		Metadata:  nilIfEmptyBytes(metaJSON),
-		CreatedAt: s.clock.Now(),
+		CreatedAt: createdAt,
 	}); err != nil {
 		slog.ErrorContext(ctx, "audit log: insert",
 			"event_type", eventType,
@@ -211,6 +212,16 @@ func (s *Storage) AuditLog(ctx context.Context, userID *string, eventType, ipAdd
 			"error", err,
 		)
 		return
+	}
+	if s.auditHook != nil {
+		s.auditHook.OnAuditLog(ctx, AuditEvent{
+			UserID:    userID,
+			EventType: eventType,
+			IPAddress: ipAddress,
+			UserAgent: userAgent,
+			Metadata:  metadata,
+			CreatedAt: createdAt,
+		})
 	}
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -37,6 +37,19 @@ var (
 // Injected from main.go — storage never imports service or guard packages.
 type StateChecker func(user *User) error
 
+type AuditEvent struct {
+	UserID    *string
+	EventType string
+	IPAddress string
+	UserAgent string
+	Metadata  map[string]any
+	CreatedAt time.Time
+}
+
+type AuditHook interface {
+	OnAuditLog(ctx context.Context, event AuditEvent)
+}
+
 // ClientResolutionPolicy resolves a client profile for client_id.
 // It is invoked by storage methods that zitadel calls directly.
 type ClientResolutionPolicy interface {
@@ -69,6 +82,7 @@ type Storage struct {
 	clients            sync.Map // map[string]*ClientModel (client_id → client)
 	clientPolicy       ClientResolutionPolicy
 	resourcePolicy     ResourceBindingPolicy
+	auditHook          AuditHook
 }
 
 func New(db *sql.DB, clk clock.Clock, gen idgen.IDGenerator, checker StateChecker, accessTTL, refreshTTL time.Duration) *Storage {
@@ -92,6 +106,10 @@ func New(db *sql.DB, clk clock.Clock, gen idgen.IDGenerator, checker StateChecke
 // both the response shape and the server-side throttle.
 func (s *Storage) SetDevicePollInterval(d time.Duration) {
 	s.devicePollInterval = d
+}
+
+func (s *Storage) SetAuditHook(h AuditHook) {
+	s.auditHook = h
 }
 
 // SetSigningKey sets the current RSA signing key used for JWT issuance.

--- a/migrations/007_notification_outbox.down.sql
+++ b/migrations/007_notification_outbox.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS notification_report_runs;
+DROP TABLE IF EXISTS notification_outbox;

--- a/migrations/007_notification_outbox.up.sql
+++ b/migrations/007_notification_outbox.up.sql
@@ -1,0 +1,33 @@
+CREATE TABLE notification_outbox (
+    id            BIGSERIAL PRIMARY KEY,
+    user_id       UUID REFERENCES users(id) ON DELETE SET NULL,
+    event_type    TEXT NOT NULL,
+    metadata      JSONB,
+    available_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    sent_at       TIMESTAMPTZ,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error    TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX notification_outbox_pending_idx
+    ON notification_outbox (available_at, id)
+    WHERE sent_at IS NULL;
+
+CREATE TABLE notification_report_runs (
+    id            BIGSERIAL PRIMARY KEY,
+    report_type   TEXT NOT NULL,
+    period_start  TIMESTAMPTZ NOT NULL,
+    period_end    TIMESTAMPTZ NOT NULL,
+    status        TEXT NOT NULL CHECK (status IN ('pending', 'sent', 'failed')),
+    sent_at       TIMESTAMPTZ,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error    TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (report_type, period_start, period_end)
+);
+
+CREATE INDEX notification_report_runs_pending_idx
+    ON notification_report_runs (report_type, period_end)
+    WHERE status <> 'sent';


### PR DESCRIPTION
## Summary

Adds optional Slack notifications for auth audit events behind a removable `internal/notification` package. Selected audit events are written to a durable notification outbox, then sent by a worker that uses PostgreSQL advisory locks so only one pod sends at a time. Weekly reports use `notification_report_runs` to avoid duplicate period delivery after restarts.

Included behavior:
- immediate Slack notifications for `auth.signup`, `auth.deletion_requested`, and `auth.refresh_reuse_detected`
- weekly Slack report over `users` and `audit_log`
- env-driven configuration for webhook, worker interval, report schedule, timezone, and lookback
- docs for operations, tests, and package boundaries

## Checklist

- [x] Tests added or updated for changed behavior
- [x] **Doc sync** (per CLAUDE.md):
  - [x] Env var change → `docs/spec/009-operations.md` updated
  - [x] Endpoint change → relevant `docs/spec/00N-*.md` updated (no endpoint change)
  - [x] Test added → `docs/tests/README.md` updated
  - [x] Package structure change → `docs/architecture/*.md` updated
- [x] No secrets committed (`.env`, keys, credentials)
- [x] `go test ./...` passes locally

Validation:
- `go test ./...`
- `go test ./...` in `examples/cli`
- `go test ./...` in `examples/mcp-server`
- `go test ./...` in `examples/webapp`
- `git diff --check`