### PR TITLE
feat(crypto): user email/name 암호화 (ADR-002 PR3)

### DIFF
--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -15,9 +15,20 @@ erDiagram
     users ||--o{ audit_log : "1:N (이벤트 기록)"
     users {
         uuid id PK "DEFAULT uuid_generate_v4()"
-        text email UK "NOT NULL"
+        text email "nullable, 평문 (백필 후 cleanup PR에서 제거)"
+        bytea email_ciphertext "nullable, AEAD"
+        bytea email_nonce "nullable"
+        text email_enc_key_id "FK crypto_key_epochs"
+        int email_enc_version "nullable"
+        text email_hash "nullable, lookup HMAC, UNIQUE"
+        text email_hash_key_id "FK crypto_key_epochs"
+        int email_hash_version "nullable"
         boolean email_verified "NOT NULL, DEFAULT false"
-        text name "nullable"
+        text name "nullable, 평문 (제거 예정)"
+        bytea name_ciphertext "nullable, AEAD"
+        bytea name_nonce "nullable"
+        text name_enc_key_id "FK crypto_key_epochs"
+        int name_enc_version "nullable"
         text status "NOT NULL, DEFAULT 'active', CHECK (active/disabled/pending_deletion/deleted)"
         timestamptz deletion_requested_at "nullable"
         timestamptz deletion_scheduled_at "nullable"
@@ -248,6 +259,7 @@ MCP
 | 규칙 | 적용 |
 |------|------|
 | provider sub은 lookup HMAC + AEAD ciphertext로 저장 | `provider_sub_hash`(매칭) + `provider_sub_ciphertext`(회전 복구), 평문 `provider_user_id`는 백필 후 제거 |
+| email/name은 AEAD ciphertext로 저장, email은 lookup HMAC도 | `email_ciphertext`/`name_ciphertext` + `email_hash`(UNIQUE/정규화 lowercase+NFC), 평문 컬럼은 백필 후 제거. 탈퇴 시 ciphertext/hash redaction |
 | refresh_token은 SHA-256 해시로 저장 | `token_hash` 컬럼 |
 | 세션 쿠키(bearer)는 SHA-256 해시로 저장 | `sessions.token_hash` 컬럼 (`id`는 내부 PK, 쿠키 아님) |
 | audit_log.metadata의 `session_id`는 해시로 저장 | audit sanitize 시 SHA-256 (평문 bearer 미기록) |

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/zitadel/oidc/v3 v3.47.5
 	golang.org/x/crypto v0.52.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/text v0.37.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -87,6 +88,5 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/internal/app/crypto.go
+++ b/internal/app/crypto.go
@@ -64,4 +64,12 @@ func mustSetupCrypto(cfg *config.Config, store *storage.Storage) {
 	if n > 0 {
 		slog.Info("provider_sub backfill complete", "rows", n)
 	}
+
+	m, err := store.BackfillUserPII(ctx)
+	if err != nil {
+		log.Fatalf("crypto: user PII backfill: %v", err)
+	}
+	if m > 0 {
+		slog.Info("user PII backfill complete", "rows", m)
+	}
 }

--- a/internal/db/queries/cleanup.sql
+++ b/internal/db/queries/cleanup.sql
@@ -42,9 +42,15 @@ DELETE FROM refresh_tokens
 WHERE user_id = $1;
 
 -- name: MarkUserDeletedByID :execrows
+-- PII redaction on deletion (ADR-002): the plaintext tombstone replaces email,
+-- and every encrypted/hashed email/name column is cleared so no recoverable PII
+-- remains for the deleted user.
 UPDATE users SET
   email = 'deleted-' || id::text || '@deleted.invalid',
   name = NULL,
+  email_ciphertext = NULL, email_nonce = NULL, email_enc_key_id = NULL, email_enc_version = NULL,
+  email_hash = NULL, email_hash_key_id = NULL, email_hash_version = NULL,
+  name_ciphertext = NULL, name_nonce = NULL, name_enc_key_id = NULL, name_enc_version = NULL,
   status = 'deleted',
   deleted_at = sqlc.arg(deleted_at),
   deletion_requested_at = NULL,

--- a/internal/db/queries/sessions.sql
+++ b/internal/db/queries/sessions.sql
@@ -4,6 +4,8 @@ VALUES ($1, $2, $3, $4, $5);
 
 -- name: GetValidSessionUser :one
 SELECT u.id, u.email, u.email_verified, u.name, u.status,
+       u.email_ciphertext, u.email_nonce, u.email_enc_key_id, u.email_enc_version,
+       u.name_ciphertext, u.name_nonce, u.name_enc_key_id, u.name_enc_version,
        u.created_at, u.updated_at
 FROM sessions s
 JOIN users u ON s.user_id = u.id

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -1,6 +1,11 @@
 -- name: InsertUser :exec
-INSERT INTO users (id, email, email_verified, name, status, created_at, updated_at)
-VALUES ($1, $2, $3, $4, 'active', $5, $5);
+INSERT INTO users (
+    id, email, email_verified, name, status,
+    email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
+    email_hash, email_hash_key_id, email_hash_version,
+    name_ciphertext, name_nonce, name_enc_key_id, name_enc_version,
+    created_at, updated_at
+) VALUES ($1, $2, $3, $4, 'active', $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $16);
 
 -- name: InsertUserIdentity :exec
 INSERT INTO user_identities (
@@ -12,6 +17,8 @@ INSERT INTO user_identities (
 
 -- name: GetUserByProviderIdentity :one
 SELECT u.id, u.email, u.email_verified, u.name, u.status,
+       u.email_ciphertext, u.email_nonce, u.email_enc_key_id, u.email_enc_version,
+       u.name_ciphertext, u.name_nonce, u.name_enc_key_id, u.name_enc_version,
        u.created_at, u.updated_at
 FROM users u
 JOIN user_identities ui ON u.id = ui.user_id
@@ -19,6 +26,8 @@ WHERE ui.provider = $1 AND ui.provider_user_id = $2;
 
 -- name: GetUserByProviderSubHash :one
 SELECT u.id, u.email, u.email_verified, u.name, u.status,
+       u.email_ciphertext, u.email_nonce, u.email_enc_key_id, u.email_enc_version,
+       u.name_ciphertext, u.name_nonce, u.name_enc_key_id, u.name_enc_version,
        u.created_at, u.updated_at
 FROM users u
 JOIN user_identities ui ON u.id = ui.user_id
@@ -49,18 +58,51 @@ WHERE id = $1;
 
 -- name: GetUserByID :one
 SELECT id, email, email_verified, name, status,
+       email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
+       name_ciphertext, name_nonce, name_enc_key_id, name_enc_version,
        created_at, updated_at
 FROM users
 WHERE id = $1;
 
 -- name: GetUserForTxByID :one
-SELECT id, email, email_verified, name, status
+SELECT id, email, email_verified, name, status,
+       email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
+       name_ciphertext, name_nonce, name_enc_key_id, name_enc_version
 FROM users
 WHERE id = $1;
 
 -- name: GetUserInfoFieldsByID :one
-SELECT id, email, email_verified, name
+SELECT id, email, email_verified, name,
+       email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
+       name_ciphertext, name_nonce, name_enc_key_id, name_enc_version
 FROM users
+WHERE id = $1;
+
+-- name: ListUsersBackfill :many
+SELECT id, email, name
+FROM users
+WHERE email_hash IS NULL AND email IS NOT NULL
+ORDER BY id
+LIMIT $1;
+
+-- name: CountUsersUnbackfilled :one
+SELECT count(*)
+FROM users
+WHERE email_hash IS NULL AND email IS NOT NULL;
+
+-- name: BackfillUserPII :exec
+UPDATE users SET
+    email_ciphertext   = $2,
+    email_nonce        = $3,
+    email_enc_key_id   = $4,
+    email_enc_version  = $5,
+    email_hash         = $6,
+    email_hash_key_id  = $7,
+    email_hash_version = $8,
+    name_ciphertext    = $9,
+    name_nonce         = $10,
+    name_enc_key_id    = $11,
+    name_enc_version   = $12
 WHERE id = $1;
 
 -- name: CompleteAuthRequestByID :execrows

--- a/internal/db/storeq/cleanup.sql.go
+++ b/internal/db/storeq/cleanup.sql.go
@@ -177,6 +177,9 @@ const markUserDeletedByID = `-- name: MarkUserDeletedByID :execrows
 UPDATE users SET
   email = 'deleted-' || id::text || '@deleted.invalid',
   name = NULL,
+  email_ciphertext = NULL, email_nonce = NULL, email_enc_key_id = NULL, email_enc_version = NULL,
+  email_hash = NULL, email_hash_key_id = NULL, email_hash_version = NULL,
+  name_ciphertext = NULL, name_nonce = NULL, name_enc_key_id = NULL, name_enc_version = NULL,
   status = 'deleted',
   deleted_at = $1,
   deletion_requested_at = NULL,
@@ -189,6 +192,9 @@ type MarkUserDeletedByIDParams struct {
 	UserID    string
 }
 
+// PII redaction on deletion (ADR-002): the plaintext tombstone replaces email,
+// and every encrypted/hashed email/name column is cleared so no recoverable PII
+// remains for the deleted user.
 func (q *Queries) MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedByIDParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, markUserDeletedByID, arg.DeletedAt, arg.UserID)
 	if err != nil {

--- a/internal/db/storeq/models.go
+++ b/internal/db/storeq/models.go
@@ -91,7 +91,7 @@ type Session struct {
 
 type User struct {
 	ID                  string
-	Email               string
+	Email               sql.NullString
 	EmailVerified       bool
 	Name                sql.NullString
 	Status              string
@@ -100,6 +100,17 @@ type User struct {
 	DeletedAt           sql.NullTime
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
+	EmailCiphertext     []byte
+	EmailNonce          []byte
+	EmailEncKeyID       sql.NullString
+	EmailEncVersion     sql.NullInt32
+	EmailHash           sql.NullString
+	EmailHashKeyID      sql.NullString
+	EmailHashVersion    sql.NullInt32
+	NameCiphertext      []byte
+	NameNonce           []byte
+	NameEncKeyID        sql.NullString
+	NameEncVersion      sql.NullInt32
 }
 
 type UserIdentity struct {

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -14,8 +14,10 @@ type Querier interface {
 	AnonymizeAuditLogBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	ApproveDeviceCodeByUserCode(ctx context.Context, arg ApproveDeviceCodeByUserCodeParams) (int64, error)
 	BackfillProviderSub(ctx context.Context, arg BackfillProviderSubParams) error
+	BackfillUserPII(ctx context.Context, arg BackfillUserPIIParams) error
 	CompleteAuthRequestByID(ctx context.Context, arg CompleteAuthRequestByIDParams) (int64, error)
 	CountProviderSubUnbackfilled(ctx context.Context) (int64, error)
+	CountUsersUnbackfilled(ctx context.Context) (int64, error)
 	DeleteAuthRequestByID(ctx context.Context, id string) error
 	DeleteExpiredAuthRequestsBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteExpiredDeviceCodesBefore(ctx context.Context, cutoff time.Time) (int64, error)
@@ -54,7 +56,11 @@ type Querier interface {
 	InsertUserIdentity(ctx context.Context, arg InsertUserIdentityParams) error
 	ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff sql.NullTime) ([]string, error)
 	ListProviderSubBackfill(ctx context.Context, limit int32) ([]ListProviderSubBackfillRow, error)
+	ListUsersBackfill(ctx context.Context, limit int32) ([]ListUsersBackfillRow, error)
 	MarkRefreshTokenUsedAndRevokedByID(ctx context.Context, arg MarkRefreshTokenUsedAndRevokedByIDParams) error
+	// PII redaction on deletion (ADR-002): the plaintext tombstone replaces email,
+	// and every encrypted/hashed email/name column is cleared so no recoverable PII
+	// remains for the deleted user.
 	MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedByIDParams) (int64, error)
 	MarkUserPendingDeletionByID(ctx context.Context, arg MarkUserPendingDeletionByIDParams) (int64, error)
 	RecoverPendingDeletionUserByID(ctx context.Context, arg RecoverPendingDeletionUserByIDParams) error

--- a/internal/db/storeq/sessions.sql.go
+++ b/internal/db/storeq/sessions.sql.go
@@ -13,6 +13,8 @@ import (
 
 const getValidSessionUser = `-- name: GetValidSessionUser :one
 SELECT u.id, u.email, u.email_verified, u.name, u.status,
+       u.email_ciphertext, u.email_nonce, u.email_enc_key_id, u.email_enc_version,
+       u.name_ciphertext, u.name_nonce, u.name_enc_key_id, u.name_enc_version,
        u.created_at, u.updated_at
 FROM sessions s
 JOIN users u ON s.user_id = u.id
@@ -27,13 +29,21 @@ type GetValidSessionUserParams struct {
 }
 
 type GetValidSessionUserRow struct {
-	ID            string
-	Email         string
-	EmailVerified bool
-	Name          sql.NullString
-	Status        string
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	ID              string
+	Email           sql.NullString
+	EmailVerified   bool
+	Name            sql.NullString
+	Status          string
+	EmailCiphertext []byte
+	EmailNonce      []byte
+	EmailEncKeyID   sql.NullString
+	EmailEncVersion sql.NullInt32
+	NameCiphertext  []byte
+	NameNonce       []byte
+	NameEncKeyID    sql.NullString
+	NameEncVersion  sql.NullInt32
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
 }
 
 func (q *Queries) GetValidSessionUser(ctx context.Context, arg GetValidSessionUserParams) (GetValidSessionUserRow, error) {
@@ -45,6 +55,14 @@ func (q *Queries) GetValidSessionUser(ctx context.Context, arg GetValidSessionUs
 		&i.EmailVerified,
 		&i.Name,
 		&i.Status,
+		&i.EmailCiphertext,
+		&i.EmailNonce,
+		&i.EmailEncKeyID,
+		&i.EmailEncVersion,
+		&i.NameCiphertext,
+		&i.NameNonce,
+		&i.NameEncKeyID,
+		&i.NameEncVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/internal/db/storeq/users.sql.go
+++ b/internal/db/storeq/users.sql.go
@@ -48,6 +48,55 @@ func (q *Queries) BackfillProviderSub(ctx context.Context, arg BackfillProviderS
 	return err
 }
 
+const backfillUserPII = `-- name: BackfillUserPII :exec
+UPDATE users SET
+    email_ciphertext   = $2,
+    email_nonce        = $3,
+    email_enc_key_id   = $4,
+    email_enc_version  = $5,
+    email_hash         = $6,
+    email_hash_key_id  = $7,
+    email_hash_version = $8,
+    name_ciphertext    = $9,
+    name_nonce         = $10,
+    name_enc_key_id    = $11,
+    name_enc_version   = $12
+WHERE id = $1
+`
+
+type BackfillUserPIIParams struct {
+	ID               string
+	EmailCiphertext  []byte
+	EmailNonce       []byte
+	EmailEncKeyID    sql.NullString
+	EmailEncVersion  sql.NullInt32
+	EmailHash        sql.NullString
+	EmailHashKeyID   sql.NullString
+	EmailHashVersion sql.NullInt32
+	NameCiphertext   []byte
+	NameNonce        []byte
+	NameEncKeyID     sql.NullString
+	NameEncVersion   sql.NullInt32
+}
+
+func (q *Queries) BackfillUserPII(ctx context.Context, arg BackfillUserPIIParams) error {
+	_, err := q.db.ExecContext(ctx, backfillUserPII,
+		arg.ID,
+		arg.EmailCiphertext,
+		arg.EmailNonce,
+		arg.EmailEncKeyID,
+		arg.EmailEncVersion,
+		arg.EmailHash,
+		arg.EmailHashKeyID,
+		arg.EmailHashVersion,
+		arg.NameCiphertext,
+		arg.NameNonce,
+		arg.NameEncKeyID,
+		arg.NameEncVersion,
+	)
+	return err
+}
+
 const completeAuthRequestByID = `-- name: CompleteAuthRequestByID :execrows
 UPDATE auth_requests
 SET subject = $1, auth_time = $2, done = true
@@ -81,21 +130,44 @@ func (q *Queries) CountProviderSubUnbackfilled(ctx context.Context) (int64, erro
 	return count, err
 }
 
+const countUsersUnbackfilled = `-- name: CountUsersUnbackfilled :one
+SELECT count(*)
+FROM users
+WHERE email_hash IS NULL AND email IS NOT NULL
+`
+
+func (q *Queries) CountUsersUnbackfilled(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countUsersUnbackfilled)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const getUserByID = `-- name: GetUserByID :one
 SELECT id, email, email_verified, name, status,
+       email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
+       name_ciphertext, name_nonce, name_enc_key_id, name_enc_version,
        created_at, updated_at
 FROM users
 WHERE id = $1
 `
 
 type GetUserByIDRow struct {
-	ID            string
-	Email         string
-	EmailVerified bool
-	Name          sql.NullString
-	Status        string
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	ID              string
+	Email           sql.NullString
+	EmailVerified   bool
+	Name            sql.NullString
+	Status          string
+	EmailCiphertext []byte
+	EmailNonce      []byte
+	EmailEncKeyID   sql.NullString
+	EmailEncVersion sql.NullInt32
+	NameCiphertext  []byte
+	NameNonce       []byte
+	NameEncKeyID    sql.NullString
+	NameEncVersion  sql.NullInt32
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
 }
 
 func (q *Queries) GetUserByID(ctx context.Context, id string) (GetUserByIDRow, error) {
@@ -107,6 +179,14 @@ func (q *Queries) GetUserByID(ctx context.Context, id string) (GetUserByIDRow, e
 		&i.EmailVerified,
 		&i.Name,
 		&i.Status,
+		&i.EmailCiphertext,
+		&i.EmailNonce,
+		&i.EmailEncKeyID,
+		&i.EmailEncVersion,
+		&i.NameCiphertext,
+		&i.NameNonce,
+		&i.NameEncKeyID,
+		&i.NameEncVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -115,6 +195,8 @@ func (q *Queries) GetUserByID(ctx context.Context, id string) (GetUserByIDRow, e
 
 const getUserByProviderIdentity = `-- name: GetUserByProviderIdentity :one
 SELECT u.id, u.email, u.email_verified, u.name, u.status,
+       u.email_ciphertext, u.email_nonce, u.email_enc_key_id, u.email_enc_version,
+       u.name_ciphertext, u.name_nonce, u.name_enc_key_id, u.name_enc_version,
        u.created_at, u.updated_at
 FROM users u
 JOIN user_identities ui ON u.id = ui.user_id
@@ -127,13 +209,21 @@ type GetUserByProviderIdentityParams struct {
 }
 
 type GetUserByProviderIdentityRow struct {
-	ID            string
-	Email         string
-	EmailVerified bool
-	Name          sql.NullString
-	Status        string
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	ID              string
+	Email           sql.NullString
+	EmailVerified   bool
+	Name            sql.NullString
+	Status          string
+	EmailCiphertext []byte
+	EmailNonce      []byte
+	EmailEncKeyID   sql.NullString
+	EmailEncVersion sql.NullInt32
+	NameCiphertext  []byte
+	NameNonce       []byte
+	NameEncKeyID    sql.NullString
+	NameEncVersion  sql.NullInt32
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
 }
 
 func (q *Queries) GetUserByProviderIdentity(ctx context.Context, arg GetUserByProviderIdentityParams) (GetUserByProviderIdentityRow, error) {
@@ -145,6 +235,14 @@ func (q *Queries) GetUserByProviderIdentity(ctx context.Context, arg GetUserByPr
 		&i.EmailVerified,
 		&i.Name,
 		&i.Status,
+		&i.EmailCiphertext,
+		&i.EmailNonce,
+		&i.EmailEncKeyID,
+		&i.EmailEncVersion,
+		&i.NameCiphertext,
+		&i.NameNonce,
+		&i.NameEncKeyID,
+		&i.NameEncVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -153,6 +251,8 @@ func (q *Queries) GetUserByProviderIdentity(ctx context.Context, arg GetUserByPr
 
 const getUserByProviderSubHash = `-- name: GetUserByProviderSubHash :one
 SELECT u.id, u.email, u.email_verified, u.name, u.status,
+       u.email_ciphertext, u.email_nonce, u.email_enc_key_id, u.email_enc_version,
+       u.name_ciphertext, u.name_nonce, u.name_enc_key_id, u.name_enc_version,
        u.created_at, u.updated_at
 FROM users u
 JOIN user_identities ui ON u.id = ui.user_id
@@ -165,13 +265,21 @@ type GetUserByProviderSubHashParams struct {
 }
 
 type GetUserByProviderSubHashRow struct {
-	ID            string
-	Email         string
-	EmailVerified bool
-	Name          sql.NullString
-	Status        string
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	ID              string
+	Email           sql.NullString
+	EmailVerified   bool
+	Name            sql.NullString
+	Status          string
+	EmailCiphertext []byte
+	EmailNonce      []byte
+	EmailEncKeyID   sql.NullString
+	EmailEncVersion sql.NullInt32
+	NameCiphertext  []byte
+	NameNonce       []byte
+	NameEncKeyID    sql.NullString
+	NameEncVersion  sql.NullInt32
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
 }
 
 func (q *Queries) GetUserByProviderSubHash(ctx context.Context, arg GetUserByProviderSubHashParams) (GetUserByProviderSubHashRow, error) {
@@ -183,6 +291,14 @@ func (q *Queries) GetUserByProviderSubHash(ctx context.Context, arg GetUserByPro
 		&i.EmailVerified,
 		&i.Name,
 		&i.Status,
+		&i.EmailCiphertext,
+		&i.EmailNonce,
+		&i.EmailEncKeyID,
+		&i.EmailEncVersion,
+		&i.NameCiphertext,
+		&i.NameNonce,
+		&i.NameEncKeyID,
+		&i.NameEncVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -190,17 +306,27 @@ func (q *Queries) GetUserByProviderSubHash(ctx context.Context, arg GetUserByPro
 }
 
 const getUserForTxByID = `-- name: GetUserForTxByID :one
-SELECT id, email, email_verified, name, status
+SELECT id, email, email_verified, name, status,
+       email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
+       name_ciphertext, name_nonce, name_enc_key_id, name_enc_version
 FROM users
 WHERE id = $1
 `
 
 type GetUserForTxByIDRow struct {
-	ID            string
-	Email         string
-	EmailVerified bool
-	Name          sql.NullString
-	Status        string
+	ID              string
+	Email           sql.NullString
+	EmailVerified   bool
+	Name            sql.NullString
+	Status          string
+	EmailCiphertext []byte
+	EmailNonce      []byte
+	EmailEncKeyID   sql.NullString
+	EmailEncVersion sql.NullInt32
+	NameCiphertext  []byte
+	NameNonce       []byte
+	NameEncKeyID    sql.NullString
+	NameEncVersion  sql.NullInt32
 }
 
 func (q *Queries) GetUserForTxByID(ctx context.Context, id string) (GetUserForTxByIDRow, error) {
@@ -212,21 +338,39 @@ func (q *Queries) GetUserForTxByID(ctx context.Context, id string) (GetUserForTx
 		&i.EmailVerified,
 		&i.Name,
 		&i.Status,
+		&i.EmailCiphertext,
+		&i.EmailNonce,
+		&i.EmailEncKeyID,
+		&i.EmailEncVersion,
+		&i.NameCiphertext,
+		&i.NameNonce,
+		&i.NameEncKeyID,
+		&i.NameEncVersion,
 	)
 	return i, err
 }
 
 const getUserInfoFieldsByID = `-- name: GetUserInfoFieldsByID :one
-SELECT id, email, email_verified, name
+SELECT id, email, email_verified, name,
+       email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
+       name_ciphertext, name_nonce, name_enc_key_id, name_enc_version
 FROM users
 WHERE id = $1
 `
 
 type GetUserInfoFieldsByIDRow struct {
-	ID            string
-	Email         string
-	EmailVerified bool
-	Name          sql.NullString
+	ID              string
+	Email           sql.NullString
+	EmailVerified   bool
+	Name            sql.NullString
+	EmailCiphertext []byte
+	EmailNonce      []byte
+	EmailEncKeyID   sql.NullString
+	EmailEncVersion sql.NullInt32
+	NameCiphertext  []byte
+	NameNonce       []byte
+	NameEncKeyID    sql.NullString
+	NameEncVersion  sql.NullInt32
 }
 
 func (q *Queries) GetUserInfoFieldsByID(ctx context.Context, id string) (GetUserInfoFieldsByIDRow, error) {
@@ -237,6 +381,14 @@ func (q *Queries) GetUserInfoFieldsByID(ctx context.Context, id string) (GetUser
 		&i.Email,
 		&i.EmailVerified,
 		&i.Name,
+		&i.EmailCiphertext,
+		&i.EmailNonce,
+		&i.EmailEncKeyID,
+		&i.EmailEncVersion,
+		&i.NameCiphertext,
+		&i.NameNonce,
+		&i.NameEncKeyID,
+		&i.NameEncVersion,
 	)
 	return i, err
 }
@@ -334,16 +486,32 @@ func (q *Queries) InsertTestAuthRequestWithResource(ctx context.Context, arg Ins
 }
 
 const insertUser = `-- name: InsertUser :exec
-INSERT INTO users (id, email, email_verified, name, status, created_at, updated_at)
-VALUES ($1, $2, $3, $4, 'active', $5, $5)
+INSERT INTO users (
+    id, email, email_verified, name, status,
+    email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
+    email_hash, email_hash_key_id, email_hash_version,
+    name_ciphertext, name_nonce, name_enc_key_id, name_enc_version,
+    created_at, updated_at
+) VALUES ($1, $2, $3, $4, 'active', $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $16)
 `
 
 type InsertUserParams struct {
-	ID            string
-	Email         string
-	EmailVerified bool
-	Name          sql.NullString
-	CreatedAt     time.Time
+	ID               string
+	Email            sql.NullString
+	EmailVerified    bool
+	Name             sql.NullString
+	EmailCiphertext  []byte
+	EmailNonce       []byte
+	EmailEncKeyID    sql.NullString
+	EmailEncVersion  sql.NullInt32
+	EmailHash        sql.NullString
+	EmailHashKeyID   sql.NullString
+	EmailHashVersion sql.NullInt32
+	NameCiphertext   []byte
+	NameNonce        []byte
+	NameEncKeyID     sql.NullString
+	NameEncVersion   sql.NullInt32
+	CreatedAt        time.Time
 }
 
 func (q *Queries) InsertUser(ctx context.Context, arg InsertUserParams) error {
@@ -352,6 +520,17 @@ func (q *Queries) InsertUser(ctx context.Context, arg InsertUserParams) error {
 		arg.Email,
 		arg.EmailVerified,
 		arg.Name,
+		arg.EmailCiphertext,
+		arg.EmailNonce,
+		arg.EmailEncKeyID,
+		arg.EmailEncVersion,
+		arg.EmailHash,
+		arg.EmailHashKeyID,
+		arg.EmailHashVersion,
+		arg.NameCiphertext,
+		arg.NameNonce,
+		arg.NameEncKeyID,
+		arg.NameEncVersion,
 		arg.CreatedAt,
 	)
 	return err
@@ -429,6 +608,43 @@ func (q *Queries) ListProviderSubBackfill(ctx context.Context, limit int32) ([]L
 			&i.Provider,
 			&i.ProviderUserID,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listUsersBackfill = `-- name: ListUsersBackfill :many
+SELECT id, email, name
+FROM users
+WHERE email_hash IS NULL AND email IS NOT NULL
+ORDER BY id
+LIMIT $1
+`
+
+type ListUsersBackfillRow struct {
+	ID    string
+	Email sql.NullString
+	Name  sql.NullString
+}
+
+func (q *Queries) ListUsersBackfill(ctx context.Context, limit int32) ([]ListUsersBackfillRow, error) {
+	rows, err := q.db.QueryContext(ctx, listUsersBackfill, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListUsersBackfillRow
+	for rows.Next() {
+		var i ListUsersBackfillRow
+		if err := rows.Scan(&i.ID, &i.Email, &i.Name); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -31,7 +31,9 @@ func (s *Storage) CreateUserWithIdentity(ctx context.Context, input CreateUserWi
 
 	err = s.insertUserForSignup(ctx, qtx, userID, input, now)
 	if err != nil {
-		if isUniqueViolation(err, "users_email_key") {
+		// Plaintext path conflicts on users_email_key; encrypted path on the
+		// email_hash unique index.
+		if isUniqueViolation(err, "users_email_key") || isUniqueViolation(err, usersEmailHashKey) {
 			return nil, ErrEmailConflict
 		}
 		return nil, err
@@ -57,13 +59,22 @@ func (s *Storage) CreateUserWithIdentity(ctx context.Context, input CreateUserWi
 }
 
 func (s *Storage) insertUserForSignup(ctx context.Context, qtx *storeq.Queries, userID string, input CreateUserWithIdentityInput, now time.Time) error {
-	return qtx.InsertUser(ctx, storeq.InsertUserParams{
+	params := storeq.InsertUserParams{
 		ID:            userID,
-		Email:         input.Email,
 		EmailVerified: input.EmailVerified,
-		Name:          sql.NullString{String: input.Name, Valid: true},
 		CreatedAt:     now,
-	})
+	}
+	// Encrypt email/name when keys are configured; otherwise keep the legacy
+	// plaintext path (ADR-002, keys-gated until the cleanup PR).
+	if s.keys != nil {
+		if err := s.applyUserPIIEncryption(&params, userID, input.Email, input.Name); err != nil {
+			return err
+		}
+	} else {
+		params.Email = nullStr(input.Email)
+		params.Name = nullStr(input.Name)
+	}
+	return qtx.InsertUser(ctx, params)
 }
 
 func (s *Storage) insertIdentityForSignup(ctx context.Context, qtx *storeq.Queries, userID string, input CreateUserWithIdentityInput, now time.Time) error {
@@ -100,7 +111,11 @@ func (s *Storage) GetUserByProviderIdentity(ctx context.Context, provider, provi
 		if err != nil {
 			return nil, err
 		}
-		return buildFullUser(row.ID, row.Email, row.EmailVerified, row.Name, row.Status, row.CreatedAt, row.UpdatedAt), nil
+		email, name, err := s.resolveUserPII(row.ID, row.Email, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.Name, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
+		if err != nil {
+			return nil, err
+		}
+		return buildFullUser(row.ID, email, row.EmailVerified, name, row.Status, row.CreatedAt, row.UpdatedAt), nil
 	}
 	row, err := q.GetUserByProviderIdentity(ctx, storeq.GetUserByProviderIdentityParams{
 		Provider:       provider,
@@ -112,7 +127,11 @@ func (s *Storage) GetUserByProviderIdentity(ctx context.Context, provider, provi
 	if err != nil {
 		return nil, err
 	}
-	return buildFullUser(row.ID, row.Email, row.EmailVerified, row.Name, row.Status, row.CreatedAt, row.UpdatedAt), nil
+	email, name, err := s.resolveUserPII(row.ID, row.Email, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.Name, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
+	if err != nil {
+		return nil, err
+	}
+	return buildFullUser(row.ID, email, row.EmailVerified, name, row.Status, row.CreatedAt, row.UpdatedAt), nil
 }
 
 func (s *Storage) getUserByID(ctx context.Context, tx *sql.Tx, userID string) (*User, error) {
@@ -123,7 +142,11 @@ func (s *Storage) getUserByID(ctx context.Context, tx *sql.Tx, userID string) (*
 	if err != nil {
 		return nil, err
 	}
-	return buildCoreUser(row.ID, row.Email, row.EmailVerified, row.Name, row.Status), nil
+	email, name, err := s.resolveUserPII(row.ID, row.Email, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.Name, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
+	if err != nil {
+		return nil, err
+	}
+	return buildCoreUser(row.ID, email, row.EmailVerified, name, row.Status), nil
 }
 
 // GetUserByID returns a user by ID. Public wrapper for DB-level re-read after mutations.
@@ -135,7 +158,11 @@ func (s *Storage) GetUserByID(ctx context.Context, userID string) (*User, error)
 	if err != nil {
 		return nil, err
 	}
-	return buildFullUser(row.ID, row.Email, row.EmailVerified, row.Name, row.Status, row.CreatedAt, row.UpdatedAt), nil
+	email, name, err := s.resolveUserPII(row.ID, row.Email, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.Name, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
+	if err != nil {
+		return nil, err
+	}
+	return buildFullUser(row.ID, email, row.EmailVerified, name, row.Status, row.CreatedAt, row.UpdatedAt), nil
 }
 
 // RecoverUser recovers a pending_deletion user to active.
@@ -171,11 +198,15 @@ func (s *Storage) setUserinfo(ctx context.Context, userinfo *oidc.UserInfo, user
 	if err != nil {
 		return err
 	}
+	email, name, err := s.resolveUserPII(row.ID, row.Email, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.Name, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
+	if err != nil {
+		return err
+	}
 	u := &User{
 		ID:            row.ID,
-		Email:         row.Email,
+		Email:         email,
 		EmailVerified: row.EmailVerified,
-		Name:          nullStringToString(row.Name),
+		Name:          nullStringToString(name),
 	}
 
 	for _, scope := range scopes {
@@ -357,7 +388,11 @@ func (s *Storage) GetValidSession(ctx context.Context, sessionID string) (*User,
 	if err != nil {
 		return nil, err
 	}
-	user := buildFullUser(row.ID, row.Email, row.EmailVerified, row.Name, row.Status, row.CreatedAt, row.UpdatedAt)
+	email, name, err := s.resolveUserPII(row.ID, row.Email, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.Name, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
+	if err != nil {
+		return nil, err
+	}
+	user := buildFullUser(row.ID, email, row.EmailVerified, name, row.Status, row.CreatedAt, row.UpdatedAt)
 	if err := requireUsableUser(user); err != nil {
 		return user, err
 	}

--- a/internal/storage/users_pii.go
+++ b/internal/storage/users_pii.go
@@ -1,0 +1,138 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/kangheeyong/authgate/internal/crypto"
+	"github.com/kangheeyong/authgate/internal/db/storeq"
+)
+
+const (
+	emailAADField     = "users.email"
+	nameAADField      = "users.name"
+	userPIIVersion    = 1
+	userPIIBatch      = 500
+	usersEmailHashKey = "users_email_hash_key"
+)
+
+// normalizeEmail canonicalizes an email for the lookup hash: Unicode NFC +
+// trim + lowercase (ADR-002, provider-independent — no dot/plus handling).
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(norm.NFC.String(email)))
+}
+
+func nullStr(s string) sql.NullString { return sql.NullString{String: s, Valid: true} }
+func nullI32(i int) sql.NullInt32     { return sql.NullInt32{Int32: int32(i), Valid: true} }
+
+// applyUserPIIEncryption fills the encrypted email/name + email_hash columns of
+// an insert params struct from plaintext, leaving the plaintext columns NULL.
+// Requires keys configured.
+func (s *Storage) applyUserPIIEncryption(p *storeq.InsertUserParams, userID, email, name string) error {
+	emailCT, emailNonce, err := s.keys.EncryptPII([]byte(email), crypto.FieldAAD(emailAADField, userID, s.keys.EncKeyID(), userPIIVersion))
+	if err != nil {
+		return fmt.Errorf("encrypt email: %w", err)
+	}
+	p.EmailCiphertext = emailCT
+	p.EmailNonce = emailNonce
+	p.EmailEncKeyID = nullStr(s.keys.EncKeyID())
+	p.EmailEncVersion = nullI32(userPIIVersion)
+	p.EmailHash = nullStr(s.keys.EmailHash(normalizeEmail(email)))
+	p.EmailHashKeyID = nullStr(s.keys.LookupKeyID())
+	p.EmailHashVersion = nullI32(userPIIVersion)
+
+	if name != "" {
+		nameCT, nameNonce, err := s.keys.EncryptPII([]byte(name), crypto.FieldAAD(nameAADField, userID, s.keys.EncKeyID(), userPIIVersion))
+		if err != nil {
+			return fmt.Errorf("encrypt name: %w", err)
+		}
+		p.NameCiphertext = nameCT
+		p.NameNonce = nameNonce
+		p.NameEncKeyID = nullStr(s.keys.EncKeyID())
+		p.NameEncVersion = nullI32(userPIIVersion)
+	}
+	return nil
+}
+
+// resolveUserPII returns the plaintext email and name for a user row, decrypting
+// when keys are configured and the ciphertext is present, otherwise falling back
+// to the legacy plaintext columns (keys-gated). The argument order matches the
+// SELECTed column order so every user-returning query maps to it in one line.
+func (s *Storage) resolveUserPII(
+	userID string,
+	emailPlain sql.NullString, emailCipher, emailNonce []byte, emailEncKeyID sql.NullString, emailEncVersion sql.NullInt32,
+	namePlain sql.NullString, nameCipher, nameNonce []byte, nameEncKeyID sql.NullString, nameEncVersion sql.NullInt32,
+) (email string, name sql.NullString, err error) {
+	if s.keys != nil && len(emailCipher) > 0 {
+		pt, derr := s.keys.DecryptPII(emailCipher, emailNonce, crypto.FieldAAD(emailAADField, userID, emailEncKeyID.String, int(emailEncVersion.Int32)))
+		if derr != nil {
+			return "", sql.NullString{}, fmt.Errorf("decrypt email: %w", derr)
+		}
+		email = string(pt)
+	} else {
+		email = emailPlain.String
+	}
+
+	if s.keys != nil && len(nameCipher) > 0 {
+		pt, derr := s.keys.DecryptPII(nameCipher, nameNonce, crypto.FieldAAD(nameAADField, userID, nameEncKeyID.String, int(nameEncVersion.Int32)))
+		if derr != nil {
+			return "", sql.NullString{}, fmt.Errorf("decrypt name: %w", derr)
+		}
+		name = nullStr(string(pt))
+	} else {
+		name = namePlain
+	}
+	return email, name, nil
+}
+
+// UserPIIBackfillRemaining counts users still holding a plaintext email without
+// an email_hash — the gate that must reach 0 before dropping plaintext columns.
+func (s *Storage) UserPIIBackfillRemaining(ctx context.Context) (int64, error) {
+	return storeq.New(s.db).CountUsersUnbackfilled(ctx)
+}
+
+// BackfillUserPII encrypts every legacy plaintext email/name into the ciphertext
+// + email_hash columns. Idempotent (only rows missing email_hash) and batched.
+func (s *Storage) BackfillUserPII(ctx context.Context) (int, error) {
+	if s.keys == nil {
+		return 0, ErrEncryptionNotConfigured
+	}
+	q := storeq.New(s.db)
+	total := 0
+	for {
+		rows, err := q.ListUsersBackfill(ctx, userPIIBatch)
+		if err != nil {
+			return total, fmt.Errorf("list user backfill: %w", err)
+		}
+		if len(rows) == 0 {
+			return total, nil
+		}
+		for _, r := range rows {
+			var p storeq.InsertUserParams // reuse for column carriers only
+			if err := s.applyUserPIIEncryption(&p, r.ID, r.Email.String, r.Name.String); err != nil {
+				return total, err
+			}
+			if err := q.BackfillUserPII(ctx, storeq.BackfillUserPIIParams{
+				ID:               r.ID,
+				EmailCiphertext:  p.EmailCiphertext,
+				EmailNonce:       p.EmailNonce,
+				EmailEncKeyID:    p.EmailEncKeyID,
+				EmailEncVersion:  p.EmailEncVersion,
+				EmailHash:        p.EmailHash,
+				EmailHashKeyID:   p.EmailHashKeyID,
+				EmailHashVersion: p.EmailHashVersion,
+				NameCiphertext:   p.NameCiphertext,
+				NameNonce:        p.NameNonce,
+				NameEncKeyID:     p.NameEncKeyID,
+				NameEncVersion:   p.NameEncVersion,
+			}); err != nil {
+				return total, fmt.Errorf("backfill user %s: %w", r.ID, err)
+			}
+			total++
+		}
+	}
+}

--- a/internal/storage/users_pii_integration_test.go
+++ b/internal/storage/users_pii_integration_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+)
+
+func encStorage(t *testing.T) *Storage {
+	t.Helper()
+	s := testStorage(t)
+	s.SetKeys(testKeys(t, "enc-1", 0x11, "lkp-1", 0x22))
+	if err := s.EnsureCryptoEpochs(context.Background()); err != nil {
+		t.Fatalf("ensure epochs: %v", err)
+	}
+	return s
+}
+
+func TestUserPII_EncryptedSignupAndAllReadPaths(t *testing.T) {
+	s := encStorage(t)
+	ctx := context.Background()
+
+	const email, name, sub = "Person@Example.com", "Alice", "sub-1"
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+		Email: email, EmailVerified: true, Name: name, Provider: "google", ProviderUserID: sub,
+	})
+	if err != nil {
+		t.Fatalf("signup: %v", err)
+	}
+
+	// Plaintext columns NULL; ciphertext present and not containing the raw values.
+	var ePlain, nPlain sql.NullString
+	var eCT, nCT []byte
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT email, name, email_ciphertext, name_ciphertext FROM users WHERE id=$1`, user.ID,
+	).Scan(&ePlain, &nPlain, &eCT, &nCT); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if ePlain.Valid || nPlain.Valid {
+		t.Error("plaintext email/name should be NULL when encrypted")
+	}
+	if bytes.Contains(eCT, []byte(email)) || bytes.Contains(nCT, []byte(name)) {
+		t.Error("ciphertext contains raw PII")
+	}
+
+	// Every user-returning read path must decrypt email + name.
+	check := func(label string, u *User, err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+		if u.Email != email || u.Name != name {
+			t.Errorf("%s: email=%q name=%q, want %q/%q", label, u.Email, u.Name, email, name)
+		}
+	}
+	byID, err := s.GetUserByID(ctx, user.ID)
+	check("GetUserByID", byID, err)
+
+	byProv, err := s.GetUserByProviderIdentity(ctx, "google", sub)
+	check("GetUserByProviderIdentity", byProv, err)
+
+	token, err := s.CreateSession(ctx, user.ID, time.Hour)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	bySession, err := s.GetValidSession(ctx, token)
+	check("GetValidSession", bySession, err)
+}
+
+func TestUserPII_EmailUniquenessNormalized(t *testing.T) {
+	s := encStorage(t)
+	ctx := context.Background()
+
+	if _, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+		Email: "dup@example.com", EmailVerified: true, Name: "A", Provider: "google", ProviderUserID: "s1",
+	}); err != nil {
+		t.Fatalf("first signup: %v", err)
+	}
+	// Same email with different case/whitespace normalizes to the same hash.
+	_, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+		Email: "  DUP@Example.com ", EmailVerified: true, Name: "B", Provider: "google", ProviderUserID: "s2",
+	})
+	if !errors.Is(err, ErrEmailConflict) {
+		t.Fatalf("err = %v, want ErrEmailConflict", err)
+	}
+}
+
+func TestUserPII_Backfill(t *testing.T) {
+	s := testStorage(t) // no keys → plaintext signup
+	ctx := context.Background()
+
+	const email, name, sub = "legacy@example.com", "Legacy", "legacy-sub"
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+		Email: email, EmailVerified: true, Name: name, Provider: "google", ProviderUserID: sub,
+	})
+	if err != nil {
+		t.Fatalf("legacy signup: %v", err)
+	}
+
+	s.SetKeys(testKeys(t, "enc-1", 0x11, "lkp-1", 0x22))
+	if err := s.EnsureCryptoEpochs(ctx); err != nil {
+		t.Fatalf("ensure epochs: %v", err)
+	}
+	n, err := s.BackfillUserPII(ctx)
+	if err != nil || n != 1 {
+		t.Fatalf("backfill = %d err=%v, want 1", n, err)
+	}
+	remaining, err := s.UserPIIBackfillRemaining(ctx)
+	if err != nil || remaining != 0 {
+		t.Fatalf("remaining = %d err=%v, want 0", remaining, err)
+	}
+
+	// Reads now decrypt the backfilled values.
+	got, err := s.GetUserByID(ctx, user.ID)
+	if err != nil || got.Email != email || got.Name != name {
+		t.Fatalf("post-backfill read: %+v err=%v", got, err)
+	}
+
+	n2, err := s.BackfillUserPII(ctx)
+	if err != nil || n2 != 0 {
+		t.Fatalf("second backfill = %d err=%v, want 0", n2, err)
+	}
+}

--- a/migrations/011_users_email_name.down.sql
+++ b/migrations/011_users_email_name.down.sql
@@ -1,0 +1,21 @@
+DROP INDEX IF EXISTS users_email_hash_key;
+
+ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS users_email_enc_consistency,
+    DROP CONSTRAINT IF EXISTS users_email_hash_consistency,
+    DROP CONSTRAINT IF EXISTS users_name_enc_consistency;
+
+ALTER TABLE users
+    DROP COLUMN IF EXISTS email_ciphertext,
+    DROP COLUMN IF EXISTS email_nonce,
+    DROP COLUMN IF EXISTS email_enc_key_id,
+    DROP COLUMN IF EXISTS email_enc_version,
+    DROP COLUMN IF EXISTS email_hash,
+    DROP COLUMN IF EXISTS email_hash_key_id,
+    DROP COLUMN IF EXISTS email_hash_version,
+    DROP COLUMN IF EXISTS name_ciphertext,
+    DROP COLUMN IF EXISTS name_nonce,
+    DROP COLUMN IF EXISTS name_enc_key_id,
+    DROP COLUMN IF EXISTS name_enc_version;
+
+-- email NOT NULL은 복원하지 않는다 (up 이후 행의 email이 NULL일 수 있음).

--- a/migrations/011_users_email_name.up.sql
+++ b/migrations/011_users_email_name.up.sql
@@ -1,0 +1,38 @@
+-- users.email / users.name을 평문 대신 AEAD ciphertext로 저장한다 (ADR-002).
+-- email은 uniqueness/lookup을 위해 HMAC(email_hash)도 함께 둔다. 평문 email/name은
+-- 백필 후 cleanup PR에서 제거한다.
+ALTER TABLE users
+    ADD COLUMN email_ciphertext   BYTEA,
+    ADD COLUMN email_nonce        BYTEA,
+    ADD COLUMN email_enc_key_id   TEXT REFERENCES crypto_key_epochs(key_id),
+    ADD COLUMN email_enc_version  INTEGER,
+    ADD COLUMN email_hash         TEXT,
+    ADD COLUMN email_hash_key_id  TEXT REFERENCES crypto_key_epochs(key_id),
+    ADD COLUMN email_hash_version INTEGER,
+    ADD COLUMN name_ciphertext    BYTEA,
+    ADD COLUMN name_nonce         BYTEA,
+    ADD COLUMN name_enc_key_id    TEXT REFERENCES crypto_key_epochs(key_id),
+    ADD COLUMN name_enc_version   INTEGER;
+
+-- 백필 전 행은 평문 email, 신규 행은 암호화 email → 평문 컬럼 nullable.
+ALTER TABLE users ALTER COLUMN email DROP NOT NULL;
+
+-- uniqueness를 email_hash로 이동. 기존 users_email_key(평문)는 cleanup까지 공존.
+CREATE UNIQUE INDEX users_email_hash_key ON users (email_hash);
+
+ALTER TABLE users
+    ADD CONSTRAINT users_email_enc_consistency CHECK (
+        (email_ciphertext IS NULL AND email_nonce IS NULL AND email_enc_key_id IS NULL AND email_enc_version IS NULL)
+        OR
+        (email_ciphertext IS NOT NULL AND email_nonce IS NOT NULL AND email_enc_key_id IS NOT NULL AND email_enc_version IS NOT NULL)
+    ),
+    ADD CONSTRAINT users_email_hash_consistency CHECK (
+        (email_hash IS NULL AND email_hash_key_id IS NULL AND email_hash_version IS NULL)
+        OR
+        (email_hash IS NOT NULL AND email_hash_key_id IS NOT NULL AND email_hash_version IS NOT NULL)
+    ),
+    ADD CONSTRAINT users_name_enc_consistency CHECK (
+        (name_ciphertext IS NULL AND name_nonce IS NULL AND name_enc_key_id IS NULL AND name_enc_version IS NULL)
+        OR
+        (name_ciphertext IS NOT NULL AND name_nonce IS NOT NULL AND name_enc_key_id IS NOT NULL AND name_enc_version IS NOT NULL)
+    );


### PR DESCRIPTION
## 무엇

`users.email`/`name`을 평문 대신 **AEAD ciphertext**로 저장한다. email은 uniqueness/lookup용 **HMAC(`email_hash`, lowercase+NFC 정규화)**도 함께. ADR-002 필드 암호화 2번째.

## keys-gated (비파괴)

root 미설정 → 평문 경로(기존 테스트 무영향). 설정 시 암호화. 평문 fallback은 cleanup PR에서 제거.

## 구성

- **migration 011**: `email_ciphertext`/`name_ciphertext`(+key_id/version), `email_hash`(+key_id/version), `email` nullable, `UNIQUE(email_hash)`, 동반컬럼 일관성 CHECK.
- **storage**: 가입 시 암호화 저장(AAD=user_id). **모든 user 반환 경로(login/provider_sub/session/byID/txByID/userinfo) storage 경계 복호화.** email 충돌은 `email_hash` UNIQUE로 감지.
- **BackfillUserPII** + `UserPIIBackfillRemaining` (멱등·배치).
- **탈퇴 redaction**: `MarkUserDeletedByID`가 email/name ciphertext/hash도 NULL scrub → 복구 가능 PII 제거.
- **app startup**: provider_sub 백필 후 user PII 백필.

## 검증

- 통합: 암호화 저장(평문 NULL, raw 미포함), **6개 읽기 경로 전부 복호화 확인**(byID/provider/session), 정규화된 email_hash 유니크 충돌, 백필(멱등, remaining=0).
- 기존 평문 경로 전체 통과(keys-gated).
- `go test ./...` + `-tags=integration` green, `gofmt`·`go vet`·`golangci-lint`(clean cache) **0 issues**.

## 범위 / 다음

Option A: 필드 PR은 additive. drop·오케스트레이션·prod 키 필수화는 cleanup PR.
다음: PR4 codes → PR5 세션 HMAC → PR6 cleanup → VERSION 1번 단일 배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)