### PR TITLE
fix(cimd): allow query string in CIMD client_id

### DIFF
--- a/docs/spec/004-mcp-login.md
+++ b/docs/spec/004-mcp-login.md
@@ -325,7 +325,8 @@ CIMD fetch의 네트워크 제약. IETF draft에서 MUST/SHOULD인 것과 authga
 | 응답 크기 | authgate 정책 | 10KB 초과 시 거부 |
 | Content-Type 검증 | IETF draft MUST | `application/json`만 허용 |
 | userinfo in URL 거부 | authgate 정책 | `https://user:pass@host/path` 형식 차단 |
-| query/fragment 거부 | authgate 정책 | `?`/`#` 포함 시 차단 |
+| fragment 거부 | authgate 정책 | `#` 포함 시 차단 (fragment는 서버로 전송되지 않음) |
+| query 허용 | authgate 정책 | `?` 허용. ChatGPT 등 일부 CIMD 제공자는 `?token_endpoint_auth_method=none` 같은 쿼리를 포함한 자기참조 `client_id`를 서빙한다. 문서의 `client_id`가 쿼리까지 정확히 일치해야 하고(아래 검증 규칙), canonical key가 쿼리를 그대로 보존하므로 별칭 표면이 늘지 않는다 |
 
 ### CIMD 메타데이터 검증 규칙
 

--- a/internal/adapter/mcp/cimd_fetcher_basic_test.go
+++ b/internal/adapter/mcp/cimd_fetcher_basic_test.go
@@ -154,8 +154,13 @@ func TestIsCIMDClientID(t *testing.T) {
 		{"https://app.example.com", false},
 		{"https:///oauth/client.json", false},
 		{"https://user:pass@app.example.com/client.json", false},
-		{"https://app.example.com/client.json?x=1", false},
+		// A query string is allowed: ChatGPT's CIMD client_id carries
+		// `?token_endpoint_auth_method=none` and the document echoes it back, so
+		// the exact-match check in fetchAndValidate still holds.
+		{"https://app.example.com/client.json?x=1", true},
+		{"https://chatgpt.com/oauth/VD94o4JXlMhn/client.json?token_endpoint_auth_method=none", true},
 		{"https://app.example.com/client.json#frag", false},
+		{"https://app.example.com/client.json?x=1#frag", false},
 		{"http://app.example.com/client", false},
 		{"my-app", false},
 		{"", false},

--- a/internal/storage/cimd_contract.go
+++ b/internal/storage/cimd_contract.go
@@ -32,9 +32,12 @@ func isCIMDClientID(clientID string) bool {
 	if u.Path == "" || u.Path == "/" {
 		return false
 	}
-	if u.RawQuery != "" {
-		return false
-	}
+	// A query string is permitted: some CIMD providers (e.g. ChatGPT) serve a
+	// self-referential document whose `client_id` includes the query (such as
+	// `?token_endpoint_auth_method=none`). The fetcher still enforces an exact
+	// `meta.ClientID == clientID` match (query included) and the canonical-key
+	// gate preserves the query verbatim, so allowing it adds no alias surface.
+	// Fragments stay rejected above because they are never sent to the server.
 	return true
 }
 


### PR DESCRIPTION
## 문제

ChatGPT MCP 커넥터가 `/authorize`에서 `invalid_request "unable to retrieve client by id"`로 실패. 라이브 로그(osaka)에서 실제 `client_id` 확인:

```
https://chatgpt.com/oauth/VD94o4JXlMhn/client.json?token_endpoint_auth_method=none
```

`isCIMDClientID`가 `u.RawQuery != ""`면 `false`를 반환 → `clientResolutionPolicy.ResolveClient`가 CIMD fetcher 분기를 건너뜀 → 정적 store에 없으므로 `ErrNotFound` → `invalid_request`.

## 왜 최소 수정으로 충분한가 (검증함)

ChatGPT는 문서를 **자기참조적으로** 서빙한다. 쿼리 포함 URL로 fetch하면 문서의 `client_id`도 쿼리 포함 값으로 돌아온다:

| fetch URL | 문서의 client_id |
|-----------|-----------------|
| `.../client.json?token_endpoint_auth_method=none` | `.../client.json?token_endpoint_auth_method=none` |
| `.../client.json` | `.../client.json` |

따라서 fetcher의 엄격검사(`meta.ClientID == clientID`, 쿼리 포함)와 canonical 게이트를 그대로 통과한다.

## 변경

- `internal/storage/cimd_contract.go`: 쿼리스트링 거부 제거 (fragment 거부는 유지 — fragment는 서버로 전송되지 않음)
- `internal/adapter/mcp/cimd_fetcher_basic_test.go`: `?x=1`→true, ChatGPT 실케이스 + `?x=1#frag` 케이스 추가
- `docs/spec/004-mcp-login.md`: "query/fragment 거부" → fragment 거부 + query 허용(근거 명시)

## 스펙 상충 확인

상충 없음:
- Spec 004 정확일치 규칙: 쿼리 포함해 여전히 정확 일치 → 유지
- #190 URL-form 정적 등록 금지: 쿼리형 URL도 이제 거부 대상에 포함 → 의도에 더 부합
- `isCanonicalCIMDClientID`: 쿼리 verbatim 보존 → 별칭 표면 무증가
- 제거한 규칙은 IETF MUST가 아닌 authgate 재량 정책

## 검증

`go build ./...`, `go vet`, `go test ./...` 전부 통과.

## 범위 밖 (별도 처리)

더 오래된 로그의 `resource mismatch / invalid_target`는 이전 토큰-엔드포인트 시도 흔적으로 이번 블로커와 별개. 이 수정으로 CIMD 해결이 통과한 뒤 resource 바인딩이 통과되는지 후속 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)