### PR TITLE
feat(security): baseline HTTP security headers middleware

### DIFF
--- a/docs/security/002-http-security-headers.md
+++ b/docs/security/002-http-security-headers.md
@@ -1,0 +1,40 @@
+# HTTP 보안 응답 헤더
+
+authgate는 모든 HTTP 응답에 기본 보안 헤더를 설정한다. 구현은
+`internal/middleware/security_headers.go`의 `SecurityHeaders` 미들웨어이며,
+미들웨어 체인의 **가장 바깥**(`internal/app/app.go`)에 배치되어 에러 응답과
+CORS preflight 응답에도 헤더가 포함된다.
+
+## 설정되는 헤더
+
+| 헤더 | 값 | 목적 |
+|------|-----|------|
+| `X-Content-Type-Options` | `nosniff` | MIME 스니핑 차단 |
+| `X-Frame-Options` | `DENY` | 클릭재킹 차단 (프레임 임베드 금지) |
+| `Referrer-Policy` | `no-referrer` | URL의 code/token이 Referer로 유출되는 것 방지 |
+| `Content-Security-Policy` | 아래 참조 | 스크립트 실행 전면 차단 + 리소스 출처 제한 + `frame-ancestors 'none'` |
+| `Strict-Transport-Security` | `max-age=31536000` | HTTPS 강제. **`DEV_MODE=false`일 때만** 전송 |
+
+## CSP 정책
+
+```
+default-src 'none';
+style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+font-src https://fonts.gstatic.com;
+img-src 'self' data:;
+frame-ancestors 'none';
+base-uri 'none'
+```
+
+`internal/pages/templates/*.html`(device-entry, device-approve, result, error)는
+인라인 `<style>` 하나와 Google Fonts만 사용하고 스크립트가 전혀 없다. 따라서
+`default-src 'none'`로 스크립트 출처를 상속 차단(script-src 미지정 → 어떤 JS도
+실행 불가)하면서, 필요한 스타일/폰트만 허용한다. JSON API 응답에도 동일 헤더가
+붙지만 브라우저가 JSON 본문에서 하위 리소스를 로드하지 않으므로 무해하다.
+
+## 비고
+
+- HSTS는 dev 모드(평문 HTTP)에서 무의미하므로 생략한다. `includeSubDomains`는
+  authgate가 제어하지 않는 형제 서브도메인에 HTTPS를 강제할 수 있어 기본값에서
+  제외했다. 더 강한 정책은 프록시 계층에서 추가할 수 있다.
+- 테스트: `internal/middleware/security_headers_test.go`

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -14,6 +14,7 @@ authgate 밖의 조직 운영 절차(법무 판단, 고객 통지, 접근권한 
 | # | 문서 | 목적 |
 |---|------|------|
 | 001 | [Audit Evidence Matrix](001-audit-evidence-matrix.md) | 한국 PIPA/통비법/SOC 2 관점에서 authgate가 생성하는 감사 증거와 현재 구현 상태 매핑 |
+| 002 | [HTTP 보안 응답 헤더](002-http-security-headers.md) | 모든 응답에 설정되는 보안 헤더(CSP, X-Frame-Options, HSTS 등)와 정책 근거 |
 
 ## 관계
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -87,9 +87,13 @@ func Run() {
 	corsHandler := middleware.NewCORSMiddleware(allowedOrigins)(clientInfoHandler)
 	// RequestIDMiddleware runs first so every handler has a request ID in context.
 	requestIDHandler := middleware.RequestIDMiddleware(corsHandler)
+	// SecurityHeaders is the outermost wrapper so baseline headers (CSP,
+	// X-Frame-Options, nosniff, Referrer-Policy, and HSTS in prod) are present
+	// on every response, including error and CORS-preflight replies.
+	securityHeadersHandler := middleware.SecurityHeaders(cfg.DevMode)(requestIDHandler)
 
 	var inflightRequests int64
-	srv, addr := buildHTTPServer(cfg, requestIDHandler, &inflightRequests)
+	srv, addr := buildHTTPServer(cfg, securityHeadersHandler, &inflightRequests)
 
 	cleanupCancel := startCleanupService(db, clk, cfg.AuditLogPIIRetention)
 	metricsCancel := startMetricsServer(cfg)

--- a/internal/middleware/security_headers.go
+++ b/internal/middleware/security_headers.go
@@ -1,0 +1,52 @@
+package middleware
+
+import "net/http"
+
+// contentSecurityPolicy is tuned for authgate's served HTML (the device-entry,
+// device-approve, result and error pages under internal/pages/templates).
+// Those pages use exactly one inline <style> block plus Google Fonts and carry
+// no scripts, no event-handler attributes and no <img> tags. The policy:
+//   - default-src 'none' denies everything not explicitly re-allowed, so
+//     script-src inherits 'none' — no inline or remote JS can ever execute.
+//   - style-src allows the inline <style> ('unsafe-inline') and the Google
+//     Fonts stylesheet; font-src allows the gstatic font files.
+//   - frame-ancestors 'none' and base-uri 'none' block clickjacking and <base>
+//     hijacking. The JSON API responses also receive this header harmlessly —
+//     browsers load no subresources from a JSON body.
+const contentSecurityPolicy = "default-src 'none'; " +
+	"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+	"font-src https://fonts.gstatic.com; " +
+	"img-src 'self' data:; " +
+	"frame-ancestors 'none'; " +
+	"base-uri 'none'"
+
+// strictTransportSecurity is emitted only outside dev mode (i.e. when served
+// over HTTPS). One year, no includeSubDomains: authgate is a dedicated host and
+// should not silently force HTTPS onto sibling subdomains the operator may not
+// control. Operators who want a stronger policy can layer it at the proxy.
+const strictTransportSecurity = "max-age=31536000"
+
+// SecurityHeaders returns middleware that sets baseline security response
+// headers on every response. It is wired as the OUTERMOST middleware so the
+// headers are present on error responses and CORS preflight replies too. The
+// headers are set before the inner handler runs, so they land in the header map
+// regardless of which downstream handler commits the response.
+//
+// devMode gates Strict-Transport-Security: in dev the server runs over plain
+// HTTP (and PUBLIC_URL is http://), where an HSTS header would be ignored by
+// browsers anyway and only confuse local testing.
+func SecurityHeaders(devMode bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := w.Header()
+			h.Set("X-Content-Type-Options", "nosniff")
+			h.Set("X-Frame-Options", "DENY")
+			h.Set("Referrer-Policy", "no-referrer")
+			h.Set("Content-Security-Policy", contentSecurityPolicy)
+			if !devMode {
+				h.Set("Strict-Transport-Security", strictTransportSecurity)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/security_headers_test.go
+++ b/internal/middleware/security_headers_test.go
@@ -1,0 +1,63 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSecurityHeaders_SetOnEveryResponse(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	SecurityHeaders(false)(next).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/anything", nil))
+
+	want := map[string]string{
+		"X-Content-Type-Options":    "nosniff",
+		"X-Frame-Options":           "DENY",
+		"Referrer-Policy":           "no-referrer",
+		"Strict-Transport-Security": strictTransportSecurity,
+		"Content-Security-Policy":   contentSecurityPolicy,
+	}
+	for k, v := range want {
+		if got := rec.Header().Get(k); got != v {
+			t.Errorf("header %q = %q, want %q", k, got, v)
+		}
+	}
+}
+
+func TestSecurityHeaders_NoHSTSInDevMode(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	rec := httptest.NewRecorder()
+	SecurityHeaders(true)(next).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if got := rec.Header().Get("Strict-Transport-Security"); got != "" {
+		t.Errorf("HSTS should be absent in dev mode, got %q", got)
+	}
+	// Non-HSTS headers must still be present in dev mode.
+	if got := rec.Header().Get("X-Frame-Options"); got != "DENY" {
+		t.Errorf("X-Frame-Options = %q, want DENY", got)
+	}
+}
+
+func TestSecurityHeaders_CSPBlocksScriptsAllowsFonts(t *testing.T) {
+	// Guard the CSP contract the served HTML pages depend on: no script source
+	// (scripts inherit default-src 'none'), but Google Fonts styles/fonts allowed.
+	for _, must := range []string{
+		"default-src 'none'",
+		"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+		"font-src https://fonts.gstatic.com",
+		"frame-ancestors 'none'",
+	} {
+		if !strings.Contains(contentSecurityPolicy, must) {
+			t.Errorf("CSP missing %q; full policy: %q", must, contentSecurityPolicy)
+		}
+	}
+	if strings.Contains(contentSecurityPolicy, "script-src") {
+		t.Errorf("CSP should not grant any script-src; full policy: %q", contentSecurityPolicy)
+	}
+}


### PR DESCRIPTION
## 무엇

모든 HTTP 응답에 기본 보안 헤더를 설정하는 `SecurityHeaders` 미들웨어를 추가한다. 심층 분석 라운드의 **"보안 헤더 전무"** finding(검증 결과 CONFIRMED, 보정 심각도 MEDIUM)에 대한 대응이다.

## 설정 헤더

| 헤더 | 값 |
|------|-----|
| `X-Content-Type-Options` | `nosniff` |
| `X-Frame-Options` | `DENY` |
| `Referrer-Policy` | `no-referrer` |
| `Content-Security-Policy` | `default-src 'none'` 기반, 스크립트 전면 차단 + 폰트/스타일만 허용 + `frame-ancestors 'none'` |
| `Strict-Transport-Security` | `max-age=31536000` (**`DEV_MODE=false`일 때만**) |

## 설계 근거

- 미들웨어 체인 **가장 바깥**에 배치 → 에러/CORS preflight 응답에도 헤더 적용.
- CSP는 `internal/pages/templates/*.html`(인라인 `<style>` 1개 + Google Fonts, 스크립트 0개)에 맞춰 조정. `default-src 'none'`로 모든 JS 차단, 필요한 style/font 출처만 허용. JSON API 응답엔 무해.
- HSTS는 dev(평문 HTTP)에서 생략. `includeSubDomains`는 형제 서브도메인 영향 우려로 기본 제외(프록시에서 강화 가능).

## 테스트/문서

- `internal/middleware/security_headers_test.go` — 헤더 설정·dev HSTS 생략·CSP 계약(스크립트 차단/폰트 허용) 검증.
- `docs/security/002-http-security-headers.md` 신규 + 보안 문서 인덱스 갱신.

## 검증

- `go build ./...` ✅ / `go test ./...` ✅ / `golangci-lint run`(clean cache) **0 issues** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)