### PR TITLE
docs: align audit-best-effort note + complete event_type table

### DIFF
--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -183,6 +183,7 @@ erDiagram
 | `auth.login` | 로그인 성공 | 브라우저/Device/MCP 로그인 |
 | `auth.channel_mismatch` | auth_request 채널 불일치 차단 | 브라우저/MCP 로그인 |
 | `auth.inactive_user` | 비활성 유저 로그인 시도 차단 | 브라우저/Device/MCP 로그인 |
+| `auth.device_code_issued` | 디바이스 코드 발급 | Device authorize 엔드포인트 |
 | `auth.device_approved` | Device 코드 승인 | Device 승인 페이지 |
 | `auth.device_denied` | Device 코드 거부 | Device 승인 페이지 |
 | `auth.deletion_requested` | 계정 삭제 요청 | 계정 삭제 API |

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -358,6 +358,8 @@ Go runtime/process Prometheus metrics를 노출한다. 운영에서는
 
 `Storage.AuditLog`는 best-effort write이므로 marshal/insert 실패가 비즈니스 트랜잭션을 차단하지 않는다. 그러나 감사 로그가 silent하게 누락되면 침해 탐지 능력 자체가 무력화되므로 실패는 구조화 로그로 남긴다.
 
+**예외**: refresh token 재사용 감지 이벤트(`auth.refresh_reuse_detected`, `auth.refresh_family_revoked`)는 family revoke·tombstone과 **같은 트랜잭션**에서 `writeAuditLogTx`로 기록된다. 감사 insert가 실패하면 트랜잭션 전체가 롤백되므로 이 두 이벤트는 silent하게 누락되지 않는다(best-effort 경로와 다름).
+
 | 로그 메시지 | 의미 |
 |-------------|------|
 | `audit log: marshal metadata` | `json.Marshal(metadata)` 실패 — 호출자 입력 형상 버그 |


### PR DESCRIPTION
## 무엇

멀티에이전트 문서갭 분석에서 나온 코드↔문서 불일치 2건 보정.

1. **009 감사 모니터링 노트**: 모든 audit write가 best-effort인 것처럼 읽혔으나, refresh 재사용 이벤트(`auth.refresh_reuse_detected`/`auth.refresh_family_revoked`)는 이제 revoke·tombstone과 같은 tx에서 `writeAuditLogTx`로 기록(실패 시 롤백) → silent 누락 안 됨. 예외 명시.
2. **007 첫 번째 event_type 표**: `auth.device_code_issued` 누락(두 번째 표와 코드엔 존재). 행 추가.

문서만 변경. 코드는 정본.

🤖 Generated with [Claude Code](https://claude.com/claude-code)