### PR TITLE
docs: dedup event-type table and drop issue numbers from headings

### DIFF
--- a/docs/spec/004-mcp-login.md
+++ b/docs/spec/004-mcp-login.md
@@ -290,7 +290,7 @@ authgate의 CIMD 처리:
   4. 검증 성공 → 메모리에서 ClientModel 생성 → 플로우 진행
 ```
 
-### URL-form static client_id 금지 (#190)
+### URL-form static client_id 금지
 
 `clients.yaml`의 정적 등록 항목 중 `client_id`가 CIMD URL 형식 (HTTPS + path 포함)이면
 설정 로드 시점에 거부한다. `ResolveClient`는 정적 in-memory 맵을 CIMD fetcher보다 먼저

--- a/docs/spec/005-token-lifecycle.md
+++ b/docs/spec/005-token-lifecycle.md
@@ -232,7 +232,7 @@ sequenceDiagram
 **RFC 7009 준수**: 토큰이 존재하지 않거나 이미 폐기된 경우에도 200 OK 반환.
 토큰 존재 여부를 외부에 노출하지 않는다.
 
-## Logout vs. Revoke (#191)
+## Logout vs. Revoke
 
 OIDC RP-Initiated Logout 1.0 §2의 `/end_session` 엔드포인트와 RFC 7009의
 `/oauth/revoke` 엔드포인트는 **별개의 개념**이다. authgate는 이 두 경로를 분리해서 처리한다.

--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -16,7 +16,7 @@ erDiagram
     users ||--o{ audit_log : "1:N (이벤트 기록)"
     users {
         uuid id PK "DEFAULT uuid_generate_v4()"
-        text email "nullable, 평문 (백필 후 cleanup PR에서 제거)"
+        text email "nullable, 평문 (백필 후 제거 예정)"
         bytea email_ciphertext "nullable, AEAD"
         bytea email_nonce "nullable"
         text email_enc_key_id "FK crypto_key_epochs"
@@ -54,7 +54,7 @@ erDiagram
         uuid id PK "DEFAULT uuid_generate_v4()"
         uuid user_id FK "NOT NULL, CASCADE"
         text provider "NOT NULL, OIDC issuer에서 파생 (예: google, mock 등)"
-        text provider_user_id "nullable, 평문 (백필 후 cleanup PR에서 제거)"
+        text provider_user_id "nullable, 평문 (백필 후 제거 예정)"
         text provider_sub_hash "nullable, lookup HMAC, UNIQUE(provider, provider_sub_hash)"
         text provider_sub_hash_key_id "FK crypto_key_epochs"
         int provider_sub_hash_version "nullable"
@@ -177,23 +177,7 @@ erDiagram
 
 #### event_type 목록
 
-| event_type | 설명 | 발생 위치 |
-|------------|------|----------|
-| `auth.signup` | 신규 가입 완료 | 브라우저 로그인 (신규 유저) |
-| `auth.login` | 로그인 성공 | 브라우저/Device/MCP 로그인 |
-| `auth.channel_mismatch` | auth_request 채널 불일치 차단 | 브라우저/MCP 로그인 |
-| `auth.inactive_user` | 비활성 유저 로그인 시도 차단 | 브라우저/Device/MCP 로그인 |
-| `auth.device_code_issued` | 디바이스 코드 발급 | Device authorize 엔드포인트 |
-| `auth.device_approved` | Device 코드 승인 | Device 승인 페이지 |
-| `auth.device_denied` | Device 코드 거부 | Device 승인 페이지 |
-| `auth.deletion_requested` | 계정 삭제 요청 | 계정 삭제 API |
-| `auth.deletion_cancelled` | 삭제 예정 계정 복구 (재로그인) | 브라우저 로그인 |
-| `auth.deletion_completed` | PII 스크러빙 완료 | cleanup 배치 |
-| `auth.token_refreshed` | refresh token rotation 성공 | 토큰 갱신 |
-| `auth.logout` | RP-Initiated Logout | OIDC end_session |
-| `auth.token_revoked` | refresh token 폐기 | RFC 7009 revoke |
-| `auth.refresh_reuse_detected` | refresh token 재사용 감지 | 토큰 갱신 |
-| `auth.refresh_family_revoked` | refresh token 패밀리 전체 폐기 | 토큰 갱신 (재사용 시) |
+이벤트별 의미와 metadata는 아래 **감사 이벤트 (audit_log.event_type)** 섹션을 정본으로 둔다. 컴플라이언스 매핑은 [docs/security/001-audit-evidence-matrix.md](../security/001-audit-evidence-matrix.md).
 
 ## 인덱스
 

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -354,7 +354,7 @@ Go runtime/process Prometheus metrics를 노출한다. 운영에서는
 | runtime/process | `METRICS_ADDR` opt-in 후 내부 Prometheus scrape | goroutine, heap, GC, process resource 급증 |
 | audit 쓰기 실패 | `slog.Error` 로그 (`audit log: marshal metadata`, `audit log: insert`) | 침해 탐지 인프라 silent broken (#208) |
 
-### audit_log 쓰기 실패 모니터링 (#208)
+### audit_log 쓰기 실패 모니터링
 
 `Storage.AuditLog`는 best-effort write이므로 marshal/insert 실패가 비즈니스 트랜잭션을 차단하지 않는다. 그러나 감사 로그가 silent하게 누락되면 침해 탐지 능력 자체가 무력화되므로 실패는 구조화 로그로 남긴다.
 


### PR DESCRIPTION
## 무엇

문서에서 **중복 + 히스토리 서사**만 정리 (이전 코드-주석 PR과 짝).

### 중복
- `007-data-model.md`: 감사 event 표가 **2개**(단순 목록 vs metadata 표)로 중복 → metadata 표를 정본으로, 단순 표는 그 섹션 + `docs/security/001`(컴플라이언스 정본) 포인터로 대체.

### 히스토리/전환 포인터
- 섹션 제목의 `(#NNN)` 제거: `005 Logout vs. Revoke`, `009 audit 쓰기 실패 모니터링`, `004 URL-form static client_id` — 출처는 git에 있음.
- `007` 평문 컬럼: `백필 후 cleanup PR에서 제거` → `백필 후 제거 예정` (진행 중 PR 포인터 제거).

## 범위
표 셀의 traceability 이슈번호(#156/#158 등)와 보안/RFC 근거는 보존 — 제목·중복만 정리. 문서만 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)