### PR TITLE
fix(config): validate PII root secrets in Load()

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net"
 	"net/url"
@@ -9,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/kangheeyong/authgate/internal/crypto"
 )
 
 type Config struct {
@@ -152,6 +155,15 @@ func Load() (*Config, error) {
 		if c.EncRootKeyID == "" || c.EncRootSecret == "" || c.LookupRootKeyID == "" || c.LookupRootSecret == "" {
 			return nil, fmt.Errorf("PII encryption requires all of PII_ENC_ROOT_KEY_ID, PII_ENC_ROOT_SECRET, PII_LOOKUP_ROOT_KEY_ID, PII_LOOKUP_ROOT_SECRET")
 		}
+		// Validate the secrets here so a bad base64/too-short root fails at the
+		// config layer (which owns env correctness) rather than later at crypto
+		// wiring. Decoded bytes are discarded — Config stays string-only.
+		if err := validateRootSecret("PII_ENC_ROOT_SECRET", c.EncRootSecret); err != nil {
+			return nil, err
+		}
+		if err := validateRootSecret("PII_LOOKUP_ROOT_SECRET", c.LookupRootSecret); err != nil {
+			return nil, err
+		}
 	}
 	if c.DBMaxOpenConns < 0 {
 		return nil, fmt.Errorf("DB_MAX_OPEN_CONNS must be >= 0")
@@ -206,6 +218,20 @@ func Load() (*Config, error) {
 	}
 
 	return c, nil
+}
+
+// validateRootSecret checks that a PII root secret is valid base64 decoding to
+// at least crypto.KeySize bytes — the same floor crypto.NewRoot enforces — so
+// the failure surfaces from the config layer that owns env correctness.
+func validateRootSecret(name, b64 string) error {
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return fmt.Errorf("%s must be base64: %w", name, err)
+	}
+	if len(raw) < crypto.KeySize {
+		return fmt.Errorf("%s must decode to >= %d bytes, got %d", name, crypto.KeySize, len(raw))
+	}
+	return nil
 }
 
 func validateParseableEnv() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -137,6 +137,47 @@ func TestLoad_DevModeFalseRequiresPIIRoots(t *testing.T) {
 	}
 }
 
+func TestLoad_RejectsNonBase64RootSecret(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("PII_ENC_ROOT_KEY_ID", "enc-1")
+	os.Setenv("PII_ENC_ROOT_SECRET", "not!base64!!!")
+	os.Setenv("PII_LOOKUP_ROOT_KEY_ID", "lkp-1")
+	os.Setenv("PII_LOOKUP_ROOT_SECRET", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=") // 32 bytes
+
+	_, err := Load()
+	if err == nil || !strings.Contains(err.Error(), "PII_ENC_ROOT_SECRET must be base64") {
+		t.Fatalf("err = %v, want base64 error for PII_ENC_ROOT_SECRET", err)
+	}
+}
+
+func TestLoad_RejectsTooShortRootSecret(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("PII_ENC_ROOT_KEY_ID", "enc-1")
+	os.Setenv("PII_ENC_ROOT_SECRET", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=") // 32 bytes, ok
+	os.Setenv("PII_LOOKUP_ROOT_KEY_ID", "lkp-1")
+	os.Setenv("PII_LOOKUP_ROOT_SECRET", "c2hvcnQ=") // "short" → 5 bytes
+
+	_, err := Load()
+	if err == nil || !strings.Contains(err.Error(), "PII_LOOKUP_ROOT_SECRET must decode to >=") {
+		t.Fatalf("err = %v, want too-short error for PII_LOOKUP_ROOT_SECRET", err)
+	}
+}
+
+func TestLoad_AcceptsValidRootSecrets(t *testing.T) {
+	clearEnv()
+	setMinimal()
+	os.Setenv("PII_ENC_ROOT_KEY_ID", "enc-1")
+	os.Setenv("PII_ENC_ROOT_SECRET", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+	os.Setenv("PII_LOOKUP_ROOT_KEY_ID", "lkp-1")
+	os.Setenv("PII_LOOKUP_ROOT_SECRET", "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=")
+
+	if _, err := Load(); err != nil {
+		t.Fatalf("valid root secrets rejected: %v", err)
+	}
+}
+
 func TestLoad_Defaults(t *testing.T) {
 	clearEnv()
 	setMinimal()


### PR DESCRIPTION
## 무엇

`config.Load()`가 PII root 4개의 존재/all-or-nothing만 검증하고, **base64 디코드+길이 검증은 `app/crypto.go`에서 `log.Fatalf`로 늦게** 수행하던 split-brain을 고친다. 멀티에이전트 리뷰에서 발견.

## 문제

비-base64이거나 32바이트 미만인 secret이 `Load()`를 통과한 뒤 wiring 단계에서야, env 정합성을 책임지는 config 레이어가 아닌 다른 에러 경로로 실패했다.

## 수정

`Load()`에서 두 secret을 디코드하고 `>= crypto.KeySize`(crypto.NewRoot와 동일 기준) 검증 → 잘못된 secret은 config 에러로 즉시 실패. 디코드 바이트는 폐기(Config는 string-only 유지).

## 검증

config 테스트 3건 추가(비-base64 거부 / 너무 짧음 거부 / 유효 허용) 통과, lint 0, gofmt 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)