### PR TITLE
feat(crypto): provider subject 암호화 (ADR-002 PR2)

### DIFF
--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -42,7 +42,14 @@ erDiagram
         uuid id PK "DEFAULT uuid_generate_v4()"
         uuid user_id FK "NOT NULL, CASCADE"
         text provider "NOT NULL, OIDC issuer에서 파생 (예: google, mock 등)"
-        text provider_user_id "NOT NULL, UNIQUE(provider, provider_user_id)"
+        text provider_user_id "nullable, 평문 (백필 후 cleanup PR에서 제거)"
+        text provider_sub_hash "nullable, lookup HMAC, UNIQUE(provider, provider_sub_hash)"
+        text provider_sub_hash_key_id "FK crypto_key_epochs"
+        int provider_sub_hash_version "nullable"
+        bytea provider_sub_ciphertext "nullable, AEAD (회전 rehash용 복구)"
+        bytea provider_sub_nonce "nullable"
+        text provider_sub_enc_key_id "FK crypto_key_epochs"
+        int provider_sub_enc_version "nullable"
         timestamptz created_at "NOT NULL, DEFAULT NOW()"
     }
 
@@ -240,6 +247,7 @@ MCP
 
 | 규칙 | 적용 |
 |------|------|
+| provider sub은 lookup HMAC + AEAD ciphertext로 저장 | `provider_sub_hash`(매칭) + `provider_sub_ciphertext`(회전 복구), 평문 `provider_user_id`는 백필 후 제거 |
 | refresh_token은 SHA-256 해시로 저장 | `token_hash` 컬럼 |
 | 세션 쿠키(bearer)는 SHA-256 해시로 저장 | `sessions.token_hash` 컬럼 (`id`는 내부 PK, 쿠키 아님) |
 | audit_log.metadata의 `session_id`는 해시로 저장 | audit sanitize 시 SHA-256 (평문 bearer 미기록) |

--- a/internal/app/crypto.go
+++ b/internal/app/crypto.go
@@ -45,11 +45,23 @@ func mustSetupCrypto(cfg *config.Config, store *storage.Storage) {
 	}
 	store.SetKeys(keys)
 
-	if err := store.EnsureCryptoEpochs(context.Background()); err != nil {
+	ctx := context.Background()
+	if err := store.EnsureCryptoEpochs(ctx); err != nil {
 		log.Fatalf("crypto: ensure key epochs: %v", err)
 	}
 	slog.Info("PII encryption configured",
 		"enc_key_id", cfg.EncRootKeyID,
 		"lookup_key_id", cfg.LookupRootKeyID,
 	)
+
+	// Backfill legacy plaintext provider subjects into encrypted columns. With
+	// keys configured, lookups go through provider_sub_hash, so any row not yet
+	// backfilled would be unfindable — backfill must complete before serving.
+	n, err := store.BackfillProviderSub(ctx)
+	if err != nil {
+		log.Fatalf("crypto: provider_sub backfill: %v", err)
+	}
+	if n > 0 {
+		slog.Info("provider_sub backfill complete", "rows", n)
+	}
 }

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -3,8 +3,12 @@ INSERT INTO users (id, email, email_verified, name, status, created_at, updated_
 VALUES ($1, $2, $3, $4, 'active', $5, $5);
 
 -- name: InsertUserIdentity :exec
-INSERT INTO user_identities (id, user_id, provider, provider_user_id, created_at)
-VALUES ($1, $2, $3, $4, $5);
+INSERT INTO user_identities (
+    id, user_id, provider, provider_user_id,
+    provider_sub_hash, provider_sub_hash_key_id, provider_sub_hash_version,
+    provider_sub_ciphertext, provider_sub_nonce, provider_sub_enc_key_id, provider_sub_enc_version,
+    created_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);
 
 -- name: GetUserByProviderIdentity :one
 SELECT u.id, u.email, u.email_verified, u.name, u.status,
@@ -12,6 +16,36 @@ SELECT u.id, u.email, u.email_verified, u.name, u.status,
 FROM users u
 JOIN user_identities ui ON u.id = ui.user_id
 WHERE ui.provider = $1 AND ui.provider_user_id = $2;
+
+-- name: GetUserByProviderSubHash :one
+SELECT u.id, u.email, u.email_verified, u.name, u.status,
+       u.created_at, u.updated_at
+FROM users u
+JOIN user_identities ui ON u.id = ui.user_id
+WHERE ui.provider = $1 AND ui.provider_sub_hash = $2;
+
+-- name: ListProviderSubBackfill :many
+SELECT id, user_id, provider, provider_user_id
+FROM user_identities
+WHERE provider_sub_hash IS NULL AND provider_user_id IS NOT NULL
+ORDER BY id
+LIMIT $1;
+
+-- name: CountProviderSubUnbackfilled :one
+SELECT count(*)
+FROM user_identities
+WHERE provider_sub_hash IS NULL AND provider_user_id IS NOT NULL;
+
+-- name: BackfillProviderSub :exec
+UPDATE user_identities SET
+    provider_sub_hash         = $2,
+    provider_sub_hash_key_id  = $3,
+    provider_sub_hash_version = $4,
+    provider_sub_ciphertext   = $5,
+    provider_sub_nonce        = $6,
+    provider_sub_enc_key_id   = $7,
+    provider_sub_enc_version  = $8
+WHERE id = $1;
 
 -- name: GetUserByID :one
 SELECT id, email, email_verified, name, status,

--- a/internal/db/storeq/models.go
+++ b/internal/db/storeq/models.go
@@ -103,9 +103,16 @@ type User struct {
 }
 
 type UserIdentity struct {
-	ID             string
-	UserID         string
-	Provider       string
-	ProviderUserID string
-	CreatedAt      time.Time
+	ID                     string
+	UserID                 string
+	Provider               string
+	ProviderUserID         sql.NullString
+	CreatedAt              time.Time
+	ProviderSubHash        sql.NullString
+	ProviderSubHashKeyID   sql.NullString
+	ProviderSubHashVersion sql.NullInt32
+	ProviderSubCiphertext  []byte
+	ProviderSubNonce       []byte
+	ProviderSubEncKeyID    sql.NullString
+	ProviderSubEncVersion  sql.NullInt32
 }

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -13,7 +13,9 @@ import (
 type Querier interface {
 	AnonymizeAuditLogBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	ApproveDeviceCodeByUserCode(ctx context.Context, arg ApproveDeviceCodeByUserCodeParams) (int64, error)
+	BackfillProviderSub(ctx context.Context, arg BackfillProviderSubParams) error
 	CompleteAuthRequestByID(ctx context.Context, arg CompleteAuthRequestByIDParams) (int64, error)
+	CountProviderSubUnbackfilled(ctx context.Context) (int64, error)
 	DeleteAuthRequestByID(ctx context.Context, id string) error
 	DeleteExpiredAuthRequestsBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteExpiredDeviceCodesBefore(ctx context.Context, cutoff time.Time) (int64, error)
@@ -35,6 +37,7 @@ type Querier interface {
 	GetRefreshTokenInfoByHashAndClientID(ctx context.Context, arg GetRefreshTokenInfoByHashAndClientIDParams) (GetRefreshTokenInfoByHashAndClientIDRow, error)
 	GetUserByID(ctx context.Context, id string) (GetUserByIDRow, error)
 	GetUserByProviderIdentity(ctx context.Context, arg GetUserByProviderIdentityParams) (GetUserByProviderIdentityRow, error)
+	GetUserByProviderSubHash(ctx context.Context, arg GetUserByProviderSubHashParams) (GetUserByProviderSubHashRow, error)
 	GetUserForTxByID(ctx context.Context, id string) (GetUserForTxByIDRow, error)
 	GetUserInfoFieldsByID(ctx context.Context, id string) (GetUserInfoFieldsByIDRow, error)
 	GetValidSessionUser(ctx context.Context, arg GetValidSessionUserParams) (GetValidSessionUserRow, error)
@@ -50,6 +53,7 @@ type Querier interface {
 	InsertUser(ctx context.Context, arg InsertUserParams) error
 	InsertUserIdentity(ctx context.Context, arg InsertUserIdentityParams) error
 	ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff sql.NullTime) ([]string, error)
+	ListProviderSubBackfill(ctx context.Context, limit int32) ([]ListProviderSubBackfillRow, error)
 	MarkRefreshTokenUsedAndRevokedByID(ctx context.Context, arg MarkRefreshTokenUsedAndRevokedByIDParams) error
 	MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedByIDParams) (int64, error)
 	MarkUserPendingDeletionByID(ctx context.Context, arg MarkUserPendingDeletionByIDParams) (int64, error)

--- a/internal/db/storeq/users.sql.go
+++ b/internal/db/storeq/users.sql.go
@@ -11,6 +11,43 @@ import (
 	"time"
 )
 
+const backfillProviderSub = `-- name: BackfillProviderSub :exec
+UPDATE user_identities SET
+    provider_sub_hash         = $2,
+    provider_sub_hash_key_id  = $3,
+    provider_sub_hash_version = $4,
+    provider_sub_ciphertext   = $5,
+    provider_sub_nonce        = $6,
+    provider_sub_enc_key_id   = $7,
+    provider_sub_enc_version  = $8
+WHERE id = $1
+`
+
+type BackfillProviderSubParams struct {
+	ID                     string
+	ProviderSubHash        sql.NullString
+	ProviderSubHashKeyID   sql.NullString
+	ProviderSubHashVersion sql.NullInt32
+	ProviderSubCiphertext  []byte
+	ProviderSubNonce       []byte
+	ProviderSubEncKeyID    sql.NullString
+	ProviderSubEncVersion  sql.NullInt32
+}
+
+func (q *Queries) BackfillProviderSub(ctx context.Context, arg BackfillProviderSubParams) error {
+	_, err := q.db.ExecContext(ctx, backfillProviderSub,
+		arg.ID,
+		arg.ProviderSubHash,
+		arg.ProviderSubHashKeyID,
+		arg.ProviderSubHashVersion,
+		arg.ProviderSubCiphertext,
+		arg.ProviderSubNonce,
+		arg.ProviderSubEncKeyID,
+		arg.ProviderSubEncVersion,
+	)
+	return err
+}
+
 const completeAuthRequestByID = `-- name: CompleteAuthRequestByID :execrows
 UPDATE auth_requests
 SET subject = $1, auth_time = $2, done = true
@@ -29,6 +66,19 @@ func (q *Queries) CompleteAuthRequestByID(ctx context.Context, arg CompleteAuthR
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+const countProviderSubUnbackfilled = `-- name: CountProviderSubUnbackfilled :one
+SELECT count(*)
+FROM user_identities
+WHERE provider_sub_hash IS NULL AND provider_user_id IS NOT NULL
+`
+
+func (q *Queries) CountProviderSubUnbackfilled(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countProviderSubUnbackfilled)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
 }
 
 const getUserByID = `-- name: GetUserByID :one
@@ -73,7 +123,7 @@ WHERE ui.provider = $1 AND ui.provider_user_id = $2
 
 type GetUserByProviderIdentityParams struct {
 	Provider       string
-	ProviderUserID string
+	ProviderUserID sql.NullString
 }
 
 type GetUserByProviderIdentityRow struct {
@@ -89,6 +139,44 @@ type GetUserByProviderIdentityRow struct {
 func (q *Queries) GetUserByProviderIdentity(ctx context.Context, arg GetUserByProviderIdentityParams) (GetUserByProviderIdentityRow, error) {
 	row := q.db.QueryRowContext(ctx, getUserByProviderIdentity, arg.Provider, arg.ProviderUserID)
 	var i GetUserByProviderIdentityRow
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.EmailVerified,
+		&i.Name,
+		&i.Status,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getUserByProviderSubHash = `-- name: GetUserByProviderSubHash :one
+SELECT u.id, u.email, u.email_verified, u.name, u.status,
+       u.created_at, u.updated_at
+FROM users u
+JOIN user_identities ui ON u.id = ui.user_id
+WHERE ui.provider = $1 AND ui.provider_sub_hash = $2
+`
+
+type GetUserByProviderSubHashParams struct {
+	Provider        string
+	ProviderSubHash sql.NullString
+}
+
+type GetUserByProviderSubHashRow struct {
+	ID            string
+	Email         string
+	EmailVerified bool
+	Name          sql.NullString
+	Status        string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+func (q *Queries) GetUserByProviderSubHash(ctx context.Context, arg GetUserByProviderSubHashParams) (GetUserByProviderSubHashRow, error) {
+	row := q.db.QueryRowContext(ctx, getUserByProviderSubHash, arg.Provider, arg.ProviderSubHash)
+	var i GetUserByProviderSubHashRow
 	err := row.Scan(
 		&i.ID,
 		&i.Email,
@@ -270,16 +358,27 @@ func (q *Queries) InsertUser(ctx context.Context, arg InsertUserParams) error {
 }
 
 const insertUserIdentity = `-- name: InsertUserIdentity :exec
-INSERT INTO user_identities (id, user_id, provider, provider_user_id, created_at)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO user_identities (
+    id, user_id, provider, provider_user_id,
+    provider_sub_hash, provider_sub_hash_key_id, provider_sub_hash_version,
+    provider_sub_ciphertext, provider_sub_nonce, provider_sub_enc_key_id, provider_sub_enc_version,
+    created_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 `
 
 type InsertUserIdentityParams struct {
-	ID             string
-	UserID         string
-	Provider       string
-	ProviderUserID string
-	CreatedAt      time.Time
+	ID                     string
+	UserID                 string
+	Provider               string
+	ProviderUserID         sql.NullString
+	ProviderSubHash        sql.NullString
+	ProviderSubHashKeyID   sql.NullString
+	ProviderSubHashVersion sql.NullInt32
+	ProviderSubCiphertext  []byte
+	ProviderSubNonce       []byte
+	ProviderSubEncKeyID    sql.NullString
+	ProviderSubEncVersion  sql.NullInt32
+	CreatedAt              time.Time
 }
 
 func (q *Queries) InsertUserIdentity(ctx context.Context, arg InsertUserIdentityParams) error {
@@ -288,9 +387,59 @@ func (q *Queries) InsertUserIdentity(ctx context.Context, arg InsertUserIdentity
 		arg.UserID,
 		arg.Provider,
 		arg.ProviderUserID,
+		arg.ProviderSubHash,
+		arg.ProviderSubHashKeyID,
+		arg.ProviderSubHashVersion,
+		arg.ProviderSubCiphertext,
+		arg.ProviderSubNonce,
+		arg.ProviderSubEncKeyID,
+		arg.ProviderSubEncVersion,
 		arg.CreatedAt,
 	)
 	return err
+}
+
+const listProviderSubBackfill = `-- name: ListProviderSubBackfill :many
+SELECT id, user_id, provider, provider_user_id
+FROM user_identities
+WHERE provider_sub_hash IS NULL AND provider_user_id IS NOT NULL
+ORDER BY id
+LIMIT $1
+`
+
+type ListProviderSubBackfillRow struct {
+	ID             string
+	UserID         string
+	Provider       string
+	ProviderUserID sql.NullString
+}
+
+func (q *Queries) ListProviderSubBackfill(ctx context.Context, limit int32) ([]ListProviderSubBackfillRow, error) {
+	rows, err := q.db.QueryContext(ctx, listProviderSubBackfill, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListProviderSubBackfillRow
+	for rows.Next() {
+		var i ListProviderSubBackfillRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.Provider,
+			&i.ProviderUserID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const markUserPendingDeletionByID = `-- name: MarkUserPendingDeletionByID :execrows

--- a/internal/storage/provider_sub.go
+++ b/internal/storage/provider_sub.go
@@ -1,0 +1,108 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/kangheeyong/authgate/internal/crypto"
+	"github.com/kangheeyong/authgate/internal/db/storeq"
+)
+
+// ErrEncryptionNotConfigured is returned when an operation requires the PII
+// crypto keys but none are wired in.
+var ErrEncryptionNotConfigured = errors.New("storage: encryption not configured")
+
+// providerSubVersion is the crypto material format version stored alongside
+// provider_sub hash/ciphertext. Bump only with a matching migration.
+const providerSubVersion = 1
+
+// providerSubBackfillBatch bounds how many rows a single backfill query loads.
+const providerSubBackfillBatch = 500
+
+// providerSubAADField is the stable crypto field id used in the AEAD AAD.
+const providerSubAADField = "user_identities.provider_sub"
+
+type providerSubColumns struct {
+	hash       string
+	hashKeyID  string
+	ciphertext []byte
+	nonce      []byte
+	encKeyID   string
+}
+
+// encryptProviderSub derives the lookup hash and AEAD ciphertext columns for a
+// provider subject under the configured keys. The AAD binds the ciphertext to
+// the owning user_id so it cannot be replayed onto another row.
+func (s *Storage) encryptProviderSub(userID, provider, sub string) (providerSubColumns, error) {
+	aad := crypto.FieldAAD(providerSubAADField, userID, s.keys.EncKeyID(), providerSubVersion)
+	ciphertext, nonce, err := s.keys.EncryptPII([]byte(sub), aad)
+	if err != nil {
+		return providerSubColumns{}, fmt.Errorf("encrypt provider sub: %w", err)
+	}
+	return providerSubColumns{
+		hash:       s.keys.ProviderSubHash(provider, sub),
+		hashKeyID:  s.keys.LookupKeyID(),
+		ciphertext: ciphertext,
+		nonce:      nonce,
+		encKeyID:   s.keys.EncKeyID(),
+	}, nil
+}
+
+// applyTo fills the encrypted provider_sub columns of an insert params struct.
+func (c providerSubColumns) applyTo(p *storeq.InsertUserIdentityParams) {
+	p.ProviderSubHash = sql.NullString{String: c.hash, Valid: true}
+	p.ProviderSubHashKeyID = sql.NullString{String: c.hashKeyID, Valid: true}
+	p.ProviderSubHashVersion = sql.NullInt32{Int32: providerSubVersion, Valid: true}
+	p.ProviderSubCiphertext = c.ciphertext
+	p.ProviderSubNonce = c.nonce
+	p.ProviderSubEncKeyID = sql.NullString{String: c.encKeyID, Valid: true}
+	p.ProviderSubEncVersion = sql.NullInt32{Int32: providerSubVersion, Valid: true}
+}
+
+// ProviderSubBackfillRemaining counts identity rows still holding a plaintext
+// provider_user_id without an encrypted hash — the gate that must reach 0 before
+// the plaintext column can be dropped.
+func (s *Storage) ProviderSubBackfillRemaining(ctx context.Context) (int64, error) {
+	return storeq.New(s.db).CountProviderSubUnbackfilled(ctx)
+}
+
+// BackfillProviderSub encrypts every legacy plaintext provider_user_id into the
+// provider_sub_hash/ciphertext columns. Idempotent (only touches rows missing a
+// hash) and resumable (batched). Returns the number of rows backfilled.
+func (s *Storage) BackfillProviderSub(ctx context.Context) (int, error) {
+	if s.keys == nil {
+		return 0, ErrEncryptionNotConfigured
+	}
+	q := storeq.New(s.db)
+	total := 0
+	for {
+		rows, err := q.ListProviderSubBackfill(ctx, providerSubBackfillBatch)
+		if err != nil {
+			return total, fmt.Errorf("list provider_sub backfill: %w", err)
+		}
+		if len(rows) == 0 {
+			return total, nil
+		}
+		for _, r := range rows {
+			cols, err := s.encryptProviderSub(r.UserID, r.Provider, r.ProviderUserID.String)
+			if err != nil {
+				return total, err
+			}
+			if err := q.BackfillProviderSub(ctx, storeq.BackfillProviderSubParams{
+				ID:                     r.ID,
+				ProviderSubHash:        sql.NullString{String: cols.hash, Valid: true},
+				ProviderSubHashKeyID:   sql.NullString{String: cols.hashKeyID, Valid: true},
+				ProviderSubHashVersion: sql.NullInt32{Int32: providerSubVersion, Valid: true},
+				ProviderSubCiphertext:  cols.ciphertext,
+				ProviderSubNonce:       cols.nonce,
+				ProviderSubEncKeyID:    sql.NullString{String: cols.encKeyID, Valid: true},
+				ProviderSubEncVersion:  sql.NullInt32{Int32: providerSubVersion, Valid: true},
+			}); err != nil {
+				return total, fmt.Errorf("backfill provider_sub %s: %w", r.ID, err)
+			}
+			total++
+		}
+	}
+}

--- a/internal/storage/provider_sub_integration_test.go
+++ b/internal/storage/provider_sub_integration_test.go
@@ -1,0 +1,105 @@
+//go:build integration
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/kangheeyong/authgate/internal/crypto"
+)
+
+func TestProviderSub_EncryptedOnSignupAndLookup(t *testing.T) {
+	s := testStorage(t)
+	ctx := context.Background()
+	keys := testKeys(t, "enc-1", 0x11, "lkp-1", 0x22)
+	s.SetKeys(keys)
+	if err := s.EnsureCryptoEpochs(ctx); err != nil {
+		t.Fatalf("ensure epochs: %v", err)
+	}
+
+	const sub = "google-sub-xyz-123"
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+		Email: "ps@test.com", EmailVerified: true, Name: "PS", Provider: "google", ProviderUserID: sub,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Plaintext provider_user_id must be NULL; hash + ciphertext present and not raw.
+	var pUID, hash sql.NullString
+	var ct, nonce []byte
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT provider_user_id, provider_sub_hash, provider_sub_ciphertext, provider_sub_nonce
+		 FROM user_identities WHERE user_id = $1`, user.ID,
+	).Scan(&pUID, &hash, &ct, &nonce); err != nil {
+		t.Fatalf("read identity: %v", err)
+	}
+	if pUID.Valid {
+		t.Error("provider_user_id should be NULL when encrypted")
+	}
+	if !hash.Valid || hash.String == "" {
+		t.Error("provider_sub_hash missing")
+	}
+	if bytes.Contains(ct, []byte(sub)) {
+		t.Error("ciphertext contains the raw provider sub")
+	}
+
+	// Ciphertext decrypts back to the original sub (with the bound AAD).
+	aad := crypto.FieldAAD(providerSubAADField, user.ID, keys.EncKeyID(), providerSubVersion)
+	got, err := keys.DecryptPII(ct, nonce, aad)
+	if err != nil || string(got) != sub {
+		t.Fatalf("decrypt = %q err=%v, want %q", got, err, sub)
+	}
+
+	// Login matching works (lookup goes through the hash internally).
+	found, err := s.GetUserByProviderIdentity(ctx, "google", sub)
+	if err != nil || found.ID != user.ID {
+		t.Fatalf("lookup by sub: id=%v err=%v, want %v", found, err, user.ID)
+	}
+	if _, err := s.GetUserByProviderIdentity(ctx, "google", "not-a-sub"); err != ErrNotFound {
+		t.Errorf("lookup wrong sub err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestProviderSub_Backfill(t *testing.T) {
+	s := testStorage(t)
+	ctx := context.Background()
+
+	// Legacy plaintext identity (no keys → plaintext path).
+	const sub = "legacy-sub-789"
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+		Email: "legacy@test.com", EmailVerified: true, Name: "L", Provider: "google", ProviderUserID: sub,
+	})
+	if err != nil {
+		t.Fatalf("create legacy: %v", err)
+	}
+
+	// Configure keys and backfill.
+	s.SetKeys(testKeys(t, "enc-1", 0x11, "lkp-1", 0x22))
+	if err := s.EnsureCryptoEpochs(ctx); err != nil {
+		t.Fatalf("ensure epochs: %v", err)
+	}
+	n, err := s.BackfillProviderSub(ctx)
+	if err != nil || n != 1 {
+		t.Fatalf("backfill = %d err=%v, want 1", n, err)
+	}
+	remaining, err := s.ProviderSubBackfillRemaining(ctx)
+	if err != nil || remaining != 0 {
+		t.Fatalf("remaining = %d err=%v, want 0", remaining, err)
+	}
+
+	// Lookup now resolves via hash even though the row was created as plaintext.
+	found, err := s.GetUserByProviderIdentity(ctx, "google", sub)
+	if err != nil || found.ID != user.ID {
+		t.Fatalf("post-backfill lookup: id=%v err=%v", found, err)
+	}
+
+	// Idempotent: a second backfill touches nothing.
+	n2, err := s.BackfillProviderSub(ctx)
+	if err != nil || n2 != 0 {
+		t.Fatalf("second backfill = %d err=%v, want 0", n2, err)
+	}
+}

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -67,19 +67,44 @@ func (s *Storage) insertUserForSignup(ctx context.Context, qtx *storeq.Queries, 
 }
 
 func (s *Storage) insertIdentityForSignup(ctx context.Context, qtx *storeq.Queries, userID string, input CreateUserWithIdentityInput, now time.Time) error {
-	return qtx.InsertUserIdentity(ctx, storeq.InsertUserIdentityParams{
-		ID:             s.idgen.NewUUID(),
-		UserID:         userID,
-		Provider:       input.Provider,
-		ProviderUserID: input.ProviderUserID,
-		CreatedAt:      now,
-	})
+	params := storeq.InsertUserIdentityParams{
+		ID:        s.idgen.NewUUID(),
+		UserID:    userID,
+		Provider:  input.Provider,
+		CreatedAt: now,
+	}
+	// Encrypt the provider subject when keys are configured; otherwise keep the
+	// legacy plaintext path (ADR-002, keys-gated until the cleanup PR).
+	if s.keys != nil {
+		cols, err := s.encryptProviderSub(userID, input.Provider, input.ProviderUserID)
+		if err != nil {
+			return err
+		}
+		cols.applyTo(&params)
+	} else {
+		params.ProviderUserID = sql.NullString{String: input.ProviderUserID, Valid: true}
+	}
+	return qtx.InsertUserIdentity(ctx, params)
 }
 
 func (s *Storage) GetUserByProviderIdentity(ctx context.Context, provider, providerUserID string) (*User, error) {
-	row, err := storeq.New(s.db).GetUserByProviderIdentity(ctx, storeq.GetUserByProviderIdentityParams{
+	q := storeq.New(s.db)
+	if s.keys != nil {
+		row, err := q.GetUserByProviderSubHash(ctx, storeq.GetUserByProviderSubHashParams{
+			Provider:        provider,
+			ProviderSubHash: sql.NullString{String: s.keys.ProviderSubHash(provider, providerUserID), Valid: true},
+		})
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		if err != nil {
+			return nil, err
+		}
+		return buildFullUser(row.ID, row.Email, row.EmailVerified, row.Name, row.Status, row.CreatedAt, row.UpdatedAt), nil
+	}
+	row, err := q.GetUserByProviderIdentity(ctx, storeq.GetUserByProviderIdentityParams{
 		Provider:       provider,
-		ProviderUserID: providerUserID,
+		ProviderUserID: sql.NullString{String: providerUserID, Valid: true},
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound

--- a/migrations/010_user_identities_provider_sub.down.sql
+++ b/migrations/010_user_identities_provider_sub.down.sql
@@ -1,0 +1,17 @@
+DROP INDEX IF EXISTS user_identities_provider_sub_hash_key;
+
+ALTER TABLE user_identities
+    DROP CONSTRAINT IF EXISTS user_identities_provider_sub_hash_consistency,
+    DROP CONSTRAINT IF EXISTS user_identities_provider_sub_enc_consistency;
+
+ALTER TABLE user_identities
+    DROP COLUMN IF EXISTS provider_sub_hash,
+    DROP COLUMN IF EXISTS provider_sub_hash_key_id,
+    DROP COLUMN IF EXISTS provider_sub_hash_version,
+    DROP COLUMN IF EXISTS provider_sub_ciphertext,
+    DROP COLUMN IF EXISTS provider_sub_nonce,
+    DROP COLUMN IF EXISTS provider_sub_enc_key_id,
+    DROP COLUMN IF EXISTS provider_sub_enc_version;
+
+-- Note: provider_user_id NOT NULL is not restored here because rows written
+-- after the up migration may have a NULL provider_user_id.

--- a/migrations/010_user_identities_provider_sub.up.sql
+++ b/migrations/010_user_identities_provider_sub.up.sql
@@ -1,0 +1,31 @@
+-- provider subject를 평문(provider_user_id)이 아니라 lookup HMAC + AEAD ciphertext로
+-- 저장한다 (ADR-002). hash는 로그인 매칭(결정적), ciphertext는 LOOKUP root 회전 시
+-- rehash를 위한 복구용. 평문 provider_user_id는 백필 후 cleanup PR에서 제거한다.
+ALTER TABLE user_identities
+    ADD COLUMN provider_sub_hash         TEXT,
+    ADD COLUMN provider_sub_hash_key_id  TEXT REFERENCES crypto_key_epochs(key_id),
+    ADD COLUMN provider_sub_hash_version INTEGER,
+    ADD COLUMN provider_sub_ciphertext   BYTEA,
+    ADD COLUMN provider_sub_nonce        BYTEA,
+    ADD COLUMN provider_sub_enc_key_id   TEXT REFERENCES crypto_key_epochs(key_id),
+    ADD COLUMN provider_sub_enc_version  INTEGER;
+
+-- 백필 전까지 기존 행은 평문만, 신규 행은 암호화만 → 평문 컬럼을 nullable로.
+ALTER TABLE user_identities ALTER COLUMN provider_user_id DROP NOT NULL;
+
+-- 동반 컬럼은 전부 NULL이거나 전부 NOT NULL (백필 전 행은 전자, 신규 행은 후자).
+ALTER TABLE user_identities
+    ADD CONSTRAINT user_identities_provider_sub_hash_consistency CHECK (
+        (provider_sub_hash IS NULL AND provider_sub_hash_key_id IS NULL AND provider_sub_hash_version IS NULL)
+        OR
+        (provider_sub_hash IS NOT NULL AND provider_sub_hash_key_id IS NOT NULL AND provider_sub_hash_version IS NOT NULL)
+    ),
+    ADD CONSTRAINT user_identities_provider_sub_enc_consistency CHECK (
+        (provider_sub_ciphertext IS NULL AND provider_sub_nonce IS NULL AND provider_sub_enc_key_id IS NULL AND provider_sub_enc_version IS NULL)
+        OR
+        (provider_sub_ciphertext IS NOT NULL AND provider_sub_nonce IS NOT NULL AND provider_sub_enc_key_id IS NOT NULL AND provider_sub_enc_version IS NOT NULL)
+    );
+
+-- 로그인 매칭 UNIQUE를 hash로. 기존 UNIQUE(provider, provider_user_id)는 cleanup까지 공존.
+CREATE UNIQUE INDEX user_identities_provider_sub_hash_key
+    ON user_identities (provider, provider_sub_hash);


### PR DESCRIPTION
## 무엇

provider subject(Google sub)를 평문이 아니라 **lookup HMAC + AEAD ciphertext**로 저장한다. ADR-002의 첫 실제 필드 암호화.

- **hash**(LOOKUP): 로그인 매칭(결정적, UNIQUE)
- **ciphertext**(ENC): LOOKUP root 회전 시 rehash 복구용 (복호화 가능 — 당신 결정)

## keys-gated (비파괴)

root env 미설정 → 기존 평문 경로 그대로(기존 테스트 무영향). 설정 시 암호화 경로. 평문 fallback은 cleanup PR에서 제거.

## 구성

- **migration 010**: `provider_sub_hash`/`ciphertext`(+key_id/version FK→crypto_key_epochs), `provider_user_id` nullable, `UNIQUE(provider, provider_sub_hash)`, 동반컬럼 일관성 CHECK. 평문 컬럼 DROP은 cleanup PR.
- **storage**: 가입 시 hash+ciphertext 저장(AAD가 user_id 바인딩), 로그인은 hash 조회.
- **BackfillProviderSub**: 기존 평문 sub → hash+ciphertext (멱등·배치·resumable) + `ProviderSubBackfillRemaining` 검증 카운트.
- **app startup**: keys 설정 시 ensure epochs 후 백필 실행. 백필 완료 전 서빙 안 함(키 있으면 hash로 조회 → 미백필 행은 못 찾으므로).

## 검증

- 통합: 가입 시 평문 NULL·hash/cipher 저장·ciphertext에 raw sub 없음·**AAD로 복호화 roundtrip**·hash 조회 매칭. 백필(평문→암호, 멱등, remaining=0, 백필 후 조회 OK).
- 기존 평문 경로 테스트 전부 통과(keys-gated).
- `go test ./...` + `-tags=integration` green, `gofmt`·`go vet`·`golangci-lint`(clean cache) **0 issues**.

## 범위 / 다음

Option A: 필드 PR은 additive. **DROP·in-process 오케스트레이션·prod 키 필수화는 마지막 cleanup PR.**
다음: PR3 email/name → PR4 codes → PR5 세션 HMAC → PR6 cleanup(drop+orchestration) → VERSION 1번 단일 배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)