### PR TITLE
perf(db): index cascade-delete FK columns

### DIFF
--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -194,8 +194,12 @@ PK/UNIQUE/FK 제약 인덱스 외에 현재 명시적으로 생성하는 보조 
 | `audit_log_user_created_idx` | `audit_log (user_id, created_at DESC)` | 사용자별 audit timeline 조회 (migration 004) |
 | `audit_log_event_created_idx` | `audit_log (event_type, created_at DESC)` | 운영 이벤트 timeline 조회 |
 | `audit_log_created_brin_idx` | `audit_log USING BRIN (created_at)` | 보존기간 cutoff 기반 PII 익명화 스캔 보조 |
+| `user_identities_user_id_idx` | `user_identities (user_id)` | user 삭제 cascade 시 full scan 방지 (migration 012) |
+| `sessions_user_id_idx` | `sessions (user_id)` | user 삭제 cascade 시 full scan 방지 (migration 012) |
+| `refresh_tokens_user_id_idx` | `refresh_tokens (user_id)` | user 삭제 cascade 시 full scan 방지 (migration 012) |
+| `refresh_tokens_family_id_idx` | `refresh_tokens (family_id)` | reuse 감지 family revoke (`WHERE family_id=$`) full scan 방지 (migration 012) |
 
-현재 `sessions.expires_at`, `auth_requests.expires_at`, `device_codes.expires_at`, `refresh_tokens.expires_at/revoked_at/family_id`에는 별도 보조 인덱스를 만들지 않는다. 운영에서 조회 패턴이 커지면 다음 원칙으로 인덱스를 추가한다:
+현재 `sessions.expires_at`, `auth_requests.expires_at`, `device_codes.expires_at`, `refresh_tokens.expires_at/revoked_at`에는 별도 보조 인덱스를 만들지 않는다. 운영에서 조회 패턴이 커지면 다음 원칙으로 인덱스를 추가한다:
 1. 실제 병목 쿼리를 기준으로 추가한다.
 2. cleanup 경로(`expires_at`)와 토큰 경로(`token_hash`, `family_id`)를 우선 고려한다.
 3. 추가 시 이 문서와 마이그레이션을 함께 갱신한다.

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -15,6 +15,9 @@ authgate를 처음 배포할 때 필요한 것:
    → 마이그레이션은 authgate가 시작 시 자동 실행
      (golang-migrate, migrations/*.up.sql 순차 적용, schema_migrations 테이블로 상태 추적)
      여러 replica가 동시에 시작해도 Postgres advisory lock으로 안전
+   → 012_fk_indexes: FK 컬럼(user_identities/sessions/refresh_tokens의 user_id,
+     refresh_tokens.family_id)에 인덱스 추가. 시작 시 해당 테이블을 잠깐 잠그며
+     (CONCURRENTLY 아님), 배포 점검창 안에서 적용된다
 
 2. OIDC IdP 자격증명 발급
    → IdP(예: Google Cloud Console)에서 OAuth 2.0 Client ID/Secret 생성

--- a/migrations/012_fk_indexes.down.sql
+++ b/migrations/012_fk_indexes.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS refresh_tokens_family_id_idx;
+DROP INDEX IF EXISTS refresh_tokens_user_id_idx;
+DROP INDEX IF EXISTS sessions_user_id_idx;
+DROP INDEX IF EXISTS user_identities_user_id_idx;

--- a/migrations/012_fk_indexes.up.sql
+++ b/migrations/012_fk_indexes.up.sql
@@ -1,0 +1,10 @@
+-- Foreign-key columns with ON DELETE CASCADE but no supporting index. A user
+-- deletion cascades into these three child tables; without an index each
+-- cascade does a sequential scan. refresh_tokens(family_id) is also scanned on
+-- every refresh-token reuse detection (RevokeRefreshFamily WHERE family_id=$).
+-- Existing UNIQUE/composite indexes do not lead with these columns, so none
+-- cover these lookups.
+CREATE INDEX IF NOT EXISTS user_identities_user_id_idx ON user_identities (user_id);
+CREATE INDEX IF NOT EXISTS sessions_user_id_idx ON sessions (user_id);
+CREATE INDEX IF NOT EXISTS refresh_tokens_user_id_idx ON refresh_tokens (user_id);
+CREATE INDEX IF NOT EXISTS refresh_tokens_family_id_idx ON refresh_tokens (family_id);


### PR DESCRIPTION
## 무엇

`ON DELETE CASCADE`가 걸린 FK 컬럼 4개에 인덱스를 추가한다. 심층 분석 라운드의 **"FK 인덱스 누락"** finding(검증 결과 CONFIRMED)에 대한 대응이다.

| 테이블.컬럼 | 영향 |
|---|---|
| `user_identities(user_id)` | user 삭제 cascade 시 full scan |
| `sessions(user_id)` | user 삭제 cascade 시 full scan |
| `refresh_tokens(user_id)` | user 삭제 cascade 시 full scan |
| `refresh_tokens(family_id)` | **매 refresh 토큰 reuse 감지마다** `RevokeRefreshFamily WHERE family_id=$` full scan |

기존 UNIQUE/복합 인덱스는 이 컬럼들로 시작하지 않아 커버하지 못한다.

## 구현

- `migrations/012_fk_indexes.{up,down}.sql` — `CREATE INDEX IF NOT EXISTS` ×4.
- 시작 시 자동 적용. `CONCURRENTLY` 아님(golang-migrate 트랜잭션 래핑과 비호환) → 해당 테이블을 잠깐 잠그므로 배포 점검창 안에서 적용. 다운타임 가능 전제(기존 합의)와 일치.
- `docs/spec/009-operations.md` 초기 설정 섹션에 잠금 주의 명시.

## 검증

실제 Postgres에 적용 확인:
- 시작 시 `migrations applied version=12 dirty=false`
- 인덱스 4개 생성 확인 (`pg_indexes`)
- down SQL 클린 롤백 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)