### PR TITLE
fix(mcp): don't trigger CIMD fetch on the token endpoint

### DIFF
--- a/internal/adapter/mcp/policy.go
+++ b/internal/adapter/mcp/policy.go
@@ -90,10 +90,13 @@ func NewClientResolutionPolicy(base storage.ClientResolutionPolicy, fetcher stor
 	return &clientResolutionPolicy{base: base, fetcher: fetcher}
 }
 
-// NewResourceBindingPolicy returns the MCP-aware wrapper. `resolver` is
-// used to look up the client's login_channel for the legacy-data and
-// defense-in-depth checks at the token endpoint; it may be nil when the
-// caller has no client registry (test-only).
+// NewResourceBindingPolicy returns the MCP-aware wrapper. `resolver` is used to
+// look up the client's login_channel for the legacy-data and defense-in-depth
+// checks at the token endpoint; it may be nil when the caller has no client
+// registry (test-only). Pass a NON-fetching resolver (the core registry
+// lookup), not the CIMD-augmented one: the token check only needs to catch a
+// browser client carrying a resource, and browser clients are always locally
+// registered, so the token endpoint must never trigger an outbound CIMD fetch.
 func NewResourceBindingPolicy(base storage.ResourceBindingPolicy, resolver storage.ClientResolutionPolicy) storage.ResourceBindingPolicy {
 	return &resourceBindingPolicy{base: base, resolver: resolver}
 }

--- a/internal/app/storage_wiring.go
+++ b/internal/app/storage_wiring.go
@@ -72,7 +72,13 @@ func configureMCPPoliciesIfEnabled(cfg *config.Config, store *storage.Storage) {
 		return
 	}
 	cimdFetcher := mcpadapter.NewHTTPCIMDFetcher()
-	clientPolicy := mcpadapter.NewClientResolutionPolicy(storage.NewCoreClientResolutionPolicy(store), cimdFetcher)
+	coreResolver := storage.NewCoreClientResolutionPolicy(store)
+	// General client resolution (e.g. /authorize) may fetch CIMD documents.
+	clientPolicy := mcpadapter.NewClientResolutionPolicy(coreResolver, cimdFetcher)
 	store.SetClientResolutionPolicy(clientPolicy)
-	store.SetResourceBindingPolicy(mcpadapter.NewResourceBindingPolicy(storage.NewCoreResourceBindingPolicy(), clientPolicy))
+	// The resource-binding policy's token-endpoint check only needs the
+	// locally-known login_channel (browser clients are always in the local
+	// registry), so give it the NON-fetching core resolver — never trigger an
+	// outbound CIMD HTTP fetch on the hot /oauth/token path.
+	store.SetResourceBindingPolicy(mcpadapter.NewResourceBindingPolicy(storage.NewCoreResourceBindingPolicy(), coreResolver))
 }


### PR DESCRIPTION
## 무엇

`resourceBindingPolicy.ValidateTokenRequest`가 CIMD-augmented resolver를 통해 `/oauth/token`에서 **외부 CIMD HTTP fetch**를 유발할 수 있던 문제를 고친다. 멀티에이전트 리뷰에서 발견.

## 문제

resource가 있으면 token 경로에서 `ResolveClient → FetchClient`(서드파티 문서 호스트로 아웃바운드 HTTP)가 호출돼 토큰 발급 지연/가용성이 외부 호스트에 결합됐다.

## 수정

token 검사는 **로컬에 등록된 login_channel**만 알면 된다(browser 클라이언트는 항상 로컬 레지스트리에 있음 → resource 보유 시 거부; MCP/CIMD 클라이언트는 정당하게 resource 보유 → fall through). 바인딩 정책에 **non-fetching 코어 resolver**를 주입. `/authorize`의 일반 클라이언트 해석은 CIMD-fetching resolver 유지.

## 검증

`go build`/유닛 테스트/lint 0 ✅, MCP·resource·token **통합 테스트 통과**(자원 바인딩 enforcement 유지 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)