### PR TITLE
refactor(comments): drop finished-history narration and dedup explanations

### DIFF
--- a/internal/adapter/mcp/cimd.go
+++ b/internal/adapter/mcp/cimd.go
@@ -65,10 +65,9 @@ const (
 
 	// cimdFloorTTL is the minimum positive-cache TTL applied to any
 	// successful response. Server-stated max-age values smaller than this
-	// (or `no-store` / `no-cache` / `max-age<=0`, which previously bypassed
-	// the cache entirely) are raised to the floor so back-to-back identical
-	// fetches cannot keep stalling the worker pool when the upstream is
-	// slow (see #158).
+	// (including `no-store` / `no-cache` / `max-age<=0`) are raised to the
+	// floor so back-to-back identical fetches cannot keep stalling the
+	// worker pool when the upstream is slow (see #158).
 	cimdFloorTTL = 5 * time.Second
 )
 

--- a/internal/adapter/mcp/policy.go
+++ b/internal/adapter/mcp/policy.go
@@ -25,23 +25,16 @@ func (p *clientResolutionPolicy) ResolveClient(ctx context.Context, clientID str
 	return nil, err
 }
 
+// resourceBindingPolicy enforces authgate's RFC 8707 §2.2 channel × resource
+// matrix (spec 004): mcp clients REQUIRE a resource (the token's audience);
+// browser clients MUST NOT carry one — a browser minting an MCP-audience token
+// is a boundary-confusion attack (#184).
 type resourceBindingPolicy struct {
 	base     storage.ResourceBindingPolicy
 	resolver storage.ClientResolutionPolicy
 }
 
-// ValidateAuthorizeRequest enforces the channel × resource matrix per
-// RFC 8707 §2.2 AS-side policy and authgate spec 004:
-//   - login_channel='mcp'     ⇒ resource is REQUIRED (the token would
-//     otherwise have no audience to bind to)
-//   - login_channel='browser' ⇒ resource MUST NOT be present (a browser
-//     client minting an MCP-audience token is a
-//     boundary-confusion attack — issue #184)
-//
-// Once /authorize rejects browser+resource here, the core policy's
-// existing "unexpected resource" check at /oauth/token covers the
-// follow-on token and refresh paths transitively (storedResource will
-// be empty for browser-channel auth_requests / refresh_tokens).
+// ValidateAuthorizeRequest is the primary enforcement point for the matrix.
 func (p *resourceBindingPolicy) ValidateAuthorizeRequest(ctx context.Context, client *storage.ClientModel, requestResource string) error {
 	if client != nil {
 		if client.LoginChannel == "mcp" {
@@ -57,22 +50,10 @@ func (p *resourceBindingPolicy) ValidateAuthorizeRequest(ctx context.Context, cl
 	return p.base.ValidateAuthorizeRequest(ctx, client, requestResource)
 }
 
-// ValidateTokenRequest enforces the channel × resource matrix at the
-// token endpoint. The /authorize gate is the primary enforcement point;
-// this hook makes the fix self-healing for any data minted before the
-// gate landed and is a defense-in-depth pass for direct token requests.
-//
-//   - A non-empty `storedResource` on a non-MCP client is a refresh
-//     token (or auth_request) created before #184 closed the gate.
-//     Reject with `invalid_grant` so the legacy binding fails closed
-//     on first reuse rather than continuing to mint MCP-aud tokens
-//     forever.
-//   - A non-empty `requestResource` on a non-MCP client mirrors the
-//     /authorize check on the off chance the request bypassed the
-//     primary gate.
-//
-// `resolver` may be nil; in that case the wrapper degrades to base
-// behavior (used by tests that don't need legacy-data coverage).
+// ValidateTokenRequest re-checks the matrix at the token endpoint: a non-mcp
+// client with a stored resource (legacy data) is rejected with invalid_grant so
+// it fails closed on reuse, and a non-mcp client carrying a request resource is
+// rejected too. resolver may be nil (test-only → base behavior).
 func (p *resourceBindingPolicy) ValidateTokenRequest(ctx context.Context, clientID, storedResource, requestResource string) error {
 	if (storedResource != "" || requestResource != "") && p.resolver != nil {
 		client, err := p.resolver.ResolveClient(ctx, clientID)

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -69,22 +69,9 @@ func registerOAuthMetadataRoute(mux *http.ServeMux, cfg *config.Config) {
 			"response_types_supported":         []string{"code"},
 			"grant_types_supported":            []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
 			"code_challenge_methods_supported": []string{"S256"},
-			// #189 / RFC 8414 §2: zitadel/oidc's /oauth/token branch always
-			// accepts `client_secret_basic` (the OIDC default), accepts
-			// `client_secret_post` because op.Config.AuthMethodPost=true,
-			// and accepts `none` for public clients. Advertise all three so
-			// confidential clients trusting discovery don't pick the wrong
-			// credential location and silently fail. The /oauth/revoke
-			// branch (RFC 7009) accepts the same set, so mirror it.
-			//
-			// /oauth/introspect (RFC 7662) is mounted by zitadel by default
-			// at the OP's IntrospectionEndpoint() and authenticates via
-			// `ClientIDFromRequest` which only flips `authenticated=true`
-			// for `ClientBasicAuth` or `ClientJWTAuth`. Form-based Post
-			// credentials don't authenticate the introspector, so we
-			// advertise only `client_secret_basic` here — matching
-			// zitadel/oidc's own discovery default in
-			// `AuthMethodsIntrospectionEndpoint`.
+			// Auth methods must match zitadel/oidc behavior (RFC 8414 §2):
+			// token + revoke accept none/basic/post; introspection authenticates
+			// only via Basic. See docs/spec/004-mcp-login.md for the rationale.
 			"token_endpoint_auth_methods_supported":         []string{"none", "client_secret_basic", "client_secret_post"},
 			"revocation_endpoint_auth_methods_supported":    []string{"none", "client_secret_basic", "client_secret_post"},
 			"introspection_endpoint_auth_methods_supported": []string{"client_secret_basic"},

--- a/internal/middleware/security_headers.go
+++ b/internal/middleware/security_headers.go
@@ -2,17 +2,9 @@ package middleware
 
 import "net/http"
 
-// contentSecurityPolicy is tuned for authgate's served HTML (the device-entry,
-// device-approve, result and error pages under internal/pages/templates).
-// Those pages use exactly one inline <style> block plus Google Fonts and carry
-// no scripts, no event-handler attributes and no <img> tags. The policy:
-//   - default-src 'none' denies everything not explicitly re-allowed, so
-//     script-src inherits 'none' — no inline or remote JS can ever execute.
-//   - style-src allows the inline <style> ('unsafe-inline') and the Google
-//     Fonts stylesheet; font-src allows the gstatic font files.
-//   - frame-ancestors 'none' and base-uri 'none' block clickjacking and <base>
-//     hijacking. The JSON API responses also receive this header harmlessly —
-//     browsers load no subresources from a JSON body.
+// contentSecurityPolicy matches authgate's static HTML (internal/pages/templates):
+// no scripts, one inline <style> block, Google Fonts only. See
+// docs/security/002-http-security-headers.md for the full rationale.
 const contentSecurityPolicy = "default-src 'none'; " +
 	"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
 	"font-src https://fonts.gstatic.com; " +
@@ -26,15 +18,9 @@ const contentSecurityPolicy = "default-src 'none'; " +
 // control. Operators who want a stronger policy can layer it at the proxy.
 const strictTransportSecurity = "max-age=31536000"
 
-// SecurityHeaders returns middleware that sets baseline security response
-// headers on every response. It is wired as the OUTERMOST middleware so the
-// headers are present on error responses and CORS preflight replies too. The
-// headers are set before the inner handler runs, so they land in the header map
-// regardless of which downstream handler commits the response.
-//
-// devMode gates Strict-Transport-Security: in dev the server runs over plain
-// HTTP (and PUBLIC_URL is http://), where an HSTS header would be ignored by
-// browsers anyway and only confuse local testing.
+// SecurityHeaders sets baseline security headers on every response. Wire it as
+// the OUTERMOST middleware so they reach error and CORS-preflight replies too.
+// devMode omits HSTS (dev serves plain HTTP, where browsers ignore it anyway).
 func SecurityHeaders(devMode bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -15,22 +15,10 @@ import (
 
 // Audit event type constants.
 //
-// EventAuthLogout vs EventAuthTokenRevoked (#191):
-//
-//   - `auth.logout` is emitted by `TerminateSession` when the user invokes
-//     OIDC RP-Initiated Logout (`/end_session`). It revokes server-side
-//     **session rows** (`sessions.revoked_at`) but does NOT touch active
-//     refresh tokens — RFC 7009 token revocation and OIDC RP-Initiated
-//     Logout 1.0 §2 are deliberately distinct concepts in the protocol.
-//   - `auth.token_revoked` is emitted by `RevokeToken` when an RP calls
-//     `/oauth/revoke` per RFC 7009 to retire a specific refresh token.
-//   - Refresh tokens issued before `auth.logout` therefore remain valid
-//     until their natural expiry, an explicit `/oauth/revoke`, or
-//     reuse-detection family revoke (`auth.refresh_family_revoked`).
-//
-// Audit consumers MUST NOT treat `auth.logout` as "session **and** tokens
-// fully invalidated" — see docs/spec/005-token-lifecycle.md "Logout vs.
-// Revoke" for the contract.
+// auth.logout (session revoke via /end_session) and auth.token_revoked
+// (refresh-token revoke via /oauth/revoke) are distinct: logout does NOT
+// invalidate refresh tokens, so consumers must not treat it as full
+// invalidation. See docs/spec/005-token-lifecycle.md "Logout vs. Revoke".
 const (
 	EventAuthRefreshReuseDetected = "auth.refresh_reuse_detected"
 	EventAuthRefreshFamilyRevoked = "auth.refresh_family_revoked"

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -71,8 +71,7 @@ type Storage struct {
 	clientPolicy       ClientResolutionPolicy
 	resourcePolicy     ResourceBindingPolicy
 	// keys holds the PII at-rest crypto subkeys (ADR-002). nil until SetKeys is
-	// called at startup; while nil, encryption is inert and authgate runs
-	// unchanged. The first encrypting consumer (PR2) requires it in production.
+	// called at startup; while nil, encryption is inert. Required in production.
 	keys *crypto.Keys
 }
 

--- a/internal/storage/storage_auth_tokens.go
+++ b/internal/storage/storage_auth_tokens.go
@@ -31,9 +31,7 @@ func (s *Storage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest, 
 
 	resource := ResourceFromContext(ctx)
 	// #184: validate the channel × resource matrix on every /authorize, not
-	// only when resource is empty. Previously the validate call was gated on
-	// `resource == ""`, which let a browser client pass an MCP-bound
-	// resource through unchallenged and mint tokens with an MCP audience.
+	// only when resource is empty.
 	client, err := s.ResolveClient(ctx, req.ClientID)
 	if err == nil {
 		if err := s.resourcePolicy.ValidateAuthorizeRequest(ctx, client, resource); err != nil {
@@ -267,14 +265,10 @@ func (s *Storage) TokenRequestByRefreshToken(ctx context.Context, refreshToken s
 	return rt, nil
 }
 
-// TerminateSession implements OIDC RP-Initiated Logout 1.0 §2 by revoking
-// session rows for the user. Per RFC 7009 / OIDC RP-Initiated Logout, this
-// does NOT cascade into refresh-token revocation: the two endpoints are
-// deliberately distinct in the protocol, and RPs that need full token
-// invalidation must call `/oauth/revoke` separately. The `auth.logout`
-// audit event therefore signals "session terminated" only — see the
-// EventAuthLogout doc-block in audit.go and docs/spec/005-token-lifecycle.md
-// "Logout vs. Revoke" (#191).
+// TerminateSession revokes the user's server-side session rows only; per OIDC
+// RP-Initiated Logout 1.0 §2 vs RFC 7009 it does NOT revoke refresh tokens (RPs
+// must call /oauth/revoke). See docs/spec/005-token-lifecycle.md "Logout vs.
+// Revoke".
 func (s *Storage) TerminateSession(ctx context.Context, userID string, clientID string) error {
 	err := storeq.New(s.db).RevokeSessionsByUserID(ctx, storeq.RevokeSessionsByUserIDParams{
 		RevokedAt: sql.NullTime{Time: s.clock.Now(), Valid: true},
@@ -284,10 +278,8 @@ func (s *Storage) TerminateSession(ctx context.Context, userID string, clientID 
 		return err
 	}
 	info := clientinfo.FromContext(ctx)
-	// Codex review NIT-3 on #191: emit client_id + client_name so the
-	// auth.logout event satisfies the audit-011 invariant ("any client-
-	// context event records both"). The clientID arrives from zitadel's
-	// RP-Initiated Logout dispatch.
+	// Emit client_id + client_name so auth.logout carries client context
+	// (audit-011 invariant). clientID arrives from zitadel's logout dispatch.
 	s.AuditLog(ctx, &userID, EventAuthLogout, info.IP, info.UserAgent, map[string]any{
 		"client_id":   clientID,
 		"client_name": s.auditClientName(ctx, clientID),

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -65,7 +65,7 @@ func (s *Storage) insertUserForSignup(ctx context.Context, qtx *storeq.Queries, 
 		CreatedAt:     now,
 	}
 	// Encrypt email/name when keys are configured; otherwise keep the legacy
-	// plaintext path (ADR-002, keys-gated until the cleanup PR).
+	// plaintext path (ADR-002, keys-gated).
 	if s.keys != nil {
 		if err := s.applyUserPIIEncryption(&params, userID, input.Email, input.Name); err != nil {
 			return err
@@ -85,7 +85,7 @@ func (s *Storage) insertIdentityForSignup(ctx context.Context, qtx *storeq.Queri
 		CreatedAt: now,
 	}
 	// Encrypt the provider subject when keys are configured; otherwise keep the
-	// legacy plaintext path (ADR-002, keys-gated until the cleanup PR).
+	// legacy plaintext path (ADR-002, keys-gated).
 	if s.keys != nil {
 		cols, err := s.encryptProviderSub(userID, input.Provider, input.ProviderUserID)
 		if err != nil {


### PR DESCRIPTION
## 무엇

**주석 전용** 정리(동작 변화 0). 두 패턴만 대상:

### ① 이미 끝난 사건 히스토리 서사 (git에 있음 → 제거)
- `storage_auth_tokens.go` "Previously the validate call was gated on…" 버그 서사
- `cimd.go` "which previously bypassed the cache"
- `policy.go` "before #184 closed the gate"
- `storage_auth_tokens.go` "Codex review NIT-3 on #191" 리뷰 출처
- `storage.go` "first encrypting consumer (PR2)" 낡은 구현 히스토리
- `users.go` "until the cleanup PR" 미래 포인터

### ② 중복 설명 (정본 한 곳으로)
- `policy.go`: channel×resource 매트릭스가 두 메서드에 중복 → 타입 doc 1회, 메서드는 1줄
- logout≠revoke 계약이 `TerminateSession`+`audit.go`+spec 005 3중복 → 005 참조
- discovery auth-methods(`routes.go`)·CSP(`security_headers.go`) 근거가 문서 중복 → docs/spec/004·docs/security/002 참조

## 보존
이슈번호 + 그 주변의 **load-bearing race/RFC 근거**(cleanup_runner #182, device slow_down #188/#185, clients #190 등)는 "특별한 것"이라 유지. 서사·중복만 제거.

## 검증
주석/공백만 변경(−68줄, non-comment 제거 0 확인). `go build`/affected 테스트/`golangci-lint` 0 ✅. Codex + self 리뷰로 도출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)