### PR TITLE
chore(deps): bump Go toolchain to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kangheeyong/authgate
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/go-jose/go-jose/v4 v4.1.4


### PR DESCRIPTION
## 왜

CI **Vulnerability Check**(`govulncheck`)가 stdlib 취약점으로 실패. 발견 심볼:

- `crypto/x509` — `Certificate.Verify`, `Certificate.VerifyHostname`, `HostnameError.Error`
- `net/textproto` — `Reader.ReadMIMEHeader`
- `crypto/rand` — `rand.Read`

전부 `app.Run → ListenAndServe`(TLS 인증서 검증, MIME 헤더 파싱)와 `idgen`의 crypto/rand 경로로 도달하는 **표준 라이브러리** 취약점이며, 특정 코드 변경과 무관하다.

## 근본 원인 (시점 문제, 코드 문제 아님)

- **Go 1.26.4가 2026-06-02 릴리즈**되며 `crypto/x509`, `mime`, `net/textproto` 보안 수정 포함.
- 현재 go.mod는 `go 1.26.3`.
- `govulncheck`는 실행 시점에 라이브 vuln DB를 조회한다. main의 마지막 통과(#266)는 06-02 **이전**이라 녹색이었고, 06-02 이후 모든 브랜치가 동일하게 실패한다.
- CI는 `go list ./...` 전체를 스캔(diff-scope 아님)하므로 이 경로는 항상 스캔 대상이었다.

## 수정

`go.mod`: `go 1.26.3` → `1.26.4`. CI가 `go-version-file: go.mod`라 툴체인이 자동 전진하며 스캔 통과.

## 검증

`go build ./...` 통과 (로컬에서 go1.26.4 자동 다운로드).

---

이 PR이 머지되면 #271(CIMD query string fix)을 리베이스해 vuln 체크를 통과시킨다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)