### PR TITLE
feat(crypto): 단명 코드 at-rest 해시 (ADR-002 PR4)

### DIFF
--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -260,6 +260,7 @@ MCP
 |------|------|
 | provider sub은 lookup HMAC + AEAD ciphertext로 저장 | `provider_sub_hash`(매칭) + `provider_sub_ciphertext`(회전 복구), 평문 `provider_user_id`는 백필 후 제거 |
 | email/name은 AEAD ciphertext로 저장, email은 lookup HMAC도 | `email_ciphertext`/`name_ciphertext` + `email_hash`(UNIQUE/정규화 lowercase+NFC), 평문 컬럼은 백필 후 제거. 탈퇴 시 ciphertext/hash redaction |
+| 단명 코드(device_code/user_code/authz code)는 lookup HMAC로 저장 | 기존 컬럼에 in-place 해시(키 설정 시). 짧은 수명이라 drain, 반환 모델은 평문 입력값 |
 | refresh_token은 SHA-256 해시로 저장 | `token_hash` 컬럼 |
 | 세션 쿠키(bearer)는 SHA-256 해시로 저장 | `sessions.token_hash` 컬럼 (`id`는 내부 PK, 쿠키 아님) |
 | audit_log.metadata의 `session_id`는 해시로 저장 | audit sanitize 시 SHA-256 (평문 bearer 미기록) |

--- a/internal/integration/integration_crypto_test.go
+++ b/internal/integration/integration_crypto_test.go
@@ -1,0 +1,37 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestIntegration_Crypto_DeviceUserCodeLookup verifies the device flow still
+// resolves a user_code end-to-end through the real server when PII/code
+// encryption is enabled (ADR-002): StoreDeviceAuthorization hashes the codes at
+// rest, and the device callback's user_code lookup must hash the incoming code
+// to match. Reaching the post-lookup 403 (account_not_found) proves the lookup
+// succeeded — a broken hash path would fail the user_code lookup earlier.
+func TestIntegration_Crypto_DeviceUserCodeLookup(t *testing.T) {
+	ts := SetupTestServerWithOptions(t, SetupOptions{EnableMCP: true, EnableCrypto: true})
+	ctx := context.Background()
+
+	if err := ts.Store.StoreDeviceAuthorization(ctx, "test-client", "fresh-dc", "TEST-CODE", ts.Clock.Now().Add(5*time.Minute), []string{"openid"}); err != nil {
+		t.Fatalf("seed device_code: %v", err)
+	}
+
+	resp, err := http.Get(ts.BaseURL + "/device/auth/callback?code=fake-code&state=TEST-CODE")
+	if err != nil {
+		t.Fatalf("device callback: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status=%d, want 403 (post-lookup account check) body=%s", resp.StatusCode, string(body))
+	}
+}

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
@@ -15,6 +16,7 @@ import (
 
 	mcpadapter "github.com/kangheeyong/authgate/internal/adapter/mcp"
 	"github.com/kangheeyong/authgate/internal/clock"
+	"github.com/kangheeyong/authgate/internal/crypto"
 	"github.com/kangheeyong/authgate/internal/handler"
 	"github.com/kangheeyong/authgate/internal/idgen"
 	"golang.org/x/time/rate"
@@ -47,6 +49,37 @@ func SetupTestServer(t *testing.T) *TestServer {
 
 type SetupOptions struct {
 	EnableMCP bool
+	// EnableCrypto wires PII at-rest encryption keys + epochs so e2e flows run
+	// the encrypted path (ADR-002).
+	EnableCrypto bool
+}
+
+// setupCryptoKeys derives test crypto keys and registers their epochs.
+func setupCryptoKeys(t *testing.T, store *storage.Storage) {
+	t.Helper()
+	mk := func(b byte) []byte {
+		s := make([]byte, crypto.KeySize)
+		for i := range s {
+			s[i] = b
+		}
+		return s
+	}
+	enc, err := crypto.NewRoot(crypto.DomainEnc, "enc-test-1", mk(0x31))
+	if err != nil {
+		t.Fatalf("enc root: %v", err)
+	}
+	lookup, err := crypto.NewRoot(crypto.DomainLookup, "lkp-test-1", mk(0x32))
+	if err != nil {
+		t.Fatalf("lookup root: %v", err)
+	}
+	keys, err := crypto.NewKeys(enc, lookup)
+	if err != nil {
+		t.Fatalf("keys: %v", err)
+	}
+	store.SetKeys(keys)
+	if err := store.EnsureCryptoEpochs(context.Background()); err != nil {
+		t.Fatalf("ensure epochs: %v", err)
+	}
 }
 
 // SetupTestServerWithOptions creates a full authgate server with selectable optional adapters.
@@ -66,6 +99,9 @@ func SetupTestServerWithOptions(t *testing.T, opts SetupOptions) *TestServer {
 
 	store := storage.New(db, clk, gen, stateChecker, 15*time.Minute, 30*24*time.Hour)
 	store.SetDevicePollInterval(devicePollInterval)
+	if opts.EnableCrypto {
+		setupCryptoKeys(t, store)
+	}
 	if opts.EnableMCP {
 		cimdFetcher := mcpadapter.NewHTTPCIMDFetcher()
 		clientPolicy := mcpadapter.NewClientResolutionPolicy(storage.NewCoreClientResolutionPolicy(store), cimdFetcher)

--- a/internal/storage/codes.go
+++ b/internal/storage/codes.go
@@ -1,0 +1,13 @@
+package storage
+
+// codeAtRest hashes a short-lived code (device_code / user_code / OAuth
+// authorization code) for storage and lookup when crypto keys are configured
+// (ADR-002, keys-gated). These codes are short-lived, so the rollout drains
+// naturally — no backfill. Returned models carry the plaintext code the caller
+// supplied, never the stored hash.
+func (s *Storage) codeAtRest(code string) string {
+	if s.keys != nil {
+		return s.keys.CodeHash(code)
+	}
+	return code
+}

--- a/internal/storage/codes_integration_test.go
+++ b/internal/storage/codes_integration_test.go
@@ -1,0 +1,75 @@
+//go:build integration
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCodes_HashedAtRest(t *testing.T) {
+	s := testStorage(t)
+	ctx := context.Background()
+	s.SetKeys(testKeys(t, "enc-1", 0x11, "lkp-1", 0x22))
+	if err := s.EnsureCryptoEpochs(ctx); err != nil {
+		t.Fatalf("ensure epochs: %v", err)
+	}
+
+	// --- device_code / user_code ---
+	if err := s.StoreDeviceAuthorization(ctx, "test-client", "dev-code-1", "USERCODE1", s.clock.Now().Add(5*time.Minute), []string{"openid"}); err != nil {
+		t.Fatalf("store device auth: %v", err)
+	}
+	dc, err := s.GetDeviceCodeByUserCode(ctx, "USERCODE1")
+	if err != nil {
+		t.Fatalf("lookup by user_code: %v", err)
+	}
+	if dc.UserCode != "USERCODE1" {
+		t.Errorf("returned UserCode=%q, want plaintext input", dc.UserCode)
+	}
+	if _, err := s.GetDeviceCodeByUserCode(ctx, "WRONG-CODE"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("wrong user_code err=%v, want ErrNotFound", err)
+	}
+
+	var storedUC, storedDC string
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT user_code, device_code FROM device_codes WHERE client_id='test-client'`,
+	).Scan(&storedUC, &storedDC); err != nil {
+		t.Fatalf("read device row: %v", err)
+	}
+	if storedUC == "USERCODE1" || storedDC == "dev-code-1" {
+		t.Error("device/user code stored in plaintext")
+	}
+
+	// --- OAuth authorization code ---
+	arID, err := s.CreateTestAuthRequest(ctx, "code-test")
+	if err != nil {
+		t.Fatalf("create auth request: %v", err)
+	}
+	if err := s.SaveAuthCode(ctx, arID, "AUTHCODE-XYZ"); err != nil {
+		t.Fatalf("save auth code: %v", err)
+	}
+	ar, err := s.AuthRequestByCode(ctx, "AUTHCODE-XYZ")
+	if err != nil {
+		t.Fatalf("lookup by code: %v", err)
+	}
+	// The returned model surfaces the plaintext code, not the stored hash.
+	arm, ok := ar.(*AuthRequestModel)
+	if !ok {
+		t.Fatalf("unexpected auth request type %T", ar)
+	}
+	if arm.Code == nil || *arm.Code != "AUTHCODE-XYZ" {
+		t.Errorf("returned Code=%v, want plaintext AUTHCODE-XYZ", arm.Code)
+	}
+
+	var storedCode string
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT code FROM auth_requests WHERE id=$1`, arID,
+	).Scan(&storedCode); err != nil {
+		t.Fatalf("read auth request row: %v", err)
+	}
+	if storedCode == "AUTHCODE-XYZ" {
+		t.Error("authorization code stored in plaintext")
+	}
+}

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -87,7 +87,7 @@ func (s *Storage) AuthRequestByID(ctx context.Context, id string) (op.AuthReques
 }
 
 func (s *Storage) AuthRequestByCode(ctx context.Context, code string) (op.AuthRequest, error) {
-	row, err := storeq.New(s.db).GetAuthRequestByCode(ctx, sql.NullString{String: code, Valid: true})
+	row, err := storeq.New(s.db).GetAuthRequestByCode(ctx, sql.NullString{String: s.codeAtRest(code), Valid: true})
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -95,6 +95,8 @@ func (s *Storage) AuthRequestByCode(ctx context.Context, code string) (op.AuthRe
 		return nil, err
 	}
 	ar := authRequestModelFromRowByCode(row)
+	// Surface the plaintext code the caller supplied, not the stored hash.
+	ar.Code = &code
 	if s.clock.Now().After(ar.ExpiresAt) {
 		return nil, &oidc.Error{ErrorType: "invalid_grant", Description: "authorization code expired"}
 	}
@@ -116,7 +118,7 @@ func (s *Storage) AuthRequestByCode(ctx context.Context, code string) (op.AuthRe
 
 func (s *Storage) SaveAuthCode(ctx context.Context, id string, code string) error {
 	return storeq.New(s.db).UpdateAuthRequestCode(ctx, storeq.UpdateAuthRequestCodeParams{
-		Code: sql.NullString{String: code, Valid: true},
+		Code: sql.NullString{String: s.codeAtRest(code), Valid: true},
 		ID:   id,
 	})
 }

--- a/internal/storage/storage_oidc_device.go
+++ b/internal/storage/storage_oidc_device.go
@@ -113,8 +113,8 @@ func (s *Storage) Health(ctx context.Context) error {
 func (s *Storage) StoreDeviceAuthorization(ctx context.Context, clientID, deviceCode, userCode string, expires time.Time, scopes []string) error {
 	if err := storeq.New(s.db).InsertDeviceCode(ctx, storeq.InsertDeviceCodeParams{
 		ID:         s.idgen.NewUUID(),
-		DeviceCode: deviceCode,
-		UserCode:   userCode,
+		DeviceCode: s.codeAtRest(deviceCode),
+		UserCode:   s.codeAtRest(userCode),
 		ClientID:   clientID,
 		Scopes:     scopes,
 		ExpiresAt:  expires,
@@ -139,7 +139,7 @@ func (s *Storage) GetDeviceAuthorizatonState(ctx context.Context, clientID, devi
 	defer func() { _ = tx.Rollback() }()
 	qtx := storeq.New(tx)
 
-	dc, err := loadDeviceAuthorizationForUpdate(ctx, qtx, clientID, deviceCode)
+	dc, err := loadDeviceAuthorizationForUpdate(ctx, qtx, clientID, s.codeAtRest(deviceCode))
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func (s *Storage) GetDeviceAuthorizatonState(ctx context.Context, clientID, devi
 
 // GetDeviceCodeByUserCode looks up a device code by user_code for the approval page.
 func (s *Storage) GetDeviceCodeByUserCode(ctx context.Context, userCode string) (*DeviceCodeModel, error) {
-	row, err := storeq.New(s.db).GetDeviceCodeByUserCode(ctx, userCode)
+	row, err := storeq.New(s.db).GetDeviceCodeByUserCode(ctx, s.codeAtRest(userCode))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -216,9 +216,11 @@ func (s *Storage) GetDeviceCodeByUserCode(ctx context.Context, userCode string) 
 		return nil, err
 	}
 	return &DeviceCodeModel{
-		ID:         row.ID,
-		DeviceCode: row.DeviceCode,
-		UserCode:   row.UserCode,
+		ID: row.ID,
+		// Return the plaintext user_code the caller supplied, never the stored
+		// hash. device_code is not surfaced by the approval flow.
+		DeviceCode: "",
+		UserCode:   userCode,
 		ClientID:   row.ClientID,
 		Scopes:     StringArray(row.Scopes),
 		State:      row.State,
@@ -234,7 +236,7 @@ func (s *Storage) ApproveDeviceCode(ctx context.Context, userCode, subject strin
 	rows, err := storeq.New(s.db).ApproveDeviceCodeByUserCode(ctx, storeq.ApproveDeviceCodeByUserCodeParams{
 		Subject:  sql.NullString{String: subject, Valid: true},
 		AuthTime: sql.NullTime{Time: now, Valid: true},
-		UserCode: userCode,
+		UserCode: s.codeAtRest(userCode),
 	})
 	if err != nil {
 		return err
@@ -244,7 +246,7 @@ func (s *Storage) ApproveDeviceCode(ctx context.Context, userCode, subject strin
 
 // DenyDeviceCode sets a device code to denied state.
 func (s *Storage) DenyDeviceCode(ctx context.Context, userCode string) error {
-	return storeq.New(s.db).DenyDeviceCodeByUserCode(ctx, userCode)
+	return storeq.New(s.db).DenyDeviceCodeByUserCode(ctx, s.codeAtRest(userCode))
 }
 
 // Compile-time interface checks


### PR DESCRIPTION
## 무엇

`device_code` / `user_code` / OAuth authorization code를 평문 대신 **lookup HMAC**로 저장. 짧은 수명이라 새 컬럼/백필 없이 **기존 컬럼에 in-place 해시(drain)**.

## keys-gated (비파괴)

root 미설정 → 평문 경로(기존 테스트 무영향). 설정 시 해시.

## 구성

- 저장/조회 시 `codeAtRest()`로 해시: `StoreDeviceAuthorization`, `GetDeviceCodeByUserCode`, `ApproveDeviceCode`, `DenyDeviceCode`, `loadDeviceAuthorizationForUpdate`, `SaveAuthCode`, `AuthRequestByCode`.
- **반환 모델의 code 필드는 호출자가 넘긴 평문을 surface** → zitadel이 되읽어도 안전 (`AuthRequest.Code`=plaintext, device 모델 `UserCode`=plaintext, `DeviceCode`=빈값).
- 마이그레이션/백필 없음(drain).

## 검증

- 통합: device/user/authz code 해시 roundtrip, **DB에 평문 미저장**, 반환 모델 평문 surface, 잘못된 코드 not-found.
- **keys-on e2e**: device callback user_code 조회가 전체 서버 경로(handler→service→store)에서 정상 동작(해시 매칭) → 403 post-lookup 도달로 확인.
- 통합 서버 `EnableCrypto` 옵션 추가.
- `go test ./...` + `-tags=integration` green, `gofmt`·`go vet`·`golangci-lint`(clean cache) 0 issues.

## 다음

PR5 세션 token_hash → session HMAC 정렬 → PR6 cleanup(drop+오케스트레이션+prod 필수화) → VERSION 1번 단일 배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)