### PR TITLE
feat(session): 세션 bearer 토큰 at-rest 해시화 (ADR-002 PR-A)

### DIFF
--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -35,8 +35,9 @@ erDiagram
     }
 
     sessions {
-        uuid id PK "DEFAULT uuid_generate_v4()"
+        uuid id PK "DEFAULT uuid_generate_v4(), 내부 PK (쿠키 아님)"
         uuid user_id FK "NOT NULL, CASCADE"
+        text token_hash UK "nullable, 세션 쿠키 bearer의 SHA-256 해시"
         timestamptz expires_at "NOT NULL, 기본 24시간(SESSION_TTL)"
         timestamptz revoked_at "nullable, 로그아웃 시 설정"
         timestamptz created_at "NOT NULL, DEFAULT NOW()"
@@ -228,6 +229,8 @@ MCP
 | 규칙 | 적용 |
 |------|------|
 | refresh_token은 SHA-256 해시로 저장 | `token_hash` 컬럼 |
+| 세션 쿠키(bearer)는 SHA-256 해시로 저장 | `sessions.token_hash` 컬럼 (`id`는 내부 PK, 쿠키 아님) |
+| audit_log.metadata의 `session_id`는 해시로 저장 | audit sanitize 시 SHA-256 (평문 bearer 미기록) |
 | client_secret은 bcrypt 해시로 저장 | `clients.yaml`의 `client_secret_hash` 필드 |
 | access_token(JWT)은 DB에 저장하지 않음 | stateless |
 | PII 스크러빙 시 email, name 제거 | `deleted` 상태 전이 시 |

--- a/internal/db/queries/sessions.sql
+++ b/internal/db/queries/sessions.sql
@@ -1,13 +1,15 @@
 -- name: InsertSession :exec
-INSERT INTO sessions (id, user_id, expires_at, created_at)
-VALUES ($1, $2, $3, $4);
+INSERT INTO sessions (id, user_id, token_hash, expires_at, created_at)
+VALUES ($1, $2, $3, $4, $5);
 
 -- name: GetValidSessionUser :one
 SELECT u.id, u.email, u.email_verified, u.name, u.status,
        u.created_at, u.updated_at
 FROM sessions s
 JOIN users u ON s.user_id = u.id
-WHERE s.id = $1 AND s.expires_at > $2 AND s.revoked_at IS NULL;
+WHERE s.token_hash = sqlc.arg(token_hash)::text
+  AND s.expires_at > sqlc.arg(expires_at)
+  AND s.revoked_at IS NULL;
 
 -- name: RevokeSessionsByUserID :exec
 UPDATE sessions

--- a/internal/db/storeq/models.go
+++ b/internal/db/storeq/models.go
@@ -74,6 +74,7 @@ type Session struct {
 	ExpiresAt time.Time
 	RevokedAt sql.NullTime
 	CreatedAt time.Time
+	TokenHash sql.NullString
 }
 
 type User struct {

--- a/internal/db/storeq/sessions.sql.go
+++ b/internal/db/storeq/sessions.sql.go
@@ -16,11 +16,13 @@ SELECT u.id, u.email, u.email_verified, u.name, u.status,
        u.created_at, u.updated_at
 FROM sessions s
 JOIN users u ON s.user_id = u.id
-WHERE s.id = $1 AND s.expires_at > $2 AND s.revoked_at IS NULL
+WHERE s.token_hash = $1::text
+  AND s.expires_at > $2
+  AND s.revoked_at IS NULL
 `
 
 type GetValidSessionUserParams struct {
-	ID        string
+	TokenHash string
 	ExpiresAt time.Time
 }
 
@@ -35,7 +37,7 @@ type GetValidSessionUserRow struct {
 }
 
 func (q *Queries) GetValidSessionUser(ctx context.Context, arg GetValidSessionUserParams) (GetValidSessionUserRow, error) {
-	row := q.db.QueryRowContext(ctx, getValidSessionUser, arg.ID, arg.ExpiresAt)
+	row := q.db.QueryRowContext(ctx, getValidSessionUser, arg.TokenHash, arg.ExpiresAt)
 	var i GetValidSessionUserRow
 	err := row.Scan(
 		&i.ID,
@@ -50,13 +52,14 @@ func (q *Queries) GetValidSessionUser(ctx context.Context, arg GetValidSessionUs
 }
 
 const insertSession = `-- name: InsertSession :exec
-INSERT INTO sessions (id, user_id, expires_at, created_at)
-VALUES ($1, $2, $3, $4)
+INSERT INTO sessions (id, user_id, token_hash, expires_at, created_at)
+VALUES ($1, $2, $3, $4, $5)
 `
 
 type InsertSessionParams struct {
 	ID        string
 	UserID    string
+	TokenHash sql.NullString
 	ExpiresAt time.Time
 	CreatedAt time.Time
 }
@@ -65,6 +68,7 @@ func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) er
 	_, err := q.db.ExecContext(ctx, insertSession,
 		arg.ID,
 		arg.UserID,
+		arg.TokenHash,
 		arg.ExpiresAt,
 		arg.CreatedAt,
 	)

--- a/internal/integration/integration_account_deletion_test.go
+++ b/internal/integration/integration_account_deletion_test.go
@@ -52,10 +52,11 @@ func TestAccountDeletion_IdempotentAndSessionAlive(t *testing.T) {
 	// First call
 	doDelete("first DELETE")
 
-	// Session must still be alive (not revoked)
+	// Session must still be alive (not revoked). The cookie is now an opaque
+	// bearer (sessions.id is an internal UUID), so assert by user_id.
 	var revokedAt *time.Time
 	if err := ts.DB.QueryRowContext(ctx,
-		`SELECT revoked_at FROM sessions WHERE id = $1`, sessionID,
+		`SELECT revoked_at FROM sessions WHERE user_id = $1`, user.ID,
 	).Scan(&revokedAt); err != nil {
 		t.Fatalf("query session: %v", err)
 	}

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -4,13 +4,22 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/kangheeyong/authgate/internal/storage"
 )
+
+// hashedSessionID mirrors storage's at-rest session hashing (ADR-002): audit
+// metadata stores the hash of the session cookie value, never the raw bearer.
+func hashedSessionID(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
 
 type auditEventRow struct {
 	EventType string
@@ -185,8 +194,8 @@ func TestAudit_ReusedSession_AuthLoginRecorded(t *testing.T) {
 	if event.Metadata["reused_session"] != true {
 		t.Fatalf("reused_session = %v, want true", event.Metadata["reused_session"])
 	}
-	if event.Metadata["session_id"] != sessionID {
-		t.Fatalf("session_id = %v, want %s", event.Metadata["session_id"], sessionID)
+	if event.Metadata["session_id"] != hashedSessionID(sessionID) {
+		t.Fatalf("session_id = %v, want hashed %s", event.Metadata["session_id"], sessionID)
 	}
 }
 
@@ -223,8 +232,8 @@ func TestAudit_ReusedSession_MCP_AuthLoginRecorded(t *testing.T) {
 	if event.Metadata["reused_session"] != true {
 		t.Fatalf("reused_session = %v, want true", event.Metadata["reused_session"])
 	}
-	if event.Metadata["session_id"] != sessionID {
-		t.Fatalf("session_id = %v, want %s", event.Metadata["session_id"], sessionID)
+	if event.Metadata["session_id"] != hashedSessionID(sessionID) {
+		t.Fatalf("session_id = %v, want hashed %s", event.Metadata["session_id"], sessionID)
 	}
 	if event.Metadata["client_id"] != "test-mcp-app" {
 		t.Fatalf("client_id = %v, want test-mcp-app", event.Metadata["client_id"])
@@ -312,8 +321,8 @@ func TestAudit006_DeletionRequested(t *testing.T) {
 	if event.Metadata["channel"] != "browser" {
 		t.Fatalf("channel = %v, want browser", event.Metadata["channel"])
 	}
-	if event.Metadata["session_id"] != loginResult.SessionID {
-		t.Fatalf("session_id = %v, want %s", event.Metadata["session_id"], loginResult.SessionID)
+	if event.Metadata["session_id"] != hashedSessionID(loginResult.SessionID) {
+		t.Fatalf("session_id = %v, want hashed %s", event.Metadata["session_id"], loginResult.SessionID)
 	}
 	if event.Metadata["client_id"] != "test-app" {
 		t.Fatalf("client_id = %v, want test-app", event.Metadata["client_id"])
@@ -345,8 +354,8 @@ func TestAudit007_DeletionCancelled(t *testing.T) {
 	if event.Metadata["channel"] != "browser" {
 		t.Fatalf("channel = %v, want browser", event.Metadata["channel"])
 	}
-	if event.Metadata["session_id"] != result.SessionID {
-		t.Fatalf("session_id = %v, want %s", event.Metadata["session_id"], result.SessionID)
+	if event.Metadata["session_id"] != hashedSessionID(result.SessionID) {
+		t.Fatalf("session_id = %v, want hashed %s", event.Metadata["session_id"], result.SessionID)
 	}
 	if event.Metadata["client_id"] != "test-app" {
 		t.Fatalf("client_id = %v, want test-app", event.Metadata["client_id"])

--- a/internal/service/cleanup_test.go
+++ b/internal/service/cleanup_test.go
@@ -148,7 +148,7 @@ func TestE2E8_CleanupRollback(t *testing.T) {
 		fx.Clock.Now().Add(-1*time.Hour), user.ID)
 
 	// Create child records that would be removed during cleanup.
-	sessionID, err := fx.Store.CreateSession(ctx, user.ID, 24*time.Hour)
+	_, err := fx.Store.CreateSession(ctx, user.ID, 24*time.Hour)
 	if err != nil {
 		t.Fatalf("create session: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestE2E8_CleanupRollback(t *testing.T) {
 
 	var identityCount, sessionCount, refreshCount, auditCount int
 	fx.DB.QueryRowContext(ctx, `SELECT count(*) FROM user_identities WHERE user_id = $1`, user.ID).Scan(&identityCount)
-	fx.DB.QueryRowContext(ctx, `SELECT count(*) FROM sessions WHERE id = $1 AND user_id = $2`, sessionID, user.ID).Scan(&sessionCount)
+	fx.DB.QueryRowContext(ctx, `SELECT count(*) FROM sessions WHERE user_id = $1`, user.ID).Scan(&sessionCount)
 	fx.DB.QueryRowContext(ctx, `SELECT count(*) FROM refresh_tokens WHERE user_id = $1`, user.ID).Scan(&refreshCount)
 	fx.DB.QueryRowContext(ctx, `SELECT count(*) FROM audit_log WHERE user_id = $1 AND event_type = 'auth.deletion_completed'`, user.ID).Scan(&auditCount)
 

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -164,7 +164,7 @@ type AuditClientContext struct {
 func (s *Storage) GetAuditClientContextBySessionID(ctx context.Context, userID, sessionID string) (AuditClientContext, error) {
 	row, err := storeq.New(s.db).GetAuditClientContextBySessionID(ctx, storeq.GetAuditClientContextBySessionIDParams{
 		UserID:    userID,
-		SessionID: sessionID,
+		SessionID: hashToken(sessionID),
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return AuditClientContext{}, ErrNotFound
@@ -242,6 +242,12 @@ func sanitizeAuditMetadata(ctx context.Context, eventType string, metadata map[s
 			"event_type", eventType,
 			"dropped_count", dropped,
 		)
+	}
+	// session_id arrives as the raw session cookie value. Store only its hash so
+	// an audit-log read cannot recover a live bearer (ADR-002). The hash matches
+	// sessions.token_hash, so GetAuditClientContextBySessionID still correlates.
+	if raw, ok := sanitized["session_id"].(string); ok && raw != "" {
+		sanitized["session_id"] = hashToken(raw)
 	}
 	if len(sanitized) == 0 {
 		return nil

--- a/internal/storage/audit_unit_test.go
+++ b/internal/storage/audit_unit_test.go
@@ -49,14 +49,18 @@ func TestSanitizeAuditMetadata_AllowsKnownKeysOnly(t *testing.T) {
 
 	got := sanitizeAuditMetadata(context.Background(), "auth.login", metadata)
 	want := map[string]any{
-		"channel":        "browser",
-		"client_id":      "client-1",
-		"client_name":    "Client One",
-		"session_id":     "sess-1",
+		"channel":     "browser",
+		"client_id":   "client-1",
+		"client_name": "Client One",
+		// session_id is stored hashed, never as the raw bearer (ADR-002).
+		"session_id":     hashToken("sess-1"),
 		"reused_session": true,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("sanitized metadata = %#v, want %#v", got, want)
+	}
+	if got["session_id"] == "sess-1" {
+		t.Fatal("session_id stored as raw bearer; want hashed")
 	}
 }
 

--- a/internal/storage/storage_integration_test.go
+++ b/internal/storage/storage_integration_test.go
@@ -171,6 +171,46 @@ func TestSession_CreateAndValidate(t *testing.T) {
 	}
 }
 
+// TestSession_TokenStoredHashed covers ADR-002: the session cookie is a bearer,
+// so the DB must store only its hash. A DB read must not yield a usable cookie.
+func TestSession_TokenStoredHashed(t *testing.T) {
+	s := testStorage(t)
+	ctx := context.Background()
+
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "session-hash@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "session-hash-sub"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	token, err := s.CreateSession(ctx, user.ID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	var id, tokenHash string
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT id, token_hash FROM sessions WHERE user_id = $1`, user.ID,
+	).Scan(&id, &tokenHash); err != nil {
+		t.Fatalf("read session row: %v", err)
+	}
+
+	// The raw bearer is never persisted — neither as id nor token_hash.
+	if id == token {
+		t.Error("sessions.id equals the cookie bearer; want internal UUID")
+	}
+	if tokenHash == token {
+		t.Error("token_hash equals the raw bearer; want hash")
+	}
+	if tokenHash != hashToken(token) {
+		t.Errorf("token_hash = %q, want hashToken(token) %q", tokenHash, hashToken(token))
+	}
+
+	// A leaked stored hash must NOT be usable as a cookie; only the raw token validates.
+	if _, err := s.GetValidSession(ctx, tokenHash); err != ErrNotFound {
+		t.Errorf("validate by stored hash err = %v, want ErrNotFound", err)
+	}
+}
+
 func ptrStr(s string) *string { return &s }
 
 // TestSession_StatusFilter covers #157: GetValidSession must reject sessions

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -300,21 +300,30 @@ func (s *Storage) CreateTestAuthRequestWithResource(ctx context.Context, label, 
 // Session management
 
 func (s *Storage) CreateSession(ctx context.Context, userID string, ttl time.Duration) (string, error) {
-	sessionID := s.idgen.NewUUID()
+	// The session cookie carries a high-entropy opaque token; the DB stores
+	// only its hash (ADR-002). sessions.id stays an internal PK (no external
+	// FK), so lookups go through token_hash, not the bearer.
+	token, err := s.idgen.NewOpaqueToken()
+	if err != nil {
+		return "", err
+	}
 	now := s.clock.Now()
-	err := storeq.New(s.db).InsertSession(ctx, storeq.InsertSessionParams{
-		ID:        sessionID,
+	if err := storeq.New(s.db).InsertSession(ctx, storeq.InsertSessionParams{
+		ID:        s.idgen.NewUUID(),
 		UserID:    userID,
+		TokenHash: sql.NullString{String: hashToken(token), Valid: true},
 		ExpiresAt: now.Add(ttl),
 		CreatedAt: now,
-	})
-	return sessionID, err
+	}); err != nil {
+		return "", err
+	}
+	return token, nil
 }
 
 func (s *Storage) GetValidSession(ctx context.Context, sessionID string) (*User, error) {
 	now := s.clock.Now()
 	row, err := storeq.New(s.db).GetValidSessionUser(ctx, storeq.GetValidSessionUserParams{
-		ID:        sessionID,
+		TokenHash: hashToken(sessionID),
 		ExpiresAt: now,
 	})
 	if errors.Is(err, sql.ErrNoRows) {

--- a/migrations/007_sessions_token_hash.down.sql
+++ b/migrations/007_sessions_token_hash.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS sessions_token_hash_key;
+
+ALTER TABLE sessions DROP COLUMN IF EXISTS token_hash;

--- a/migrations/007_sessions_token_hash.up.sql
+++ b/migrations/007_sessions_token_hash.up.sql
@@ -1,0 +1,6 @@
+-- 세션 bearer 토큰을 평문이 아니라 해시로 저장한다 (ADR-002).
+-- 쿠키는 고엔트로피 opaque 토큰을 담고, DB에는 그 SHA-256 해시만 둔다.
+-- sessions.id는 내부 PK로만 남고(외부 FK 없음), 조회는 token_hash로 한다.
+ALTER TABLE sessions ADD COLUMN token_hash TEXT;
+
+CREATE UNIQUE INDEX sessions_token_hash_key ON sessions (token_hash);


### PR DESCRIPTION
## 무엇

세션 쿠키 bearer를 평문이 아니라 해시로 저장한다. ADR-002의 첫 구현(PR-A), CRITICAL 보안 수정.

## 왜 (CRITICAL)

`sessions.id`(UUID)가 곧 쿠키 값이었다 → DB 덤프·백업·리드 레플리카·감사로그를 **읽기만** 해도 활성 세션을 그대로 탈취 가능. `refresh_token`은 해시 저장하면서 세션만 평문이었음.

## 설계 (refresh_tokens 패턴 차용)

- 쿠키 = 256-bit opaque 토큰(`idgen.NewOpaqueToken`), DB엔 SHA-256 해시만(`sessions.token_hash`).
- `sessions.id`는 내부 PK로 유지 — **외부 FK 참조 없음 확인**(스키마 grep), 조회는 `token_hash`로.
- `audit_log.metadata`의 `session_id`도 storage 경계(`sanitizeAuditMetadata`)에서 해시 → 감사로그 유출에도 평문 bearer 미노출. `token_hash`와 동일 해시라 `GetAuditClientContextBySessionID` 상관관계 유지.
- 해시는 SHA-256(`hashToken`) — 고엔트로피 토큰이라 충분, pepper 인프라(후속 PR)에 의존 안 함.

## 마이그레이션

`007_sessions_token_hash`: `token_hash TEXT` + unique index (nullable, 드레인).

## ⚠️ 배포 영향

기존 세션(`token_hash`=NULL)은 무효화 → **1회 전체 재로그인** 필요(드레인 fallback 없이 즉시 전환, 합의된 선택).

## 검증

- `go test ./...` + `go test -tags=integration ./...` 전부 green, `make lint` 0 issues.
- 신규 테스트 `TestSession_TokenStoredHashed`: 저장된 건 해시이고 raw bearer는 DB(`id`/`token_hash`)에 없음, 저장 해시로는 검증 불가.
- 영향받은 테스트(audit session_id, cleanup/deletion 직접조회) = 옛 "쿠키==id" 가정 제거하도록 갱신.

## 문서

`docs/spec/007-data-model.md` 보안 규칙표 + sessions ER 동기화.

## 범위

ADR-002 시리즈 중 첫 PR. 후속: crypto infra(DEK/KEK) → provider sub → email/name → codes → crypto-shred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)