### PR TITLE
feat(crypto): 세션 토큰 해시를 lookup/session HMAC로 정렬 (ADR-002 PR5)

### DIFF
--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -67,7 +67,7 @@ erDiagram
     sessions {
         uuid id PK "DEFAULT uuid_generate_v4(), 내부 PK (쿠키 아님)"
         uuid user_id FK "NOT NULL, CASCADE"
-        text token_hash UK "nullable, 세션 쿠키 bearer의 SHA-256 해시"
+        text token_hash UK "nullable, 세션 쿠키 bearer 해시 (키 설정 시 lookup/session HMAC, 아니면 SHA-256)"
         timestamptz expires_at "NOT NULL, 기본 24시간(SESSION_TTL)"
         timestamptz revoked_at "nullable, 로그아웃 시 설정"
         timestamptz created_at "NOT NULL, DEFAULT NOW()"
@@ -262,7 +262,7 @@ MCP
 | email/name은 AEAD ciphertext로 저장, email은 lookup HMAC도 | `email_ciphertext`/`name_ciphertext` + `email_hash`(UNIQUE/정규화 lowercase+NFC), 평문 컬럼은 백필 후 제거. 탈퇴 시 ciphertext/hash redaction |
 | 단명 코드(device_code/user_code/authz code)는 lookup HMAC로 저장 | 기존 컬럼에 in-place 해시(키 설정 시). 짧은 수명이라 drain, 반환 모델은 평문 입력값 |
 | refresh_token은 SHA-256 해시로 저장 | `token_hash` 컬럼 |
-| 세션 쿠키(bearer)는 SHA-256 해시로 저장 | `sessions.token_hash` 컬럼 (`id`는 내부 PK, 쿠키 아님) |
+| 세션 쿠키(bearer)는 해시로 저장 | `sessions.token_hash` (`id`는 내부 PK). 키 설정 시 lookup/session HMAC, 아니면 SHA-256 |
 | audit_log.metadata의 `session_id`는 해시로 저장 | audit sanitize 시 SHA-256 (평문 bearer 미기록) |
 | client_secret은 bcrypt 해시로 저장 | `clients.yaml`의 `client_secret_hash` 필드 |
 | access_token(JWT)은 DB에 저장하지 않음 | stateless |

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -164,7 +164,7 @@ type AuditClientContext struct {
 func (s *Storage) GetAuditClientContextBySessionID(ctx context.Context, userID, sessionID string) (AuditClientContext, error) {
 	row, err := storeq.New(s.db).GetAuditClientContextBySessionID(ctx, storeq.GetAuditClientContextBySessionIDParams{
 		UserID:    userID,
-		SessionID: hashToken(sessionID),
+		SessionID: s.sessionAtRest(sessionID),
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return AuditClientContext{}, ErrNotFound
@@ -182,7 +182,7 @@ func (s *Storage) GetAuditClientContextBySessionID(ctx context.Context, userID, 
 // included in failure logs to avoid leaking session/family identifiers.
 func (s *Storage) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
 	ipAddress = normalizeIPAddress(ipAddress)
-	metadata = sanitizeAuditMetadata(ctx, eventType, metadata)
+	metadata = s.sanitizeAuditMetadata(ctx, eventType, metadata)
 	var metaJSON []byte
 	if metadata != nil {
 		marshaled, err := json.Marshal(metadata)
@@ -214,7 +214,7 @@ func (s *Storage) AuditLog(ctx context.Context, userID *string, eventType, ipAdd
 	}
 }
 
-func sanitizeAuditMetadata(ctx context.Context, eventType string, metadata map[string]any) map[string]any {
+func (s *Storage) sanitizeAuditMetadata(ctx context.Context, eventType string, metadata map[string]any) map[string]any {
 	if len(metadata) == 0 {
 		return nil
 	}
@@ -247,7 +247,7 @@ func sanitizeAuditMetadata(ctx context.Context, eventType string, metadata map[s
 	// an audit-log read cannot recover a live bearer (ADR-002). The hash matches
 	// sessions.token_hash, so GetAuditClientContextBySessionID still correlates.
 	if raw, ok := sanitized["session_id"].(string); ok && raw != "" {
-		sanitized["session_id"] = hashToken(raw)
+		sanitized["session_id"] = s.sessionAtRest(raw)
 	}
 	if len(sanitized) == 0 {
 		return nil

--- a/internal/storage/audit_unit_test.go
+++ b/internal/storage/audit_unit_test.go
@@ -47,7 +47,7 @@ func TestSanitizeAuditMetadata_AllowsKnownKeysOnly(t *testing.T) {
 		"access_token":   "secret-token",
 	}
 
-	got := sanitizeAuditMetadata(context.Background(), "auth.login", metadata)
+	got := (&Storage{}).sanitizeAuditMetadata(context.Background(), "auth.login", metadata)
 	want := map[string]any{
 		"channel":     "browser",
 		"client_id":   "client-1",
@@ -65,7 +65,7 @@ func TestSanitizeAuditMetadata_AllowsKnownKeysOnly(t *testing.T) {
 }
 
 func TestSanitizeAuditMetadata_UnknownEventDropsMetadata(t *testing.T) {
-	got := sanitizeAuditMetadata(context.Background(), "custom.event", map[string]any{
+	got := (&Storage{}).sanitizeAuditMetadata(context.Background(), "custom.event", map[string]any{
 		"client_id": "client-1",
 	})
 	if got != nil {
@@ -74,7 +74,7 @@ func TestSanitizeAuditMetadata_UnknownEventDropsMetadata(t *testing.T) {
 }
 
 func TestSanitizeAuditMetadata_EmptyResultReturnsNil(t *testing.T) {
-	got := sanitizeAuditMetadata(context.Background(), "auth.login", map[string]any{
+	got := (&Storage{}).sanitizeAuditMetadata(context.Background(), "auth.login", map[string]any{
 		"email": "person@example.com",
 	})
 	if got != nil {

--- a/internal/storage/codes.go
+++ b/internal/storage/codes.go
@@ -11,3 +11,14 @@ func (s *Storage) codeAtRest(code string) string {
 	}
 	return code
 }
+
+// sessionAtRest hashes a session bearer token for storage/lookup. Uses the
+// lookup/session HMAC subkey when keys are configured (ADR-002), otherwise the
+// legacy SHA-256 (keys-gated). Used for sessions.token_hash and the audit
+// session_id so both correlate. Short-lived → drain, no backfill.
+func (s *Storage) sessionAtRest(token string) string {
+	if s.keys != nil {
+		return s.keys.SessionHash(token)
+	}
+	return hashToken(token)
+}

--- a/internal/storage/session_hmac_integration_test.go
+++ b/internal/storage/session_hmac_integration_test.go
@@ -1,0 +1,48 @@
+//go:build integration
+
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSession_UsesSessionHMACWhenEncrypted(t *testing.T) {
+	s := testStorage(t)
+	ctx := context.Background()
+	keys := testKeys(t, "enc-1", 0x11, "lkp-1", 0x22)
+	s.SetKeys(keys)
+	if err := s.EnsureCryptoEpochs(ctx); err != nil {
+		t.Fatalf("ensure epochs: %v", err)
+	}
+	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+		Email: "sess-hmac@test.com", EmailVerified: true, Name: "S", Provider: "google", ProviderUserID: "sess-hmac-sub",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	token, err := s.CreateSession(ctx, user.ID, time.Hour)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	var stored string
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT token_hash FROM sessions WHERE user_id=$1`, user.ID,
+	).Scan(&stored); err != nil {
+		t.Fatalf("read token_hash: %v", err)
+	}
+	if stored != keys.SessionHash(token) {
+		t.Error("token_hash is not the lookup/session HMAC")
+	}
+	if stored == hashToken(token) {
+		t.Error("token_hash still uses legacy SHA-256 when keys configured")
+	}
+
+	got, err := s.GetValidSession(ctx, token)
+	if err != nil || got.ID != user.ID {
+		t.Fatalf("validate session: id=%v err=%v", got, err)
+	}
+}

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -367,7 +367,7 @@ func (s *Storage) CreateSession(ctx context.Context, userID string, ttl time.Dur
 	if err := storeq.New(s.db).InsertSession(ctx, storeq.InsertSessionParams{
 		ID:        s.idgen.NewUUID(),
 		UserID:    userID,
-		TokenHash: sql.NullString{String: hashToken(token), Valid: true},
+		TokenHash: sql.NullString{String: s.sessionAtRest(token), Valid: true},
 		ExpiresAt: now.Add(ttl),
 		CreatedAt: now,
 	}); err != nil {
@@ -379,7 +379,7 @@ func (s *Storage) CreateSession(ctx context.Context, userID string, ttl time.Dur
 func (s *Storage) GetValidSession(ctx context.Context, sessionID string) (*User, error) {
 	now := s.clock.Now()
 	row, err := storeq.New(s.db).GetValidSessionUser(ctx, storeq.GetValidSessionUserParams{
-		TokenHash: hashToken(sessionID),
+		TokenHash: s.sessionAtRest(sessionID),
 		ExpiresAt: now,
 	})
 	if errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
## 무엇

세션 bearer 해시(#278에서 SHA-256)를 crypto_key_epochs 모델의 **lookup/session HMAC subkey**로 정렬한다. keys-gated — 키 설정 시 HMAC, 아니면 기존 SHA-256. 단명이라 drain(백필 없음).

## 구성

- `sessionAtRest()` 헬퍼: keys 있으면 `SessionHash`, 없으면 `hashToken`(SHA-256).
- 적용: `CreateSession`/`GetValidSession`의 `token_hash`, audit `session_id`(`sanitizeAuditMetadata`를 메서드화해 keys 접근).
- `sessions.token_hash`와 audit `session_id`가 동일 함수 → 상관관계 유지.

## 검증

- 통합: 키 설정 시 `token_hash == SessionHash(token)`(SHA-256 아님), 검증 동작.
- 단위: sanitize 호출을 `(&Storage{})` 리시버로 (keys nil→SHA-256 fallback, 기대값 동일).
- `go test ./...` + `-tags=integration` green, `gofmt`·`go vet`·`golangci-lint`(clean cache) 0 issues.

## 다음

마지막: PR6 cleanup — 평문 컬럼 DROP(provider_user_id/email/name) + in-process add→백필→drop 오케스트레이션 + 엄격 검증 게이트 + prod 키 필수화 + 평문 fallback 제거. 그 후 VERSION 1번 단일 배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)