### PR TITLE
ci: run race detector against integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,12 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests with race detector
-        run: go test -race ./...
+        # -tags=integration so the concurrency tests (refresh-token rotation
+        # atomicity, device-code polling, etc. — all behind //go:build
+        # integration) are actually compiled under the race detector. Without
+        # the tag they were excluded, leaving the concurrency paths unchecked.
+        # Same runner as the Test job, so Docker/testcontainers is available.
+        run: go test -race -tags=integration ./...
 
   coverage-report:
     name: Coverage Report


### PR DESCRIPTION
## 무엇

`Race` job이 `go test -race ./...`를 **`-tags=integration` 없이** 실행해서, 동시성 테스트들이 race detector로 컴파일조차 안 되던 문제를 고친다. 심층 분석 라운드의 **"CI -race에 integration 태그 없음"** finding(검증 결과 CONFIRMED)에 대한 대응이다.

## 문제

`//go:build integration` 뒤에 있는 동시성 테스트(`TestRefreshTokenRotation_Atomicity`, device-code polling 등)는 `-tags=integration` 없이는 빌드 대상에서 제외된다. 따라서 `race` job과 `test` job(integration은 돌지만 race 없음)이 겹치지 않아, refresh 토큰 rotation `FOR UPDATE` 직렬화 같은 핵심 동시성 경로가 race detector 검증을 전혀 못 받고 있었다.

## 수정

`race` job → `go test -race -tags=integration ./...`. `test` job과 동일 runner라 Docker/testcontainers 사용 가능. examples/*는 별도 모듈이라 root `./...`에 미포함(스코프 변화 없음).

## 검증

로컬에서 `go test -race -tags=integration -run '^TestRefreshTokenRotation_Atomicity$' ./internal/storage/` → **ok, race 미검출**. integration 테스트 전체 `go vet -tags=integration` 컴파일 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)