### PR TITLE
fix(ratelimit): share rate limiters across both route groups

### DIFF
--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -27,10 +27,31 @@ func registerRoutes(
 	mcpLoginHandler *handler.MCPLoginHandler,
 	isShuttingDown *atomic.Bool,
 ) {
+	// Build the per-IP rate limiters once and share them across both route
+	// groups. Building them per-registrar would give each group its own bucket
+	// map, so a single IP would get the configured burst separately on, e.g.,
+	// /authorize (provider) and /login (authgate) — silently doubling the
+	// effective limit and spawning duplicate cleanup goroutines.
+	lim := newRouteLimiters(cfg)
+
 	registerOAuthMetadataRoute(mux, cfg)
-	registerProviderRoutes(mux, cfg, store, provider)
-	registerAuthgateRoutes(mux, cfg, loginHandler, deviceHandler, accountHandler, mcpLoginHandler)
+	registerProviderRoutes(mux, cfg, store, provider, lim)
+	registerAuthgateRoutes(mux, cfg, loginHandler, deviceHandler, accountHandler, mcpLoginHandler, lim)
 	registerHealthRoutes(mux, db, isShuttingDown)
+}
+
+// routeLimiters holds the shared rate-limiting middlewares: strict for token
+// endpoints, moderate for auth/login endpoints.
+type routeLimiters struct {
+	token func(http.Handler) http.Handler
+	auth  func(http.Handler) http.Handler
+}
+
+func newRouteLimiters(cfg *config.Config) routeLimiters {
+	return routeLimiters{
+		token: middleware.NewRateLimiter(rate.Limit(cfg.RateLimitTokenRPS), cfg.RateLimitTokenBurst),
+		auth:  middleware.NewRateLimiter(rate.Limit(cfg.RateLimitAuthRPS), cfg.RateLimitAuthBurst),
+	}
 }
 
 func registerOAuthMetadataRoute(mux *http.ServeMux, cfg *config.Config) {
@@ -75,10 +96,8 @@ func registerOAuthMetadataRoute(mux *http.ServeMux, cfg *config.Config) {
 	})
 }
 
-func registerProviderRoutes(mux *http.ServeMux, cfg *config.Config, store *storage.Storage, provider http.Handler) {
-	// Rate limiters: strict for token endpoints, moderate for auth/login
-	tokenLimiter := middleware.NewRateLimiter(rate.Limit(cfg.RateLimitTokenRPS), cfg.RateLimitTokenBurst)
-	authLimiter := middleware.NewRateLimiter(rate.Limit(cfg.RateLimitAuthRPS), cfg.RateLimitAuthBurst)
+func registerProviderRoutes(mux *http.ServeMux, cfg *config.Config, store *storage.Storage, provider http.Handler, lim routeLimiters) {
+	tokenLimiter, authLimiter := lim.token, lim.auth
 
 	mux.Handle("/authorize", authLimiter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resource, err := storage.ResourceFromRequestStrict(r)
@@ -125,9 +144,9 @@ func registerAuthgateRoutes(
 	deviceHandler *handler.DeviceHandler,
 	accountHandler *handler.AccountHandler,
 	mcpLoginHandler *handler.MCPLoginHandler,
+	lim routeLimiters,
 ) {
-	tokenLimiter := middleware.NewRateLimiter(rate.Limit(cfg.RateLimitTokenRPS), cfg.RateLimitTokenBurst)
-	authLimiter := middleware.NewRateLimiter(rate.Limit(cfg.RateLimitAuthRPS), cfg.RateLimitAuthBurst)
+	tokenLimiter, authLimiter := lim.token, lim.auth
 
 	mux.Handle("/login", authLimiter(http.HandlerFunc(loginHandler.HandleLogin)))
 	mux.Handle("/login/callback", authLimiter(http.HandlerFunc(loginHandler.HandleCallback)))

--- a/internal/app/routes_test.go
+++ b/internal/app/routes_test.go
@@ -88,7 +88,8 @@ func TestRegisterProviderRoutes_RateLimitsSensitiveOAuthEndpoints(t *testing.T) 
 			provider := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			})
-			registerProviderRoutes(mux, rateLimitTestConfig(), nil, provider)
+			cfg := rateLimitTestConfig()
+			registerProviderRoutes(mux, cfg, nil, provider, newRouteLimiters(cfg))
 
 			assertRateLimited(t, mux, tt.method, tt.path)
 		})
@@ -112,13 +113,15 @@ func TestRegisterAuthgateRoutes_RateLimitsSensitiveAuthgateEndpoints(t *testing.
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
 			mux := http.NewServeMux()
+			cfg := rateLimitTestConfig()
 			registerAuthgateRoutes(
 				mux,
-				rateLimitTestConfig(),
+				cfg,
 				handler.NewLoginHandler(nil, nil, true, "authgate"),
 				handler.NewDeviceHandler(nil, nil, true, "authgate"),
 				handler.NewAccountHandler(nil, "http://authgate.example.com"),
 				handler.NewMCPLoginHandler(nil, nil, true, "authgate"),
+				newRouteLimiters(cfg),
 			)
 
 			assertRateLimited(t, mux, tt.method, tt.path)


### PR DESCRIPTION
## 무엇

토큰/auth 레이트리미터가 `registerProviderRoutes`와 `registerAuthgateRoutes`에서 **각각 새로 생성**되어 IP당 버킷 맵이 그룹별로 분리돼 있던 문제를 고친다. 멀티에이전트 컴포넌트 리뷰에서 발견.

## 문제

한 IP가 provider 엔드포인트(`/authorize` 등)와 authgate 엔드포인트(`/login` 등)에서 **각각 별도 버스트**를 받아 `RATE_LIMIT_AUTH_*`/`RATE_LIMIT_TOKEN_*`의 실효 한도가 사실상 2배가 됐다. 인증 엔드포인트의 레이트리밋은 보안 통제이므로 이는 통제 약화다. 추가로 cleanup 고루틴/티커도 중복 생성됐다.

## 수정

`registerRoutes`에서 `newRouteLimiters(cfg)`로 **한 번만** 만들어 두 registrar에 공유 주입. 라우트 테스트(`routes_test.go`)도 공유 리미터를 넘기도록 갱신.

## 검증
`go build`/`go test ./internal/app/...` ✅, `golangci-lint` 0 issues ✅, gofmt 클린.

Found by the multi-agent component review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)