### PR TITLE
fix(cors): forward Flusher/Hijacker through corsWriter

### DIFF
--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -1,6 +1,9 @@
 package middleware
 
 import (
+	"bufio"
+	"errors"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -91,6 +94,28 @@ func (c *corsWriter) flushCORSHeaders() {
 		h.Del("Access-Control-Allow-Credentials")
 		h.Del("Access-Control-Max-Age")
 	}
+}
+
+// Flush forwards to the underlying ResponseWriter's http.Flusher so streaming
+// handlers downstream (e.g. the OIDC provider) are not silently broken by the
+// wrapper. CORS headers are committed first so they precede any flushed body.
+func (c *corsWriter) Flush() {
+	if f, ok := c.ResponseWriter.(http.Flusher); ok {
+		if !c.written {
+			c.flushCORSHeaders()
+		}
+		f.Flush()
+	}
+}
+
+// Hijack forwards to the underlying ResponseWriter's http.Hijacker so
+// connection-upgrade handlers keep working through the wrapper. After a hijack
+// the caller owns the raw connection, so CORS response headers no longer apply.
+func (c *corsWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := c.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, errors.New("corsWriter: underlying ResponseWriter does not implement http.Hijacker")
 }
 
 // OriginsFromRedirectURIs extracts unique scheme+host values from a list of

--- a/internal/middleware/cors_test.go
+++ b/internal/middleware/cors_test.go
@@ -1,0 +1,56 @@
+package middleware
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// corsWriter must preserve the optional ResponseWriter interfaces of the writer
+// it wraps, otherwise streaming/upgrade handlers downstream break silently.
+
+func TestCorsWriter_ForwardsFlush(t *testing.T) {
+	rec := httptest.NewRecorder()
+	cw := &corsWriter{ResponseWriter: rec}
+	cw.Flush()
+	if !rec.Flushed {
+		t.Error("Flush was not forwarded to the underlying ResponseWriter")
+	}
+}
+
+type hijackableWriter struct {
+	*httptest.ResponseRecorder
+	hijacked bool
+}
+
+func (h *hijackableWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h.hijacked = true
+	return nil, nil, nil
+}
+
+func TestCorsWriter_ForwardsHijack(t *testing.T) {
+	hw := &hijackableWriter{ResponseRecorder: httptest.NewRecorder()}
+	cw := &corsWriter{ResponseWriter: hw}
+	if _, _, err := cw.Hijack(); err != nil {
+		t.Fatalf("Hijack returned error: %v", err)
+	}
+	if !hw.hijacked {
+		t.Error("Hijack was not forwarded to the underlying ResponseWriter")
+	}
+}
+
+func TestCorsWriter_HijackUnsupportedReturnsError(t *testing.T) {
+	// httptest.ResponseRecorder does not implement http.Hijacker.
+	cw := &corsWriter{ResponseWriter: httptest.NewRecorder()}
+	if _, _, err := cw.Hijack(); err == nil {
+		t.Error("expected an error when the underlying writer is not an http.Hijacker")
+	}
+}
+
+// Compile-time guarantee that corsWriter advertises the optional interfaces.
+var (
+	_ http.Flusher  = (*corsWriter)(nil)
+	_ http.Hijacker = (*corsWriter)(nil)
+)


### PR DESCRIPTION
## 무엇

`corsWriter`가 래핑한 ResponseWriter의 `http.Flusher`/`http.Hijacker`를 전달하지 않아, 다운스트림(특히 `/`에 마운트된 OIDC provider)의 스트리밍/연결 업그레이드 능력이 조용히 사라지던 문제를 고친다. 멀티에이전트 리뷰에서 발견.

## 수정

`corsWriter`에 `Flush()`·`Hijack()` 패스스루 추가(인터페이스 단언으로 가드). `Flush`는 CORS 헤더를 먼저 커밋. 데코레이터는 래핑 대상의 optional 인터페이스를 보존해야 한다.

## 검증

`cors_test.go` 추가: Flush 전달 / Hijack 전달 / 미지원 시 에러 + 컴파일타임 인터페이스 단언. `go test ./internal/middleware/...` ✅, lint 0 ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)