### PR TITLE
fix(token): tombstone refresh-token family on reuse detection

### DIFF
--- a/docs/spec/005-token-lifecycle.md
+++ b/docs/spec/005-token-lifecycle.md
@@ -132,6 +132,11 @@ sequenceDiagram
 **규칙**: 폐기된 토큰이 제출되면, 해당 `family_id`의 모든 토큰을 즉시 revoke한다.
 정상 유저는 재로그인해야 하지만, 공격자의 토큰도 무효화된다.
 
+재사용 감지는 기존 토큰 행을 revoke하는 동시에 `refresh_token_families`에 해당
+`family_id`의 **tombstone**을 남긴다(같은 트랜잭션). 토큰 발급 경로는 rotation 시
+family가 tombstone되었는지 확인하고, 되었으면 새 자식 토큰 발급을 거부한다. 이로써
+family revoke와 거의 동시에 진행되던 rotation이 끼워넣는 새 토큰까지 차단된다.
+
 ## 계정 상태별 토큰 동작
 
 [ADR-000](../adr/000-authgate-identity.md) 상태 판정 규칙과 일치:

--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -12,6 +12,7 @@ erDiagram
     users ||--o{ user_identities : "1:N (IdP 매핑)"
     users ||--o{ sessions : "1:N (로그인 상태)"
     users ||--o{ refresh_tokens : "1:N (토큰 갱신)"
+    users ||--o{ refresh_token_families : "1:N (재사용 tombstone)"
     users ||--o{ audit_log : "1:N (이벤트 기록)"
     users {
         uuid id PK "DEFAULT uuid_generate_v4()"
@@ -87,6 +88,13 @@ erDiagram
         timestamptz created_at "NOT NULL, DEFAULT NOW()"
     }
 
+    refresh_token_families {
+        uuid family_id PK "tombstone된 family만 행 존재 (sparse)"
+        uuid user_id FK "NOT NULL, CASCADE"
+        text reason "NOT NULL, 예: reuse_detected"
+        timestamptz revoked_at "NOT NULL, DEFAULT NOW()"
+    }
+
     auth_requests {
         uuid id PK "DEFAULT uuid_generate_v4()"
         text client_id "NOT NULL"
@@ -152,6 +160,7 @@ erDiagram
 |--------|------|------|----------|
 | **sessions** | 로그인 상태 | SESSION_TTL (기본 24시간) | 만료 후 cleanup |
 | **refresh_tokens** | 토큰 갱신 권한 | REFRESH_TOKEN_TTL (기본 30일) | 폐기 후 30일 뒤 hard delete |
+| **refresh_token_families** | 재사용 감지로 폐기된 family tombstone | 영구 | CASCADE (users 삭제 시) |
 
 ### 임시 데이터
 
@@ -198,6 +207,7 @@ PK/UNIQUE/FK 제약 인덱스 외에 현재 명시적으로 생성하는 보조 
 | `sessions_user_id_idx` | `sessions (user_id)` | user 삭제 cascade 시 full scan 방지 (migration 012) |
 | `refresh_tokens_user_id_idx` | `refresh_tokens (user_id)` | user 삭제 cascade 시 full scan 방지 (migration 012) |
 | `refresh_tokens_family_id_idx` | `refresh_tokens (family_id)` | reuse 감지 family revoke (`WHERE family_id=$`) full scan 방지 (migration 012) |
+| `refresh_token_families_user_id_idx` | `refresh_token_families (user_id)` | user 삭제 cascade 시 full scan 방지 (migration 013) |
 
 현재 `sessions.expires_at`, `auth_requests.expires_at`, `device_codes.expires_at`, `refresh_tokens.expires_at/revoked_at`에는 별도 보조 인덱스를 만들지 않는다. 운영에서 조회 패턴이 커지면 다음 원칙으로 인덱스를 추가한다:
 1. 실제 병목 쿼리를 기준으로 추가한다.
@@ -222,6 +232,9 @@ FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 
 -- refresh_tokens
+FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+
+-- refresh_token_families
 FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 -- audit_log
 FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -18,6 +18,8 @@ authgate를 처음 배포할 때 필요한 것:
    → 012_fk_indexes: FK 컬럼(user_identities/sessions/refresh_tokens의 user_id,
      refresh_tokens.family_id)에 인덱스 추가. 시작 시 해당 테이블을 잠깐 잠그며
      (CONCURRENTLY 아님), 배포 점검창 안에서 적용된다
+   → 013_refresh_token_families: refresh 토큰 재사용 감지 시 family tombstone을
+     기록하는 테이블 추가 (빈 테이블 생성, 영향 없음)
 
 2. OIDC IdP 자격증명 발급
    → IdP(예: Google Cloud Console)에서 OAuth 2.0 Client ID/Secret 생성

--- a/internal/db/queries/refresh_tokens.sql
+++ b/internal/db/queries/refresh_tokens.sql
@@ -38,3 +38,13 @@ WHERE id = $2 AND revoked_at IS NULL;
 SELECT user_id, id
 FROM refresh_tokens
 WHERE token_hash = $1 AND client_id = $2;
+
+-- name: TombstoneRefreshFamily :exec
+INSERT INTO refresh_token_families (family_id, user_id, reason, revoked_at)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (family_id) DO NOTHING;
+
+-- name: IsRefreshFamilyRevoked :one
+SELECT EXISTS (
+    SELECT 1 FROM refresh_token_families WHERE family_id = $1
+) AS revoked;

--- a/internal/db/storeq/models.go
+++ b/internal/db/storeq/models.go
@@ -80,6 +80,13 @@ type RefreshToken struct {
 	CreatedAt time.Time
 }
 
+type RefreshTokenFamily struct {
+	FamilyID  string
+	UserID    string
+	Reason    string
+	RevokedAt time.Time
+}
+
 type Session struct {
 	ID        string
 	UserID    string

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -54,6 +54,7 @@ type Querier interface {
 	InsertTestAuthRequestWithResource(ctx context.Context, arg InsertTestAuthRequestWithResourceParams) error
 	InsertUser(ctx context.Context, arg InsertUserParams) error
 	InsertUserIdentity(ctx context.Context, arg InsertUserIdentityParams) error
+	IsRefreshFamilyRevoked(ctx context.Context, familyID string) (bool, error)
 	ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff sql.NullTime) ([]string, error)
 	ListProviderSubBackfill(ctx context.Context, limit int32) ([]ListProviderSubBackfillRow, error)
 	ListUsersBackfill(ctx context.Context, limit int32) ([]ListUsersBackfillRow, error)
@@ -71,6 +72,7 @@ type Querier interface {
 	RevokeRefreshTokenByID(ctx context.Context, arg RevokeRefreshTokenByIDParams) error
 	RevokeSessionsByUserID(ctx context.Context, arg RevokeSessionsByUserIDParams) error
 	SetUserStatusByID(ctx context.Context, arg SetUserStatusByIDParams) error
+	TombstoneRefreshFamily(ctx context.Context, arg TombstoneRefreshFamilyParams) error
 	TryCleanupAdvisoryLock(ctx context.Context, lockKey int64) (bool, error)
 	UnlockCleanupAdvisoryLock(ctx context.Context, lockKey int64) (bool, error)
 	UpdateAuthRequestCode(ctx context.Context, arg UpdateAuthRequestCodeParams) error

--- a/internal/db/storeq/refresh_tokens.sql.go
+++ b/internal/db/storeq/refresh_tokens.sql.go
@@ -120,6 +120,19 @@ func (q *Queries) InsertRefreshToken(ctx context.Context, arg InsertRefreshToken
 	return err
 }
 
+const isRefreshFamilyRevoked = `-- name: IsRefreshFamilyRevoked :one
+SELECT EXISTS (
+    SELECT 1 FROM refresh_token_families WHERE family_id = $1
+) AS revoked
+`
+
+func (q *Queries) IsRefreshFamilyRevoked(ctx context.Context, familyID string) (bool, error) {
+	row := q.db.QueryRowContext(ctx, isRefreshFamilyRevoked, familyID)
+	var revoked bool
+	err := row.Scan(&revoked)
+	return revoked, err
+}
+
 const markRefreshTokenUsedAndRevokedByID = `-- name: MarkRefreshTokenUsedAndRevokedByID :exec
 UPDATE refresh_tokens
 SET used_at = $1, revoked_at = $1
@@ -184,5 +197,28 @@ type RevokeRefreshTokenByIDParams struct {
 
 func (q *Queries) RevokeRefreshTokenByID(ctx context.Context, arg RevokeRefreshTokenByIDParams) error {
 	_, err := q.db.ExecContext(ctx, revokeRefreshTokenByID, arg.RevokedAt, arg.ID)
+	return err
+}
+
+const tombstoneRefreshFamily = `-- name: TombstoneRefreshFamily :exec
+INSERT INTO refresh_token_families (family_id, user_id, reason, revoked_at)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (family_id) DO NOTHING
+`
+
+type TombstoneRefreshFamilyParams struct {
+	FamilyID  string
+	UserID    string
+	Reason    string
+	RevokedAt time.Time
+}
+
+func (q *Queries) TombstoneRefreshFamily(ctx context.Context, arg TombstoneRefreshFamilyParams) error {
+	_, err := q.db.ExecContext(ctx, tombstoneRefreshFamily,
+		arg.FamilyID,
+		arg.UserID,
+		arg.Reason,
+		arg.RevokedAt,
+	)
 	return err
 }

--- a/internal/storage/refresh_family_tombstone_integration_test.go
+++ b/internal/storage/refresh_family_tombstone_integration_test.go
@@ -1,0 +1,132 @@
+//go:build integration
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/zitadel/oidc/v3/pkg/op"
+
+	"github.com/kangheeyong/authgate/internal/clock"
+	"github.com/kangheeyong/authgate/internal/idgen"
+	"github.com/kangheeyong/authgate/internal/testutil"
+)
+
+func newTombstoneStore(t *testing.T) (*Storage, *clock.FixedClock, idgen.CryptoGenerator) {
+	t.Helper()
+	db := testutil.SetupPostgres(t)
+	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
+	gen := idgen.CryptoGenerator{}
+	store := New(db, clk, gen, func(*User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
+	return store, clk, gen
+}
+
+// Reuse detection must tombstone the family, not only flip existing rows.
+func TestRefreshFamily_TombstonedOnReuse(t *testing.T) {
+	store, clk, gen := newTombstoneStore(t)
+	ctx := context.Background()
+
+	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+		Email: "tombstone-reuse@test.com", EmailVerified: true, Name: "T", Provider: "google", ProviderUserID: "tombstone-reuse-sub",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	now := clk.Now()
+	familyID := gen.NewUUID()
+	reusedToken := "tombstone-reused-token"
+	if _, err := store.DB().ExecContext(ctx,
+		`INSERT INTO refresh_tokens (id, token_hash, family_id, user_id, client_id, scopes, expires_at, revoked_at, used_at, created_at)
+		 VALUES (uuid_generate_v4(), $1, $2, $3, 'test-client', '{openid}', $4, $5, $5, $5)`,
+		hashToken(reusedToken), familyID, user.ID, now.Add(30*24*time.Hour), now,
+	); err != nil {
+		t.Fatalf("insert reused token: %v", err)
+	}
+
+	if _, err := store.TokenRequestByRefreshToken(ctx, reusedToken); err == nil {
+		t.Fatal("expected invalid refresh token error on reuse")
+	}
+
+	var reason string
+	if err := store.DB().QueryRowContext(ctx,
+		`SELECT reason FROM refresh_token_families WHERE family_id = $1`, familyID,
+	).Scan(&reason); err != nil {
+		t.Fatalf("expected tombstone row for family: %v", err)
+	}
+	if reason != "reuse_detected" {
+		t.Errorf("tombstone reason = %q, want reuse_detected", reason)
+	}
+}
+
+// A tombstoned family must refuse to issue a new child token even when a valid
+// (not-yet-used) parent token is presented for rotation — this is the race the
+// tombstone closes (row-level family revoke alone would miss the new child).
+func TestRefreshFamily_TombstoneBlocksChildIssue(t *testing.T) {
+	store, clk, gen := newTombstoneStore(t)
+	ctx := context.Background()
+
+	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+		Email: "tombstone-block@test.com", EmailVerified: true, Name: "B", Provider: "google", ProviderUserID: "tombstone-block-sub",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	now := clk.Now()
+	familyID := gen.NewUUID()
+	currentToken := "tombstone-current-token"
+	if _, err := store.DB().ExecContext(ctx,
+		`INSERT INTO refresh_tokens (id, token_hash, family_id, user_id, client_id, scopes, expires_at, created_at)
+		 VALUES (uuid_generate_v4(), $1, $2, $3, 'test-client', '{openid}', $4, $5)`,
+		hashToken(currentToken), familyID, user.ID, now.Add(30*24*time.Hour), now,
+	); err != nil {
+		t.Fatalf("insert current token: %v", err)
+	}
+
+	// Family gets tombstoned (as reuse detection would do).
+	if _, err := store.DB().ExecContext(ctx,
+		`INSERT INTO refresh_token_families (family_id, user_id, reason) VALUES ($1, $2, 'reuse_detected')`,
+		familyID, user.ID,
+	); err != nil {
+		t.Fatalf("tombstone family: %v", err)
+	}
+
+	req := &RefreshTokenModel{UserID: user.ID, ClientID: "test-client", Scopes: StringArray{"openid"}}
+	_, _, _, err = store.CreateAccessAndRefreshTokens(ctx, req, currentToken)
+	if !errors.Is(err, op.ErrInvalidRefreshToken) {
+		t.Fatalf("rotation into tombstoned family err = %v, want ErrInvalidRefreshToken", err)
+	}
+}
+
+// Rotation into a healthy (non-tombstoned) family must still succeed.
+func TestRefreshFamily_HealthyFamilyRotates(t *testing.T) {
+	store, clk, gen := newTombstoneStore(t)
+	ctx := context.Background()
+
+	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
+		Email: "tombstone-healthy@test.com", EmailVerified: true, Name: "H", Provider: "google", ProviderUserID: "tombstone-healthy-sub",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	now := clk.Now()
+	familyID := gen.NewUUID()
+	currentToken := "tombstone-healthy-token"
+	if _, err := store.DB().ExecContext(ctx,
+		`INSERT INTO refresh_tokens (id, token_hash, family_id, user_id, client_id, scopes, expires_at, created_at)
+		 VALUES (uuid_generate_v4(), $1, $2, $3, 'test-client', '{openid}', $4, $5)`,
+		hashToken(currentToken), familyID, user.ID, now.Add(30*24*time.Hour), now,
+	); err != nil {
+		t.Fatalf("insert current token: %v", err)
+	}
+
+	req := &RefreshTokenModel{UserID: user.ID, ClientID: "test-client", Scopes: StringArray{"openid"}}
+	if _, newRefresh, _, err := store.CreateAccessAndRefreshTokens(ctx, req, currentToken); err != nil || newRefresh == "" {
+		t.Fatalf("healthy rotation failed: token=%q err=%v", newRefresh, err)
+	}
+}

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -157,6 +157,19 @@ func (s *Storage) CreateAccessAndRefreshTokens(ctx context.Context, request op.T
 		return "", "", time.Time{}, err
 	}
 
+	// On rotation, refuse to issue a child into a family that reuse detection
+	// has tombstoned. The initial code/device exchange mints a fresh family_id
+	// that can never be tombstoned, so the check is skipped there.
+	if currentRefreshToken != "" {
+		revoked, err := qtx.IsRefreshFamilyRevoked(ctx, derived.familyID)
+		if err != nil {
+			return "", "", time.Time{}, err
+		}
+		if revoked {
+			return "", "", time.Time{}, op.ErrInvalidRefreshToken
+		}
+	}
+
 	if err := revokeRefreshTokenIfPresent(ctx, qtx, currentRefreshToken, now); err != nil {
 		return "", "", time.Time{}, err
 	}
@@ -209,16 +222,21 @@ func (s *Storage) TokenRequestByRefreshToken(ctx context.Context, refreshToken s
 		return nil, err
 	}
 
-	// Already used/revoked → reuse detection → family revoke
+	// Already used/revoked → reuse detection → family revoke + tombstone
 	if isRefreshTokenUsedOrRevoked(rt) {
 		if err := revokeRefreshFamilyOnReuse(ctx, qtx, rt.FamilyID, now); err != nil {
 			return nil, op.ErrInvalidRefreshToken
 		}
-		// Write the reuse-detection audit rows in the SAME transaction as the
-		// family revoke, so the security action and its audit evidence commit
-		// atomically. If the audit insert fails the whole tx rolls back and the
-		// client's retry triggers reuse detection again — the token is already
-		// used/revoked, so it stays unusable either way.
+		// Tombstone the family in the same tx as the revoke. RevokeRefreshFamily
+		// only flips existing rows; the tombstone is what CreateAccessAndRefreshTokens
+		// checks so a child rotating in just after the revoke is still refused.
+		if err := tombstoneRefreshFamilyOnReuse(ctx, qtx, rt.FamilyID, rt.UserID, now); err != nil {
+			return nil, op.ErrInvalidRefreshToken
+		}
+		// Write the reuse-detection audit rows in the SAME transaction too, so the
+		// revoke, tombstone and audit evidence commit atomically. If any insert
+		// fails the whole tx rolls back; the client's retry triggers reuse
+		// detection again (token already used/revoked, so it stays unusable).
 		if err := s.auditRefreshReuseDetectionTx(ctx, qtx, rt.UserID, rt.FamilyID); err != nil {
 			return nil, op.ErrInvalidRefreshToken
 		}
@@ -444,6 +462,18 @@ func revokeRefreshFamilyOnReuse(ctx context.Context, qtx *storeq.Queries, family
 	return qtx.RevokeRefreshFamily(ctx, storeq.RevokeRefreshFamilyParams{
 		RevokedAt: sql.NullTime{Time: now, Valid: true},
 		FamilyID:  familyID,
+	})
+}
+
+// tombstoneRefreshFamilyOnReuse records a permanent per-family tombstone so a
+// child token cannot be issued into the family later (checked by
+// CreateAccessAndRefreshTokens). Idempotent via ON CONFLICT DO NOTHING.
+func tombstoneRefreshFamilyOnReuse(ctx context.Context, qtx *storeq.Queries, familyID, userID string, now time.Time) error {
+	return qtx.TombstoneRefreshFamily(ctx, storeq.TombstoneRefreshFamilyParams{
+		FamilyID:  familyID,
+		UserID:    userID,
+		Reason:    "reuse_detected",
+		RevokedAt: now,
 	})
 }
 

--- a/migrations/013_refresh_token_families.down.sql
+++ b/migrations/013_refresh_token_families.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS refresh_token_families;

--- a/migrations/013_refresh_token_families.up.sql
+++ b/migrations/013_refresh_token_families.up.sql
@@ -1,0 +1,14 @@
+-- Family-level tombstone for refresh-token reuse detection. RevokeRefreshFamily
+-- only flips revoked_at on rows that already exist, so a child token inserted
+-- into a family in the narrow window just after a reuse-triggered family revoke
+-- could escape revocation. This table records a permanent per-family tombstone
+-- when reuse is detected; CreateAccessAndRefreshTokens refuses to issue a child
+-- for a tombstoned family. Rows are sparse — only revoked families appear here.
+CREATE TABLE refresh_token_families (
+    family_id  UUID PRIMARY KEY,
+    user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    reason     TEXT NOT NULL,
+    revoked_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX refresh_token_families_user_id_idx ON refresh_token_families (user_id);


### PR DESCRIPTION
## 무엇

refresh 토큰 **재사용 감지** 시 family 레벨 **tombstone**을 도입해, family revoke 직후 좁은 레이스에서 새 자식 토큰이 살아남는 갭을 닫는다. 심층 분석 라운드의 **"Refresh Token Family Revoke 무력화"** finding(검증 PARTIAL — 실재 갭, 좁은 동시성 레이스)에 대한 대응이다.

## 문제

`RevokeRefreshFamily`는 **이미 존재하는** 행의 `revoked_at`만 갱신한다. reuse 감지가 family를 revoke한 직후, 거의 동시에 진행되던 rotation이 새 자식 토큰을 INSERT하면 그 토큰은 revoke 스윕을 피해 살아남을 수 있다(family 레벨 tombstone 부재 + 발급 경로의 family-revoked 미확인).

## 수정

- `refresh_token_families` tombstone 테이블 (migration 013) — tombstone된 family만 행 존재(sparse).
- reuse 감지 시 revoke와 **같은 트랜잭션**에서 tombstone 기록(`reason='reuse_detected'`).
- `CreateAccessAndRefreshTokens`가 rotation 시 `IsRefreshFamilyRevoked` 확인 → tombstone된 family면 발급 거부. 최초 code/device 교환은 새 family라 확인 생략.

## 검증

- 신규 통합 테스트 3건: reuse→tombstone 생성 / tombstone family rotation 거부 / 정상 family rotation 성공.
- 기존 reuse·rotation 테스트(`TestAudit010And011...`, `TestRefreshTokenRotation_Atomicity`) 통과.
- `go test -tags=integration ./internal/...` 전체 통과, `golangci-lint`(clean cache) 0 issues.
- 마이그레이션 013 실제 부팅 적용 확인(테이블/PK/user_id 인덱스/FK cascade).
- 문서: 005(재사용 탐지 규칙), 007(데이터 모델), 009(마이그레이션 노트).

## ⚠️ 머지 순서

golang-migrate는 단일 version 카운터라 마이그레이션을 **번호 오름차순**으로 적용한다.
- 반드시 **#289(012 FK 인덱스) 머지 후** 머지할 것. (012가 나중에 오면 건너뛰어 적용 안 됨)
- #291(감사 트랜잭션화)과 reuse 블록이 겹치므로, #291 머지 후 이 브랜치를 rebase하면 충돌 없이 깔끔하다. 필요 시 rebase 처리하겠다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)