### PR TITLE
ci: raise go test timeout for integration/race jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,11 @@ jobs:
         run: go build ./...
 
       - name: Run all tests with coverage
-        run: go test -coverprofile=coverage.out -tags=integration ./internal/...
+        # -timeout 20m: the integration suite spins up testcontainers Postgres
+        # and runs in ~2-3min locally, but the shared ARC runner under load can
+        # exceed Go's default 10m per-package timeout and panic. 20m gives wide
+        # headroom without masking a genuine hang.
+        run: go test -coverprofile=coverage.out -tags=integration -timeout 20m ./internal/...
 
       - name: Upload coverage
         uses: actions/upload-artifact@v7
@@ -139,7 +143,10 @@ jobs:
         # integration) are actually compiled under the race detector. Without
         # the tag they were excluded, leaving the concurrency paths unchecked.
         # Same runner as the Test job, so Docker/testcontainers is available.
-        run: go test -race -tags=integration ./...
+        # -timeout 30m: the race detector makes the integration suite several
+        # times slower, so it needs a larger ceiling than the Test job's 20m to
+        # avoid Go's default 10m timeout panic on the shared runner.
+        run: go test -race -tags=integration -timeout 30m ./...
 
   coverage-report:
     name: Coverage Report


### PR DESCRIPTION
## 무엇

`Test`/`Race` job의 `go test`에 `-timeout`을 추가한다. 통합 테스트가 testcontainers Postgres를 띄우는데, 공유 ARC 러너가 부하를 받으면 Go 기본 10분 per-package 타임아웃을 초과해 `panic: test timed out after 10m0s`로 깨진다(로컬은 패키지당 ~80s).

## 증거

- 로컬: `internal/service` ~77s, `internal/integration` ~82s.
- CI(러너 부하): 두 패키지 모두 600s에서 타임아웃 panic → Test job FAIL.
- `Race` job은 #290으로 `-tags=integration`이 붙어 race+통합이라 더 느리다 → 같은 위험.

## 수정

- `Test`: `-timeout 20m`
- `Race`: `-timeout 30m` (race가 수 배 느림)

넉넉한 상한이지만 실제 hang은 여전히 잡힌다(로컬 정상 시간의 수 배 이상 여유).

🤖 Generated with [Claude Code](https://claude.com/claude-code)