### PR TITLE
fix(audit): atomic reuse-detection audit with family revoke

### DIFF
--- a/docs/security/001-audit-evidence-matrix.md
+++ b/docs/security/001-audit-evidence-matrix.md
@@ -31,6 +31,8 @@ HTTP request
   │    ├─ user_agent
   │    ├─ metadata allowlist
   │    └─ best-effort INSERT
+  │       (예외: refresh reuse 감지는 family revoke와 같은 트랜잭션으로
+  │        원자적 기록 — writeAuditLogTx. 감사 기록 실패 시 revoke도 롤백)
   │
   ▼
 audit_log

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -181,37 +181,58 @@ func (s *Storage) GetAuditClientContextBySessionID(ctx context.Context, userID, 
 // must not be failed by an audit-write error. The metadata payload is *not*
 // included in failure logs to avoid leaking session/family identifiers.
 func (s *Storage) AuditLog(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) {
-	ipAddress = normalizeIPAddress(ipAddress)
-	metadata = s.sanitizeAuditMetadata(ctx, eventType, metadata)
-	var metaJSON []byte
-	if metadata != nil {
-		marshaled, err := json.Marshal(metadata)
-		if err != nil {
-			slog.ErrorContext(ctx, "audit log: marshal metadata",
-				"event_type", eventType,
-				"user_id", userIDLogValue(userID),
-				"error", err,
-			)
-			return
-		}
-		metaJSON = marshaled
-	}
-
-	if err := storeq.New(s.db).InsertAuditLog(ctx, storeq.InsertAuditLogParams{
-		UserID:    userIDLogValue(userID),
-		EventType: eventType,
-		IpAddress: nilIfEmpty(ipAddress),
-		UserAgent: nilIfEmpty(userAgent),
-		Metadata:  nilIfEmptyBytes(metaJSON),
-		CreatedAt: s.clock.Now(),
-	}); err != nil {
-		slog.ErrorContext(ctx, "audit log: insert",
+	params, err := s.prepareAuditRow(ctx, userID, eventType, ipAddress, userAgent, metadata)
+	if err != nil {
+		slog.ErrorContext(ctx, "audit log: marshal metadata",
 			"event_type", eventType,
 			"user_id", userIDLogValue(userID),
 			"error", err,
 		)
 		return
 	}
+	if err := storeq.New(s.db).InsertAuditLog(ctx, params); err != nil {
+		slog.ErrorContext(ctx, "audit log: insert",
+			"event_type", eventType,
+			"user_id", userIDLogValue(userID),
+			"error", err,
+		)
+	}
+}
+
+// writeAuditLogTx inserts an audit row using the supplied transaction queries
+// so the row commits atomically with the surrounding business write (see the
+// refresh-reuse path in storage_auth_tokens.go). Unlike AuditLog it returns the
+// error instead of swallowing it, so transactional callers can roll back.
+func (s *Storage) writeAuditLogTx(ctx context.Context, qtx *storeq.Queries, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) error {
+	params, err := s.prepareAuditRow(ctx, userID, eventType, ipAddress, userAgent, metadata)
+	if err != nil {
+		return err
+	}
+	return qtx.InsertAuditLog(ctx, params)
+}
+
+// prepareAuditRow normalizes, sanitizes and marshals an audit event into insert
+// params. It performs no DB access, so both the best-effort AuditLog path and
+// the transactional writeAuditLogTx path share identical sanitization.
+func (s *Storage) prepareAuditRow(ctx context.Context, userID *string, eventType, ipAddress, userAgent string, metadata map[string]any) (storeq.InsertAuditLogParams, error) {
+	ipAddress = normalizeIPAddress(ipAddress)
+	metadata = s.sanitizeAuditMetadata(ctx, eventType, metadata)
+	var metaJSON []byte
+	if metadata != nil {
+		marshaled, err := json.Marshal(metadata)
+		if err != nil {
+			return storeq.InsertAuditLogParams{}, err
+		}
+		metaJSON = marshaled
+	}
+	return storeq.InsertAuditLogParams{
+		UserID:    userIDLogValue(userID),
+		EventType: eventType,
+		IpAddress: nilIfEmpty(ipAddress),
+		UserAgent: nilIfEmpty(userAgent),
+		Metadata:  nilIfEmptyBytes(metaJSON),
+		CreatedAt: s.clock.Now(),
+	}, nil
 }
 
 func (s *Storage) sanitizeAuditMetadata(ctx context.Context, eventType string, metadata map[string]any) map[string]any {

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -214,11 +214,17 @@ func (s *Storage) TokenRequestByRefreshToken(ctx context.Context, refreshToken s
 		if err := revokeRefreshFamilyOnReuse(ctx, qtx, rt.FamilyID, now); err != nil {
 			return nil, op.ErrInvalidRefreshToken
 		}
+		// Write the reuse-detection audit rows in the SAME transaction as the
+		// family revoke, so the security action and its audit evidence commit
+		// atomically. If the audit insert fails the whole tx rolls back and the
+		// client's retry triggers reuse detection again — the token is already
+		// used/revoked, so it stays unusable either way.
+		if err := s.auditRefreshReuseDetectionTx(ctx, qtx, rt.UserID, rt.FamilyID); err != nil {
+			return nil, op.ErrInvalidRefreshToken
+		}
 		if err := tx.Commit(); err != nil {
 			return nil, op.ErrInvalidRefreshToken
 		}
-		// Audit only after successful commit
-		s.auditRefreshReuseDetection(ctx, rt.UserID, rt.FamilyID)
 		return nil, op.ErrInvalidRefreshToken
 	}
 
@@ -441,10 +447,16 @@ func revokeRefreshFamilyOnReuse(ctx context.Context, qtx *storeq.Queries, family
 	})
 }
 
-func (s *Storage) auditRefreshReuseDetection(ctx context.Context, userID, familyID string) {
+// auditRefreshReuseDetectionTx writes the reuse-detection and family-revoked
+// audit rows via the supplied transaction queries, so they commit atomically
+// with the family revoke. An insert error is returned (not swallowed) so the
+// caller can roll back the whole reuse-detection transaction.
+func (s *Storage) auditRefreshReuseDetectionTx(ctx context.Context, qtx *storeq.Queries, userID, familyID string) error {
 	info := clientinfo.FromContext(ctx)
-	s.AuditLog(ctx, &userID, EventAuthRefreshReuseDetected, info.IP, info.UserAgent, map[string]any{"family_id": familyID})
-	s.AuditLog(ctx, &userID, EventAuthRefreshFamilyRevoked, info.IP, info.UserAgent, map[string]any{"family_id": familyID})
+	if err := s.writeAuditLogTx(ctx, qtx, &userID, EventAuthRefreshReuseDetected, info.IP, info.UserAgent, map[string]any{"family_id": familyID}); err != nil {
+		return err
+	}
+	return s.writeAuditLogTx(ctx, qtx, &userID, EventAuthRefreshFamilyRevoked, info.IP, info.UserAgent, map[string]any{"family_id": familyID})
 }
 
 func (s *Storage) validateRefreshTokenRequest(ctx context.Context, tx *sql.Tx, rt *RefreshTokenModel, now time.Time) error {


### PR DESCRIPTION
## 무엇

refresh token **reuse 감지** 시 family revoke와 감사 기록(`auth.refresh_reuse_detected`, `auth.refresh_family_revoked`)을 **같은 트랜잭션**으로 묶어 원자적으로 기록한다. 심층 분석 라운드의 **"감사 이벤트 best-effort"** finding(검증 결과 CONFIRMED, 보정 LOW)에 대한 대응이다.

## 문제

기존 reuse 경로는 family revoke를 먼저 commit한 뒤 감사 2건을 best-effort로 기록했다. revoke는 성공했는데 audit insert가 실패하면 **commit된 보안 조치에 대한 감사 증거가 누락**될 수 있었다(slog ERROR로는 남지만 audit_log에는 없음).

## 수정

- `Storage.writeAuditLogTx(qtx, ...)` 추가 — 트랜잭션 쿼리로 감사 행을 기록하고 에러를 반환.
- reuse 경로(`TokenRequestByRefreshToken`)가 commit **전에** `qtx`로 감사 2건 기록. 실패 시 전체 tx 롤백 → 클라이언트 재시도 시 reuse 재감지(토큰은 이미 used/revoked라 계속 무효).
- `prepareAuditRow` 헬퍼로 sanitize/marshal 로직을 best-effort `AuditLog`와 공유 → 두 경로의 정제 동작 동일. 다른 모든 이벤트의 best-effort 동작은 그대로.

## 검증

- `go build` ✅ / storage 유닛 테스트 ✅ (marshal 실패 시 distinct 로그 유지)
- `TestAudit010And011_RefreshReuseAndFamilyRevoke` (integration) ✅ — reuse 후 두 감사 행 존재 확인
- `TestRefreshTokenRotation_Atomicity` (integration) ✅
- `golangci-lint`(clean cache) **0 issues** ✅
- 문서: `docs/security/001-audit-evidence-matrix.md` 감사 흐름도에 reuse 경로 원자성 예외 명시

🤖 Generated with [Claude Code](https://claude.com/claude-code)