### PR TITLE
feat(crypto): 백필 평문 scrub + prod 키 필수화 (ADR-002 PR6)

### DIFF
--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -58,10 +58,10 @@ authgate를 처음 배포할 때 필요한 것:
 | `OIDC_HTTP_TIMEOUT_SEC` | X | `10` | Upstream OIDC HTTP 호출 timeout(초) |
 | `OIDC_CLIENT_ID` | X | `authgate` | OIDC Client ID |
 | `OIDC_CLIENT_SECRET` | X | — | OIDC Client Secret (`DEV_MODE=false`에서 필수) |
-| `PII_ENC_ROOT_KEY_ID` | X | — | PII 암호화(ENC) root 식별자 (ADR-002). 4개 root 변수는 all-or-nothing — 전부 설정 시 암호화 활성, 미설정 시 inert |
-| `PII_ENC_ROOT_SECRET` | X | — | ENC root secret (base64, ≥32 bytes). 로그/감사에 노출 금지 |
-| `PII_LOOKUP_ROOT_KEY_ID` | X | — | lookup HMAC(LOOKUP) root 식별자 |
-| `PII_LOOKUP_ROOT_SECRET` | X | — | LOOKUP root secret (base64, ≥32 bytes). 로그/감사에 노출 금지 |
+| `PII_ENC_ROOT_KEY_ID` | △ | — | PII 암호화(ENC) root 식별자 (ADR-002). **`DEV_MODE=false`에서 4개 모두 필수.** 부팅 시 백필이 기존 평문을 암호화하고 평문 컬럼을 비운다 |
+| `PII_ENC_ROOT_SECRET` | △ | — | ENC root secret (base64, ≥32 bytes). 로그/감사에 노출 금지 |
+| `PII_LOOKUP_ROOT_KEY_ID` | △ | — | lookup HMAC(LOOKUP) root 식별자 |
+| `PII_LOOKUP_ROOT_SECRET` | △ | — | LOOKUP root secret (base64, ≥32 bytes). 로그/감사에 노출 금지 |
 | `SESSION_TTL` | X | `86400` | 세션 수명 (초) |
 | `ACCESS_TOKEN_TTL` | X | `900` | access_token 수명 (초, 15분) |
 | `REFRESH_TOKEN_TTL` | X | `2592000` | refresh_token 수명 (초, 30일) |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,6 +198,11 @@ func Load() (*Config, error) {
 		if c.OIDCClientID == "" || c.OIDCClientSecret == "" {
 			return nil, fmt.Errorf("DEV_MODE=false requires OIDC_CLIENT_ID and OIDC_CLIENT_SECRET")
 		}
+		// PII at-rest encryption is mandatory in production (ADR-002): without
+		// the roots, signups would persist plaintext PII.
+		if c.EncRootKeyID == "" || c.EncRootSecret == "" || c.LookupRootKeyID == "" || c.LookupRootSecret == "" {
+			return nil, fmt.Errorf("DEV_MODE=false requires PII_ENC_ROOT_KEY_ID, PII_ENC_ROOT_SECRET, PII_LOOKUP_ROOT_KEY_ID, PII_LOOKUP_ROOT_SECRET")
+		}
 	}
 
 	return c, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,6 +14,8 @@ func clearEnv() {
 		"OIDC_HTTP_TIMEOUT_SEC",
 		"SESSION_TTL", "ACCESS_TOKEN_TTL", "REFRESH_TOKEN_TTL", "AUDIT_LOG_PII_RETENTION_DAYS",
 		"DEV_MODE", "ENABLE_MCP", "ENABLE_ACCOUNT_DELETION",
+		"PII_ENC_ROOT_KEY_ID", "PII_ENC_ROOT_SECRET",
+		"PII_LOOKUP_ROOT_KEY_ID", "PII_LOOKUP_ROOT_SECRET",
 		"SIGNING_KEY_PATH",
 		"DB_MAX_OPEN_CONNS", "DB_MAX_IDLE_CONNS",
 		"DB_CONN_MAX_LIFETIME_SEC", "DB_CONN_MAX_IDLE_TIME_SEC",
@@ -112,6 +114,26 @@ func TestLoad_DevModeFalseRequiresOIDCCredentials(t *testing.T) {
 	_, err := Load()
 	if err == nil {
 		t.Fatal("expected error: DEV_MODE=false requires OIDC credentials")
+	}
+}
+
+func TestLoad_DevModeFalseRequiresPIIRoots(t *testing.T) {
+	clearEnv()
+	os.Setenv("DATABASE_URL", "postgres://localhost/test")
+	os.Setenv("SESSION_SECRET", "test-secret-32-chars-long-enough!")
+	os.Setenv("PUBLIC_URL", "https://authgate.example.com")
+	os.Setenv("DEV_MODE", "false")
+	os.Setenv("OIDC_ISSUER_URL", "https://accounts.google.com")
+	os.Setenv("OIDC_CLIENT_ID", "authgate")
+	os.Setenv("OIDC_CLIENT_SECRET", "secret")
+	// Missing PII_*_ROOT_* → must fail in production.
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error: DEV_MODE=false requires PII encryption roots")
+	}
+	if !strings.Contains(err.Error(), "PII_ENC_ROOT_KEY_ID") {
+		t.Errorf("error = %v, want one mentioning PII roots", err)
 	}
 }
 

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -53,7 +53,8 @@ UPDATE user_identities SET
     provider_sub_ciphertext   = $5,
     provider_sub_nonce        = $6,
     provider_sub_enc_key_id   = $7,
-    provider_sub_enc_version  = $8
+    provider_sub_enc_version  = $8,
+    provider_user_id          = NULL
 WHERE id = $1;
 
 -- name: GetUserByID :one
@@ -102,7 +103,9 @@ UPDATE users SET
     name_ciphertext    = $9,
     name_nonce         = $10,
     name_enc_key_id    = $11,
-    name_enc_version   = $12
+    name_enc_version   = $12,
+    email              = NULL,
+    name               = NULL
 WHERE id = $1;
 
 -- name: CompleteAuthRequestByID :execrows

--- a/internal/db/storeq/users.sql.go
+++ b/internal/db/storeq/users.sql.go
@@ -19,7 +19,8 @@ UPDATE user_identities SET
     provider_sub_ciphertext   = $5,
     provider_sub_nonce        = $6,
     provider_sub_enc_key_id   = $7,
-    provider_sub_enc_version  = $8
+    provider_sub_enc_version  = $8,
+    provider_user_id          = NULL
 WHERE id = $1
 `
 
@@ -60,7 +61,9 @@ UPDATE users SET
     name_ciphertext    = $9,
     name_nonce         = $10,
     name_enc_key_id    = $11,
-    name_enc_version   = $12
+    name_enc_version   = $12,
+    email              = NULL,
+    name               = NULL
 WHERE id = $1
 `
 

--- a/internal/storage/provider_sub_integration_test.go
+++ b/internal/storage/provider_sub_integration_test.go
@@ -91,6 +91,17 @@ func TestProviderSub_Backfill(t *testing.T) {
 		t.Fatalf("remaining = %d err=%v, want 0", remaining, err)
 	}
 
+	// Backfill scrubs the plaintext provider_user_id.
+	var pUID sql.NullString
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT provider_user_id FROM user_identities WHERE user_id=$1`, user.ID,
+	).Scan(&pUID); err != nil {
+		t.Fatalf("read plaintext: %v", err)
+	}
+	if pUID.Valid {
+		t.Error("plaintext provider_user_id not cleared after backfill")
+	}
+
 	// Lookup now resolves via hash even though the row was created as plaintext.
 	found, err := s.GetUserByProviderIdentity(ctx, "google", sub)
 	if err != nil || found.ID != user.ID {

--- a/internal/storage/users_pii_integration_test.go
+++ b/internal/storage/users_pii_integration_test.go
@@ -115,6 +115,17 @@ func TestUserPII_Backfill(t *testing.T) {
 		t.Fatalf("remaining = %d err=%v, want 0", remaining, err)
 	}
 
+	// Backfill scrubs the plaintext columns (PII no longer at rest in clear).
+	var ePlain, nPlain sql.NullString
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT email, name FROM users WHERE id=$1`, user.ID,
+	).Scan(&ePlain, &nPlain); err != nil {
+		t.Fatalf("read plaintext: %v", err)
+	}
+	if ePlain.Valid || nPlain.Valid {
+		t.Error("plaintext email/name not cleared after backfill")
+	}
+
 	// Reads now decrypt the backfilled values.
 	got, err := s.GetUserByID(ctx, user.ID)
 	if err != nil || got.Email != email || got.Name != name {


### PR DESCRIPTION
## 무엇

PII at-rest 보호를 **완성**한다. 백필이 암호화 후 **평문 컬럼을 NULL로 비워** 키 설정 시 평문 PII가 at-rest에 남지 않게 하고, **프로덕션에서 암호화 키를 필수화**한다.

## 구성

- 백필이 평문 scrub: `BackfillProviderSub` → `provider_user_id=NULL`, `BackfillUserPII` → `email=NULL, name=NULL` (암호화/해시 채운 뒤).
- config: `DEV_MODE=false`면 `PII_ENC/LOOKUP_ROOT_*` 4개 필수 (없으면 시작 실패). `setMinimal`이 `DEV_MODE=true`라 기존 성공 테스트 무영향.

## 검증

- 통합: 백필 후 평문 컬럼 NULL 확인(provider_sub, email/name). config: prod 키 필수 테스트.
- `go test ./...` + `-tags=integration` green, `gofmt`·`go vet`·`golangci-lint`(clean cache) 0 issues.

## 평문 컬럼 DROP을 분리한 이유 (중요)

같은 배포에서 컬럼을 DROP하면 `migrator.Run`(startup)이 **백필보다 먼저** 실행돼 평문이 암호화 전에 사라지고(데이터 손실), 드롭 후 재기동 시 백필 쿼리가 없는 컬럼을 참조해 깨집니다(순서 footgun). **백필이 컬럼을 비우므로 보호는 즉시 달성**되고, 전부 NULL이 된 컬럼의 물리적 DROP은 백필 확인 후 **무위험 후속 릴리즈**로 수행합니다.

## 전체 시리즈 완료

ADR-002 PII 암호화: ADR(#277) → 세션(#278) → crypto 토대(#281) → provider_sub(#282) → email/name(#283) → codes(#285) → 세션 HMAC(#286) → 본 PR(보호 완성).
배포: 키 프로비저닝(opsgate) + VERSION bump → 점검창에서 부팅 시 백필이 자동 암호화·scrub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)