### PR TITLE
fix(docker): bump builder base image to golang:1.26.4-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 ENV GOTOOLCHAIN=local
 
 WORKDIR /app


### PR DESCRIPTION
## 문제

v0.7.2 릴리즈(#273)의 Docker 이미지 빌드가 실패했다:

```
go: go.mod requires go >= 1.26.4 (running go 1.26.3; GOTOOLCHAIN=local)
```

#272가 `go.mod`를 `go 1.26.4`로 올렸지만 `Dockerfile` builder는 `golang:1.26.3-alpine` + `GOTOOLCHAIN=local`(툴체인 자동 업그레이드 금지)에 머물러, `go mod download`에서 1.26.4 요구를 거부.

CI는 `go-version-file: go.mod`로 툴체인을 해석해 통과했지만, Docker 빌드는 베이스 이미지를 수동 핀하므로 따라오지 못함. **Go 버전 핀이 go.mod·Dockerfile 두 곳인데 한 곳만 올린** 누락.

## 수정

`Dockerfile` builder 베이스 `1.26.3-alpine` → `1.26.4-alpine`.

## 검증

로컬 `docker build --target builder` 로 CI 실패 지점 재현 후 통과 확인 (`go mod download` + `go build` 성공).

## 후속

이 PR 머지 후 별도 릴리즈 PR로 VERSION을 v0.7.3으로 올려 이미지까지 정상 발행한다. (실패한 v0.7.2 태그/릴리즈는 이미지가 없어 별도 정리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)