### PR TITLE
refactor(pii): drop plaintext PII columns + keys-OFF fallback (migration 014)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,11 @@ services:
       OIDC_INTERNAL_URL: http://mock-idp:8082
       OIDC_CLIENT_ID: authgate
       OIDC_CLIENT_SECRET: fake-secret
+      # PII at-rest 암호화는 필수다 (ADR-002, 평문 컬럼 제거 후). 아래는 로컬 dev 전용 더미 키.
+      PII_ENC_ROOT_KEY_ID: "enc-dev-1"
+      PII_ENC_ROOT_SECRET: "ISA5aviCx54GVBxSHvU8nqcYwC5JKOj5OFUj7uwzuUA="
+      PII_LOOKUP_ROOT_KEY_ID: "lookup-dev-1"
+      PII_LOOKUP_ROOT_SECRET: "/lXaqOM5dvoYzptzzEJ5oF3n+OyEQ/etgXmCDb5bJLI="
     depends_on:
       db:
         condition: service_healthy

--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -16,7 +16,6 @@ erDiagram
     users ||--o{ audit_log : "1:N (이벤트 기록)"
     users {
         uuid id PK "DEFAULT uuid_generate_v4()"
-        text email "nullable, 평문 (백필 후 제거 예정)"
         bytea email_ciphertext "nullable, AEAD"
         bytea email_nonce "nullable"
         text email_enc_key_id "FK crypto_key_epochs"
@@ -25,7 +24,6 @@ erDiagram
         text email_hash_key_id "FK crypto_key_epochs"
         int email_hash_version "nullable"
         boolean email_verified "NOT NULL, DEFAULT false"
-        text name "nullable, 평문 (제거 예정)"
         bytea name_ciphertext "nullable, AEAD"
         bytea name_nonce "nullable"
         text name_enc_key_id "FK crypto_key_epochs"
@@ -54,7 +52,6 @@ erDiagram
         uuid id PK "DEFAULT uuid_generate_v4()"
         uuid user_id FK "NOT NULL, CASCADE"
         text provider "NOT NULL, OIDC issuer에서 파생 (예: google, mock 등)"
-        text provider_user_id "nullable, 평문 (백필 후 제거 예정)"
         text provider_sub_hash "nullable, lookup HMAC, UNIQUE(provider, provider_sub_hash)"
         text provider_sub_hash_key_id "FK crypto_key_epochs"
         int provider_sub_hash_version "nullable"
@@ -210,7 +207,6 @@ CHECK (state IN ('pending', 'approved', 'denied', 'consumed'))
 
 -- user_identities
 UNIQUE (provider, provider_sub_hash)  -- 로그인 매칭 (user_identities_provider_sub_hash_key). NULL 다중 허용(Postgres UNIQUE)
-UNIQUE (provider, provider_user_id)   -- 레거시 (평문 provider_user_id 매칭)
 FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 
 -- sessions
@@ -261,8 +257,8 @@ MCP
 
 | 규칙 | 적용 |
 |------|------|
-| provider sub은 lookup HMAC + AEAD ciphertext로 저장 | `provider_sub_hash`(매칭) + `provider_sub_ciphertext`(회전 복구), 평문 `provider_user_id`는 백필 후 제거 |
-| email/name은 AEAD ciphertext로 저장, email은 lookup HMAC도 | `email_ciphertext`/`name_ciphertext` + `email_hash`(UNIQUE/정규화 lowercase+NFC), 평문 컬럼은 백필 후 제거. 탈퇴 시 ciphertext/hash redaction |
+| provider sub은 lookup HMAC + AEAD ciphertext로 저장 | `provider_sub_hash`(매칭) + `provider_sub_ciphertext`(회전 복구). 평문 `provider_user_id` 컬럼은 제거됨(migration 014) |
+| email/name은 AEAD ciphertext로 저장, email은 lookup HMAC도 | `email_ciphertext`/`name_ciphertext` + `email_hash`(UNIQUE/정규화 lowercase+NFC). 평문 `email`/`name` 컬럼은 제거됨(migration 014). 탈퇴 시 ciphertext/hash redaction |
 | 단명 코드(device_code/user_code/authz code)는 lookup HMAC로 저장 | 기존 컬럼에 in-place 해시(키 설정 시). 짧은 수명이라 drain, 반환 모델은 평문 입력값 |
 | refresh_token은 SHA-256 해시로 저장 | `token_hash` 컬럼 |
 | 세션 쿠키(bearer)는 해시로 저장 | `sessions.token_hash` (`id`는 내부 PK). 키 설정 시 lookup/session HMAC, 아니면 SHA-256 |

--- a/docs/spec/009-operations.md
+++ b/docs/spec/009-operations.md
@@ -73,7 +73,7 @@ authgate를 처음 배포할 때 필요한 것:
 | `OIDC_HTTP_TIMEOUT_SEC` | X | `10` | Upstream OIDC HTTP 호출 timeout(초) |
 | `OIDC_CLIENT_ID` | X | `authgate` | OIDC Client ID |
 | `OIDC_CLIENT_SECRET` | X | — | OIDC Client Secret (`DEV_MODE=false`에서 필수) |
-| `PII_ENC_ROOT_KEY_ID` | △ | — | PII 암호화(ENC) root 식별자 (ADR-002). **`DEV_MODE=false`에서 4개 모두 필수.** 부팅 시 백필이 기존 평문을 암호화하고 평문 컬럼을 비운다 |
+| `PII_ENC_ROOT_KEY_ID` | △ | — | PII 암호화(ENC) root 식별자 (ADR-002). **PII at-rest 암호화는 필수** — 키 없이는 가입/로그인 불가(평문 컬럼 제거됨, migration 014). `DEV_MODE=false`는 4개 미설정 시 시작 거부, dev는 docker-compose가 더미 키 주입 |
 | `PII_ENC_ROOT_SECRET` | △ | — | ENC root secret (base64, ≥32 bytes). 로그/감사에 노출 금지 |
 | `PII_LOOKUP_ROOT_KEY_ID` | △ | — | lookup HMAC(LOOKUP) root 식별자 |
 | `PII_LOOKUP_ROOT_SECRET` | △ | — | LOOKUP root secret (base64, ≥32 bytes). 로그/감사에 노출 금지 |

--- a/docs/spec/010-upgrade-compatibility.md
+++ b/docs/spec/010-upgrade-compatibility.md
@@ -20,7 +20,8 @@ PII 평문(email / name / provider_user_id)을 암호화 컬럼으로 옮기는 
    · backfill 완료 확인
             ↓  (count 둘 다 0 확인 후에만)
 [2단계] 평문 제거(cleanup) 릴리즈                 — ⚠️ 하위 호환 깨짐
-   · 평문 컬럼 + 구 평문 UNIQUE 제약을 DROP (backfill 코드 없음)
+   · 평문 컬럼 + 구 평문 UNIQUE 제약을 DROP (migration 014). backfill 코드 제거,
+     PII 키 필수화(keys-OFF fallback 제거)
 ```
 
 ### 1단계: PII 암호화 (backfill)
@@ -43,7 +44,9 @@ PII 평문(email / name / provider_user_id)을 암호화 컬럼으로 옮기는 
 ### 2단계: 평문 제거 (cleanup) — 하위 호환 깨짐
 
 - 평문 컬럼(`users.email` / `users.name` / `user_identities.provider_user_id`)과 구 평문
-  UNIQUE 제약을 DROP한다.
+  UNIQUE 제약을 DROP한다(**migration 014**). backfill 코드와 keys-OFF 평문 fallback이 함께
+  제거되어 **PII 키가 항상 필수**가 된다. 계정 삭제 redaction은 평문 tombstone 대신 암호/해시
+  컬럼을 `NULL`로 비우는 방식으로 바뀐다.
 - **하위 호환이 깨지는 지점:**
   - 평문 컬럼을 참조하던 **이전 버전의 쿼리는 `column does not exist`로 실패**한다.
     롤링 배포로 구/신 바이너리가 공존하면 구버전이 깨진다.

--- a/internal/app/crypto.go
+++ b/internal/app/crypto.go
@@ -53,23 +53,4 @@ func mustSetupCrypto(cfg *config.Config, store *storage.Storage) {
 		"enc_key_id", cfg.EncRootKeyID,
 		"lookup_key_id", cfg.LookupRootKeyID,
 	)
-
-	// Backfill legacy plaintext provider subjects into encrypted columns. With
-	// keys configured, lookups go through provider_sub_hash, so any row not yet
-	// backfilled would be unfindable — backfill must complete before serving.
-	n, err := store.BackfillProviderSub(ctx)
-	if err != nil {
-		log.Fatalf("crypto: provider_sub backfill: %v", err)
-	}
-	if n > 0 {
-		slog.Info("provider_sub backfill complete", "rows", n)
-	}
-
-	m, err := store.BackfillUserPII(ctx)
-	if err != nil {
-		log.Fatalf("crypto: user PII backfill: %v", err)
-	}
-	if m > 0 {
-		slog.Info("user PII backfill complete", "rows", m)
-	}
 }

--- a/internal/db/queries/cleanup.sql
+++ b/internal/db/queries/cleanup.sql
@@ -42,12 +42,9 @@ DELETE FROM refresh_tokens
 WHERE user_id = $1;
 
 -- name: MarkUserDeletedByID :execrows
--- PII redaction on deletion (ADR-002): the plaintext tombstone replaces email,
--- and every encrypted/hashed email/name column is cleared so no recoverable PII
--- remains for the deleted user.
+-- PII redaction on deletion (ADR-002): every encrypted/hashed email/name column
+-- is cleared so no recoverable PII remains for the deleted user.
 UPDATE users SET
-  email = 'deleted-' || id::text || '@deleted.invalid',
-  name = NULL,
   email_ciphertext = NULL, email_nonce = NULL, email_enc_key_id = NULL, email_enc_version = NULL,
   email_hash = NULL, email_hash_key_id = NULL, email_hash_version = NULL,
   name_ciphertext = NULL, name_nonce = NULL, name_enc_key_id = NULL, name_enc_version = NULL,

--- a/internal/db/queries/sessions.sql
+++ b/internal/db/queries/sessions.sql
@@ -3,7 +3,7 @@ INSERT INTO sessions (id, user_id, token_hash, expires_at, created_at)
 VALUES ($1, $2, $3, $4, $5);
 
 -- name: GetValidSessionUser :one
-SELECT u.id, u.email, u.email_verified, u.name, u.status,
+SELECT u.id, u.email_verified, u.status,
        u.email_ciphertext, u.email_nonce, u.email_enc_key_id, u.email_enc_version,
        u.name_ciphertext, u.name_nonce, u.name_enc_key_id, u.name_enc_version,
        u.created_at, u.updated_at

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -1,31 +1,22 @@
 -- name: InsertUser :exec
 INSERT INTO users (
-    id, email, email_verified, name, status,
+    id, email_verified, status,
     email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
     email_hash, email_hash_key_id, email_hash_version,
     name_ciphertext, name_nonce, name_enc_key_id, name_enc_version,
     created_at, updated_at
-) VALUES ($1, $2, $3, $4, 'active', $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $16);
+) VALUES ($1, $2, 'active', $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $14);
 
 -- name: InsertUserIdentity :exec
 INSERT INTO user_identities (
-    id, user_id, provider, provider_user_id,
+    id, user_id, provider,
     provider_sub_hash, provider_sub_hash_key_id, provider_sub_hash_version,
     provider_sub_ciphertext, provider_sub_nonce, provider_sub_enc_key_id, provider_sub_enc_version,
     created_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);
-
--- name: GetUserByProviderIdentity :one
-SELECT u.id, u.email, u.email_verified, u.name, u.status,
-       u.email_ciphertext, u.email_nonce, u.email_enc_key_id, u.email_enc_version,
-       u.name_ciphertext, u.name_nonce, u.name_enc_key_id, u.name_enc_version,
-       u.created_at, u.updated_at
-FROM users u
-JOIN user_identities ui ON u.id = ui.user_id
-WHERE ui.provider = $1 AND ui.provider_user_id = $2;
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);
 
 -- name: GetUserByProviderSubHash :one
-SELECT u.id, u.email, u.email_verified, u.name, u.status,
+SELECT u.id, u.email_verified, u.status,
        u.email_ciphertext, u.email_nonce, u.email_enc_key_id, u.email_enc_version,
        u.name_ciphertext, u.name_nonce, u.name_enc_key_id, u.name_enc_version,
        u.created_at, u.updated_at
@@ -33,32 +24,8 @@ FROM users u
 JOIN user_identities ui ON u.id = ui.user_id
 WHERE ui.provider = $1 AND ui.provider_sub_hash = $2;
 
--- name: ListProviderSubBackfill :many
-SELECT id, user_id, provider, provider_user_id
-FROM user_identities
-WHERE provider_sub_hash IS NULL AND provider_user_id IS NOT NULL
-ORDER BY id
-LIMIT $1;
-
--- name: CountProviderSubUnbackfilled :one
-SELECT count(*)
-FROM user_identities
-WHERE provider_sub_hash IS NULL AND provider_user_id IS NOT NULL;
-
--- name: BackfillProviderSub :exec
-UPDATE user_identities SET
-    provider_sub_hash         = $2,
-    provider_sub_hash_key_id  = $3,
-    provider_sub_hash_version = $4,
-    provider_sub_ciphertext   = $5,
-    provider_sub_nonce        = $6,
-    provider_sub_enc_key_id   = $7,
-    provider_sub_enc_version  = $8,
-    provider_user_id          = NULL
-WHERE id = $1;
-
 -- name: GetUserByID :one
-SELECT id, email, email_verified, name, status,
+SELECT id, email_verified, status,
        email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
        name_ciphertext, name_nonce, name_enc_key_id, name_enc_version,
        created_at, updated_at
@@ -66,46 +33,17 @@ FROM users
 WHERE id = $1;
 
 -- name: GetUserForTxByID :one
-SELECT id, email, email_verified, name, status,
+SELECT id, email_verified, status,
        email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
        name_ciphertext, name_nonce, name_enc_key_id, name_enc_version
 FROM users
 WHERE id = $1;
 
 -- name: GetUserInfoFieldsByID :one
-SELECT id, email, email_verified, name,
+SELECT id, email_verified,
        email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
        name_ciphertext, name_nonce, name_enc_key_id, name_enc_version
 FROM users
-WHERE id = $1;
-
--- name: ListUsersBackfill :many
-SELECT id, email, name
-FROM users
-WHERE email_hash IS NULL AND email IS NOT NULL
-ORDER BY id
-LIMIT $1;
-
--- name: CountUsersUnbackfilled :one
-SELECT count(*)
-FROM users
-WHERE email_hash IS NULL AND email IS NOT NULL;
-
--- name: BackfillUserPII :exec
-UPDATE users SET
-    email_ciphertext   = $2,
-    email_nonce        = $3,
-    email_enc_key_id   = $4,
-    email_enc_version  = $5,
-    email_hash         = $6,
-    email_hash_key_id  = $7,
-    email_hash_version = $8,
-    name_ciphertext    = $9,
-    name_nonce         = $10,
-    name_enc_key_id    = $11,
-    name_enc_version   = $12,
-    email              = NULL,
-    name               = NULL
 WHERE id = $1;
 
 -- name: CompleteAuthRequestByID :execrows

--- a/internal/db/storeq/cleanup.sql.go
+++ b/internal/db/storeq/cleanup.sql.go
@@ -175,8 +175,6 @@ func (q *Queries) ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff s
 
 const markUserDeletedByID = `-- name: MarkUserDeletedByID :execrows
 UPDATE users SET
-  email = 'deleted-' || id::text || '@deleted.invalid',
-  name = NULL,
   email_ciphertext = NULL, email_nonce = NULL, email_enc_key_id = NULL, email_enc_version = NULL,
   email_hash = NULL, email_hash_key_id = NULL, email_hash_version = NULL,
   name_ciphertext = NULL, name_nonce = NULL, name_enc_key_id = NULL, name_enc_version = NULL,
@@ -192,9 +190,8 @@ type MarkUserDeletedByIDParams struct {
 	UserID    string
 }
 
-// PII redaction on deletion (ADR-002): the plaintext tombstone replaces email,
-// and every encrypted/hashed email/name column is cleared so no recoverable PII
-// remains for the deleted user.
+// PII redaction on deletion (ADR-002): every encrypted/hashed email/name column
+// is cleared so no recoverable PII remains for the deleted user.
 func (q *Queries) MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedByIDParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, markUserDeletedByID, arg.DeletedAt, arg.UserID)
 	if err != nil {

--- a/internal/db/storeq/models.go
+++ b/internal/db/storeq/models.go
@@ -98,9 +98,7 @@ type Session struct {
 
 type User struct {
 	ID                  string
-	Email               sql.NullString
 	EmailVerified       bool
-	Name                sql.NullString
 	Status              string
 	DeletionRequestedAt sql.NullTime
 	DeletionScheduledAt sql.NullTime
@@ -124,7 +122,6 @@ type UserIdentity struct {
 	ID                     string
 	UserID                 string
 	Provider               string
-	ProviderUserID         sql.NullString
 	CreatedAt              time.Time
 	ProviderSubHash        sql.NullString
 	ProviderSubHashKeyID   sql.NullString

--- a/internal/db/storeq/querier.go
+++ b/internal/db/storeq/querier.go
@@ -13,11 +13,7 @@ import (
 type Querier interface {
 	AnonymizeAuditLogBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	ApproveDeviceCodeByUserCode(ctx context.Context, arg ApproveDeviceCodeByUserCodeParams) (int64, error)
-	BackfillProviderSub(ctx context.Context, arg BackfillProviderSubParams) error
-	BackfillUserPII(ctx context.Context, arg BackfillUserPIIParams) error
 	CompleteAuthRequestByID(ctx context.Context, arg CompleteAuthRequestByIDParams) (int64, error)
-	CountProviderSubUnbackfilled(ctx context.Context) (int64, error)
-	CountUsersUnbackfilled(ctx context.Context) (int64, error)
 	DeleteAuthRequestByID(ctx context.Context, id string) error
 	DeleteExpiredAuthRequestsBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteExpiredDeviceCodesBefore(ctx context.Context, cutoff time.Time) (int64, error)
@@ -38,7 +34,6 @@ type Querier interface {
 	GetRefreshTokenForUpdateByHash(ctx context.Context, tokenHash string) (GetRefreshTokenForUpdateByHashRow, error)
 	GetRefreshTokenInfoByHashAndClientID(ctx context.Context, arg GetRefreshTokenInfoByHashAndClientIDParams) (GetRefreshTokenInfoByHashAndClientIDRow, error)
 	GetUserByID(ctx context.Context, id string) (GetUserByIDRow, error)
-	GetUserByProviderIdentity(ctx context.Context, arg GetUserByProviderIdentityParams) (GetUserByProviderIdentityRow, error)
 	GetUserByProviderSubHash(ctx context.Context, arg GetUserByProviderSubHashParams) (GetUserByProviderSubHashRow, error)
 	GetUserForTxByID(ctx context.Context, id string) (GetUserForTxByIDRow, error)
 	GetUserInfoFieldsByID(ctx context.Context, id string) (GetUserInfoFieldsByIDRow, error)
@@ -56,12 +51,9 @@ type Querier interface {
 	InsertUserIdentity(ctx context.Context, arg InsertUserIdentityParams) error
 	IsRefreshFamilyRevoked(ctx context.Context, familyID string) (bool, error)
 	ListPendingDeletionUserIDsBefore(ctx context.Context, cutoff sql.NullTime) ([]string, error)
-	ListProviderSubBackfill(ctx context.Context, limit int32) ([]ListProviderSubBackfillRow, error)
-	ListUsersBackfill(ctx context.Context, limit int32) ([]ListUsersBackfillRow, error)
 	MarkRefreshTokenUsedAndRevokedByID(ctx context.Context, arg MarkRefreshTokenUsedAndRevokedByIDParams) error
-	// PII redaction on deletion (ADR-002): the plaintext tombstone replaces email,
-	// and every encrypted/hashed email/name column is cleared so no recoverable PII
-	// remains for the deleted user.
+	// PII redaction on deletion (ADR-002): every encrypted/hashed email/name column
+	// is cleared so no recoverable PII remains for the deleted user.
 	MarkUserDeletedByID(ctx context.Context, arg MarkUserDeletedByIDParams) (int64, error)
 	MarkUserPendingDeletionByID(ctx context.Context, arg MarkUserPendingDeletionByIDParams) (int64, error)
 	RecoverPendingDeletionUserByID(ctx context.Context, arg RecoverPendingDeletionUserByIDParams) error

--- a/internal/db/storeq/sessions.sql.go
+++ b/internal/db/storeq/sessions.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getValidSessionUser = `-- name: GetValidSessionUser :one
-SELECT u.id, u.email, u.email_verified, u.name, u.status,
+SELECT u.id, u.email_verified, u.status,
        u.email_ciphertext, u.email_nonce, u.email_enc_key_id, u.email_enc_version,
        u.name_ciphertext, u.name_nonce, u.name_enc_key_id, u.name_enc_version,
        u.created_at, u.updated_at
@@ -30,9 +30,7 @@ type GetValidSessionUserParams struct {
 
 type GetValidSessionUserRow struct {
 	ID              string
-	Email           sql.NullString
 	EmailVerified   bool
-	Name            sql.NullString
 	Status          string
 	EmailCiphertext []byte
 	EmailNonce      []byte
@@ -51,9 +49,7 @@ func (q *Queries) GetValidSessionUser(ctx context.Context, arg GetValidSessionUs
 	var i GetValidSessionUserRow
 	err := row.Scan(
 		&i.ID,
-		&i.Email,
 		&i.EmailVerified,
-		&i.Name,
 		&i.Status,
 		&i.EmailCiphertext,
 		&i.EmailNonce,

--- a/internal/db/storeq/users.sql.go
+++ b/internal/db/storeq/users.sql.go
@@ -11,95 +11,6 @@ import (
 	"time"
 )
 
-const backfillProviderSub = `-- name: BackfillProviderSub :exec
-UPDATE user_identities SET
-    provider_sub_hash         = $2,
-    provider_sub_hash_key_id  = $3,
-    provider_sub_hash_version = $4,
-    provider_sub_ciphertext   = $5,
-    provider_sub_nonce        = $6,
-    provider_sub_enc_key_id   = $7,
-    provider_sub_enc_version  = $8,
-    provider_user_id          = NULL
-WHERE id = $1
-`
-
-type BackfillProviderSubParams struct {
-	ID                     string
-	ProviderSubHash        sql.NullString
-	ProviderSubHashKeyID   sql.NullString
-	ProviderSubHashVersion sql.NullInt32
-	ProviderSubCiphertext  []byte
-	ProviderSubNonce       []byte
-	ProviderSubEncKeyID    sql.NullString
-	ProviderSubEncVersion  sql.NullInt32
-}
-
-func (q *Queries) BackfillProviderSub(ctx context.Context, arg BackfillProviderSubParams) error {
-	_, err := q.db.ExecContext(ctx, backfillProviderSub,
-		arg.ID,
-		arg.ProviderSubHash,
-		arg.ProviderSubHashKeyID,
-		arg.ProviderSubHashVersion,
-		arg.ProviderSubCiphertext,
-		arg.ProviderSubNonce,
-		arg.ProviderSubEncKeyID,
-		arg.ProviderSubEncVersion,
-	)
-	return err
-}
-
-const backfillUserPII = `-- name: BackfillUserPII :exec
-UPDATE users SET
-    email_ciphertext   = $2,
-    email_nonce        = $3,
-    email_enc_key_id   = $4,
-    email_enc_version  = $5,
-    email_hash         = $6,
-    email_hash_key_id  = $7,
-    email_hash_version = $8,
-    name_ciphertext    = $9,
-    name_nonce         = $10,
-    name_enc_key_id    = $11,
-    name_enc_version   = $12,
-    email              = NULL,
-    name               = NULL
-WHERE id = $1
-`
-
-type BackfillUserPIIParams struct {
-	ID               string
-	EmailCiphertext  []byte
-	EmailNonce       []byte
-	EmailEncKeyID    sql.NullString
-	EmailEncVersion  sql.NullInt32
-	EmailHash        sql.NullString
-	EmailHashKeyID   sql.NullString
-	EmailHashVersion sql.NullInt32
-	NameCiphertext   []byte
-	NameNonce        []byte
-	NameEncKeyID     sql.NullString
-	NameEncVersion   sql.NullInt32
-}
-
-func (q *Queries) BackfillUserPII(ctx context.Context, arg BackfillUserPIIParams) error {
-	_, err := q.db.ExecContext(ctx, backfillUserPII,
-		arg.ID,
-		arg.EmailCiphertext,
-		arg.EmailNonce,
-		arg.EmailEncKeyID,
-		arg.EmailEncVersion,
-		arg.EmailHash,
-		arg.EmailHashKeyID,
-		arg.EmailHashVersion,
-		arg.NameCiphertext,
-		arg.NameNonce,
-		arg.NameEncKeyID,
-		arg.NameEncVersion,
-	)
-	return err
-}
-
 const completeAuthRequestByID = `-- name: CompleteAuthRequestByID :execrows
 UPDATE auth_requests
 SET subject = $1, auth_time = $2, done = true
@@ -120,34 +31,8 @@ func (q *Queries) CompleteAuthRequestByID(ctx context.Context, arg CompleteAuthR
 	return result.RowsAffected()
 }
 
-const countProviderSubUnbackfilled = `-- name: CountProviderSubUnbackfilled :one
-SELECT count(*)
-FROM user_identities
-WHERE provider_sub_hash IS NULL AND provider_user_id IS NOT NULL
-`
-
-func (q *Queries) CountProviderSubUnbackfilled(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countProviderSubUnbackfilled)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
-}
-
-const countUsersUnbackfilled = `-- name: CountUsersUnbackfilled :one
-SELECT count(*)
-FROM users
-WHERE email_hash IS NULL AND email IS NOT NULL
-`
-
-func (q *Queries) CountUsersUnbackfilled(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countUsersUnbackfilled)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
-}
-
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, email, email_verified, name, status,
+SELECT id, email_verified, status,
        email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
        name_ciphertext, name_nonce, name_enc_key_id, name_enc_version,
        created_at, updated_at
@@ -157,9 +42,7 @@ WHERE id = $1
 
 type GetUserByIDRow struct {
 	ID              string
-	Email           sql.NullString
 	EmailVerified   bool
-	Name            sql.NullString
 	Status          string
 	EmailCiphertext []byte
 	EmailNonce      []byte
@@ -178,65 +61,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id string) (GetUserByIDRow, e
 	var i GetUserByIDRow
 	err := row.Scan(
 		&i.ID,
-		&i.Email,
 		&i.EmailVerified,
-		&i.Name,
-		&i.Status,
-		&i.EmailCiphertext,
-		&i.EmailNonce,
-		&i.EmailEncKeyID,
-		&i.EmailEncVersion,
-		&i.NameCiphertext,
-		&i.NameNonce,
-		&i.NameEncKeyID,
-		&i.NameEncVersion,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
-}
-
-const getUserByProviderIdentity = `-- name: GetUserByProviderIdentity :one
-SELECT u.id, u.email, u.email_verified, u.name, u.status,
-       u.email_ciphertext, u.email_nonce, u.email_enc_key_id, u.email_enc_version,
-       u.name_ciphertext, u.name_nonce, u.name_enc_key_id, u.name_enc_version,
-       u.created_at, u.updated_at
-FROM users u
-JOIN user_identities ui ON u.id = ui.user_id
-WHERE ui.provider = $1 AND ui.provider_user_id = $2
-`
-
-type GetUserByProviderIdentityParams struct {
-	Provider       string
-	ProviderUserID sql.NullString
-}
-
-type GetUserByProviderIdentityRow struct {
-	ID              string
-	Email           sql.NullString
-	EmailVerified   bool
-	Name            sql.NullString
-	Status          string
-	EmailCiphertext []byte
-	EmailNonce      []byte
-	EmailEncKeyID   sql.NullString
-	EmailEncVersion sql.NullInt32
-	NameCiphertext  []byte
-	NameNonce       []byte
-	NameEncKeyID    sql.NullString
-	NameEncVersion  sql.NullInt32
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
-}
-
-func (q *Queries) GetUserByProviderIdentity(ctx context.Context, arg GetUserByProviderIdentityParams) (GetUserByProviderIdentityRow, error) {
-	row := q.db.QueryRowContext(ctx, getUserByProviderIdentity, arg.Provider, arg.ProviderUserID)
-	var i GetUserByProviderIdentityRow
-	err := row.Scan(
-		&i.ID,
-		&i.Email,
-		&i.EmailVerified,
-		&i.Name,
 		&i.Status,
 		&i.EmailCiphertext,
 		&i.EmailNonce,
@@ -253,7 +78,7 @@ func (q *Queries) GetUserByProviderIdentity(ctx context.Context, arg GetUserByPr
 }
 
 const getUserByProviderSubHash = `-- name: GetUserByProviderSubHash :one
-SELECT u.id, u.email, u.email_verified, u.name, u.status,
+SELECT u.id, u.email_verified, u.status,
        u.email_ciphertext, u.email_nonce, u.email_enc_key_id, u.email_enc_version,
        u.name_ciphertext, u.name_nonce, u.name_enc_key_id, u.name_enc_version,
        u.created_at, u.updated_at
@@ -269,9 +94,7 @@ type GetUserByProviderSubHashParams struct {
 
 type GetUserByProviderSubHashRow struct {
 	ID              string
-	Email           sql.NullString
 	EmailVerified   bool
-	Name            sql.NullString
 	Status          string
 	EmailCiphertext []byte
 	EmailNonce      []byte
@@ -290,9 +113,7 @@ func (q *Queries) GetUserByProviderSubHash(ctx context.Context, arg GetUserByPro
 	var i GetUserByProviderSubHashRow
 	err := row.Scan(
 		&i.ID,
-		&i.Email,
 		&i.EmailVerified,
-		&i.Name,
 		&i.Status,
 		&i.EmailCiphertext,
 		&i.EmailNonce,
@@ -309,7 +130,7 @@ func (q *Queries) GetUserByProviderSubHash(ctx context.Context, arg GetUserByPro
 }
 
 const getUserForTxByID = `-- name: GetUserForTxByID :one
-SELECT id, email, email_verified, name, status,
+SELECT id, email_verified, status,
        email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
        name_ciphertext, name_nonce, name_enc_key_id, name_enc_version
 FROM users
@@ -318,9 +139,7 @@ WHERE id = $1
 
 type GetUserForTxByIDRow struct {
 	ID              string
-	Email           sql.NullString
 	EmailVerified   bool
-	Name            sql.NullString
 	Status          string
 	EmailCiphertext []byte
 	EmailNonce      []byte
@@ -337,9 +156,7 @@ func (q *Queries) GetUserForTxByID(ctx context.Context, id string) (GetUserForTx
 	var i GetUserForTxByIDRow
 	err := row.Scan(
 		&i.ID,
-		&i.Email,
 		&i.EmailVerified,
-		&i.Name,
 		&i.Status,
 		&i.EmailCiphertext,
 		&i.EmailNonce,
@@ -354,7 +171,7 @@ func (q *Queries) GetUserForTxByID(ctx context.Context, id string) (GetUserForTx
 }
 
 const getUserInfoFieldsByID = `-- name: GetUserInfoFieldsByID :one
-SELECT id, email, email_verified, name,
+SELECT id, email_verified,
        email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
        name_ciphertext, name_nonce, name_enc_key_id, name_enc_version
 FROM users
@@ -363,9 +180,7 @@ WHERE id = $1
 
 type GetUserInfoFieldsByIDRow struct {
 	ID              string
-	Email           sql.NullString
 	EmailVerified   bool
-	Name            sql.NullString
 	EmailCiphertext []byte
 	EmailNonce      []byte
 	EmailEncKeyID   sql.NullString
@@ -381,9 +196,7 @@ func (q *Queries) GetUserInfoFieldsByID(ctx context.Context, id string) (GetUser
 	var i GetUserInfoFieldsByIDRow
 	err := row.Scan(
 		&i.ID,
-		&i.Email,
 		&i.EmailVerified,
-		&i.Name,
 		&i.EmailCiphertext,
 		&i.EmailNonce,
 		&i.EmailEncKeyID,
@@ -490,19 +303,17 @@ func (q *Queries) InsertTestAuthRequestWithResource(ctx context.Context, arg Ins
 
 const insertUser = `-- name: InsertUser :exec
 INSERT INTO users (
-    id, email, email_verified, name, status,
+    id, email_verified, status,
     email_ciphertext, email_nonce, email_enc_key_id, email_enc_version,
     email_hash, email_hash_key_id, email_hash_version,
     name_ciphertext, name_nonce, name_enc_key_id, name_enc_version,
     created_at, updated_at
-) VALUES ($1, $2, $3, $4, 'active', $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $16)
+) VALUES ($1, $2, 'active', $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $14)
 `
 
 type InsertUserParams struct {
 	ID               string
-	Email            sql.NullString
 	EmailVerified    bool
-	Name             sql.NullString
 	EmailCiphertext  []byte
 	EmailNonce       []byte
 	EmailEncKeyID    sql.NullString
@@ -520,9 +331,7 @@ type InsertUserParams struct {
 func (q *Queries) InsertUser(ctx context.Context, arg InsertUserParams) error {
 	_, err := q.db.ExecContext(ctx, insertUser,
 		arg.ID,
-		arg.Email,
 		arg.EmailVerified,
-		arg.Name,
 		arg.EmailCiphertext,
 		arg.EmailNonce,
 		arg.EmailEncKeyID,
@@ -541,18 +350,17 @@ func (q *Queries) InsertUser(ctx context.Context, arg InsertUserParams) error {
 
 const insertUserIdentity = `-- name: InsertUserIdentity :exec
 INSERT INTO user_identities (
-    id, user_id, provider, provider_user_id,
+    id, user_id, provider,
     provider_sub_hash, provider_sub_hash_key_id, provider_sub_hash_version,
     provider_sub_ciphertext, provider_sub_nonce, provider_sub_enc_key_id, provider_sub_enc_version,
     created_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 `
 
 type InsertUserIdentityParams struct {
 	ID                     string
 	UserID                 string
 	Provider               string
-	ProviderUserID         sql.NullString
 	ProviderSubHash        sql.NullString
 	ProviderSubHashKeyID   sql.NullString
 	ProviderSubHashVersion sql.NullInt32
@@ -568,7 +376,6 @@ func (q *Queries) InsertUserIdentity(ctx context.Context, arg InsertUserIdentity
 		arg.ID,
 		arg.UserID,
 		arg.Provider,
-		arg.ProviderUserID,
 		arg.ProviderSubHash,
 		arg.ProviderSubHashKeyID,
 		arg.ProviderSubHashVersion,
@@ -579,86 +386,6 @@ func (q *Queries) InsertUserIdentity(ctx context.Context, arg InsertUserIdentity
 		arg.CreatedAt,
 	)
 	return err
-}
-
-const listProviderSubBackfill = `-- name: ListProviderSubBackfill :many
-SELECT id, user_id, provider, provider_user_id
-FROM user_identities
-WHERE provider_sub_hash IS NULL AND provider_user_id IS NOT NULL
-ORDER BY id
-LIMIT $1
-`
-
-type ListProviderSubBackfillRow struct {
-	ID             string
-	UserID         string
-	Provider       string
-	ProviderUserID sql.NullString
-}
-
-func (q *Queries) ListProviderSubBackfill(ctx context.Context, limit int32) ([]ListProviderSubBackfillRow, error) {
-	rows, err := q.db.QueryContext(ctx, listProviderSubBackfill, limit)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []ListProviderSubBackfillRow
-	for rows.Next() {
-		var i ListProviderSubBackfillRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.UserID,
-			&i.Provider,
-			&i.ProviderUserID,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listUsersBackfill = `-- name: ListUsersBackfill :many
-SELECT id, email, name
-FROM users
-WHERE email_hash IS NULL AND email IS NOT NULL
-ORDER BY id
-LIMIT $1
-`
-
-type ListUsersBackfillRow struct {
-	ID    string
-	Email sql.NullString
-	Name  sql.NullString
-}
-
-func (q *Queries) ListUsersBackfill(ctx context.Context, limit int32) ([]ListUsersBackfillRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUsersBackfill, limit)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []ListUsersBackfillRow
-	for rows.Next() {
-		var i ListUsersBackfillRow
-		if err := rows.Scan(&i.ID, &i.Email, &i.Name); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }
 
 const markUserPendingDeletionByID = `-- name: MarkUserPendingDeletionByID :execrows

--- a/internal/integration/integration_crypto_test.go
+++ b/internal/integration/integration_crypto_test.go
@@ -17,7 +17,7 @@ import (
 // to match. Reaching the post-lookup 403 (account_not_found) proves the lookup
 // succeeded — a broken hash path would fail the user_code lookup earlier.
 func TestIntegration_Crypto_DeviceUserCodeLookup(t *testing.T) {
-	ts := SetupTestServerWithOptions(t, SetupOptions{EnableMCP: true, EnableCrypto: true})
+	ts := SetupTestServerWithOptions(t, SetupOptions{EnableMCP: true})
 	ctx := context.Background()
 
 	if err := ts.Store.StoreDeviceAuthorization(ctx, "test-client", "fresh-dc", "TEST-CODE", ts.Clock.Now().Add(5*time.Minute), []string{"openid"}); err != nil {

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -49,9 +49,6 @@ func SetupTestServer(t *testing.T) *TestServer {
 
 type SetupOptions struct {
 	EnableMCP bool
-	// EnableCrypto wires PII at-rest encryption keys + epochs so e2e flows run
-	// the encrypted path (ADR-002).
-	EnableCrypto bool
 }
 
 // setupCryptoKeys derives test crypto keys and registers their epochs.
@@ -99,9 +96,9 @@ func SetupTestServerWithOptions(t *testing.T, opts SetupOptions) *TestServer {
 
 	store := storage.New(db, clk, gen, stateChecker, 15*time.Minute, 30*24*time.Hour)
 	store.SetDevicePollInterval(devicePollInterval)
-	if opts.EnableCrypto {
-		setupCryptoKeys(t, store)
-	}
+	// PII at-rest encryption keys are mandatory after the plaintext-PII cleanup
+	// (ADR-002): signup/lookup require them, so every test server wires them.
+	setupCryptoKeys(t, store)
 	if opts.EnableMCP {
 		cimdFetcher := mcpadapter.NewHTTPCIMDFetcher()
 		clientPolicy := mcpadapter.NewClientResolutionPolicy(storage.NewCoreClientResolutionPolicy(store), cimdFetcher)

--- a/internal/service/account_test.go
+++ b/internal/service/account_test.go
@@ -30,7 +30,7 @@ func setupAccountTest(t *testing.T) *accountFixture {
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
 	noopChecker := func(user *storage.User) error { return nil }
-	store := storage.New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	store := newTestStore(t, db, clk, gen, noopChecker)
 
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: "acct-sub-123", Email: "acct@test.com", EmailVerified: true, Name: "Acct User"},
@@ -189,13 +189,14 @@ func TestE2E_DeleteThenReregister(t *testing.T) {
 	cleanupSvc := NewCleanupService(storage.NewCleanupRunner(fx.DB), fx.Clock, time.Hour)
 	cleanupSvc.RunOnce(ctx)
 
-	var dbStatus, email string
-	fx.DB.QueryRowContext(ctx, `SELECT status, email FROM users WHERE id = $1`, userID).Scan(&dbStatus, &email)
+	var dbStatus string
+	var emailCipher []byte
+	fx.DB.QueryRowContext(ctx, `SELECT status, email_ciphertext FROM users WHERE id = $1`, userID).Scan(&dbStatus, &emailCipher)
 	if dbStatus != "deleted" {
 		t.Fatalf("status = %q, want deleted", dbStatus)
 	}
-	if email == "e2e5@test.com" {
-		t.Error("email should be scrubbed")
+	if emailCipher != nil {
+		t.Error("email ciphertext should be scrubbed (NULL) after deletion")
 	}
 
 	arID, _ := fx.Store.CreateTestAuthRequest(ctx, "e2e5-reregister")

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -4,9 +4,7 @@ package service
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"testing"
 	"time"
@@ -15,10 +13,10 @@ import (
 )
 
 // hashedSessionID mirrors storage's at-rest session hashing (ADR-002): audit
-// metadata stores the hash of the session cookie value, never the raw bearer.
-func hashedSessionID(s string) string {
-	h := sha256.Sum256([]byte(s))
-	return hex.EncodeToString(h[:])
+// metadata stores the keyed hash of the session cookie value, never the raw
+// bearer. Keys are mandatory, so this is the lookup/session HMAC.
+func hashedSessionID(store *storage.Storage, s string) string {
+	return store.Keys().SessionHash(s)
 }
 
 type auditEventRow struct {
@@ -194,7 +192,7 @@ func TestAudit_ReusedSession_AuthLoginRecorded(t *testing.T) {
 	if event.Metadata["reused_session"] != true {
 		t.Fatalf("reused_session = %v, want true", event.Metadata["reused_session"])
 	}
-	if event.Metadata["session_id"] != hashedSessionID(sessionID) {
+	if event.Metadata["session_id"] != hashedSessionID(store, sessionID) {
 		t.Fatalf("session_id = %v, want hashed %s", event.Metadata["session_id"], sessionID)
 	}
 }
@@ -232,7 +230,7 @@ func TestAudit_ReusedSession_MCP_AuthLoginRecorded(t *testing.T) {
 	if event.Metadata["reused_session"] != true {
 		t.Fatalf("reused_session = %v, want true", event.Metadata["reused_session"])
 	}
-	if event.Metadata["session_id"] != hashedSessionID(sessionID) {
+	if event.Metadata["session_id"] != hashedSessionID(store, sessionID) {
 		t.Fatalf("session_id = %v, want hashed %s", event.Metadata["session_id"], sessionID)
 	}
 	if event.Metadata["client_id"] != "test-mcp-app" {
@@ -321,7 +319,7 @@ func TestAudit006_DeletionRequested(t *testing.T) {
 	if event.Metadata["channel"] != "browser" {
 		t.Fatalf("channel = %v, want browser", event.Metadata["channel"])
 	}
-	if event.Metadata["session_id"] != hashedSessionID(loginResult.SessionID) {
+	if event.Metadata["session_id"] != hashedSessionID(store, loginResult.SessionID) {
 		t.Fatalf("session_id = %v, want hashed %s", event.Metadata["session_id"], loginResult.SessionID)
 	}
 	if event.Metadata["client_id"] != "test-app" {
@@ -354,7 +352,7 @@ func TestAudit007_DeletionCancelled(t *testing.T) {
 	if event.Metadata["channel"] != "browser" {
 		t.Fatalf("channel = %v, want browser", event.Metadata["channel"])
 	}
-	if event.Metadata["session_id"] != hashedSessionID(result.SessionID) {
+	if event.Metadata["session_id"] != hashedSessionID(store, result.SessionID) {
 		t.Fatalf("session_id = %v, want hashed %s", event.Metadata["session_id"], result.SessionID)
 	}
 	if event.Metadata["client_id"] != "test-app" {

--- a/internal/service/cleanup_test.go
+++ b/internal/service/cleanup_test.go
@@ -22,7 +22,7 @@ func setupCleanupTest(t *testing.T) (*sql.DB, *storage.Storage, *clock.FixedCloc
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
 	noopChecker := func(user *storage.User) error { return nil }
-	store := storage.New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	store := newTestStore(t, db, clk, gen, noopChecker)
 	return db, store, clk
 }
 
@@ -98,18 +98,18 @@ func TestCleanup_DeletionPIIScrub(t *testing.T) {
 	svc := NewCleanupService(storage.NewCleanupRunner(db), clk, time.Hour)
 	svc.RunOnce(ctx)
 
-	// User should be scrubbed
-	var status, email string
-	var name sql.NullString
-	db.QueryRowContext(ctx, `SELECT status, email, name FROM users WHERE id = $1`, user.ID).Scan(&status, &email, &name)
+	// User should be scrubbed: deletion redaction NULLs the encrypted PII columns.
+	var status string
+	var emailCipher, nameCipher []byte
+	db.QueryRowContext(ctx, `SELECT status, email_ciphertext, name_ciphertext FROM users WHERE id = $1`, user.ID).Scan(&status, &emailCipher, &nameCipher)
 	if status != "deleted" {
 		t.Errorf("status = %q, want deleted", status)
 	}
-	if email == "delete-me@test.com" {
-		t.Error("email should be scrubbed")
+	if emailCipher != nil {
+		t.Error("email ciphertext should be scrubbed (NULL) after deletion")
 	}
-	if name.Valid {
-		t.Error("name should be NULL after scrub")
+	if nameCipher != nil {
+		t.Error("name ciphertext should be scrubbed (NULL) after deletion")
 	}
 
 	// Child records should be gone

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -20,7 +20,7 @@ func setupDeviceService(t *testing.T) (*DeviceService, *storage.Storage, clock.C
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
 	noopChecker := func(user *storage.User) error { return nil }
-	store := storage.New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	store := newTestStore(t, db, clk, gen, noopChecker)
 
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{

--- a/internal/service/e2e_test.go
+++ b/internal/service/e2e_test.go
@@ -39,7 +39,7 @@ func setupE2ETest(t *testing.T) *e2eFixture {
 		}
 		return nil
 	}
-	store := storage.New(db, clk, gen, stateChecker, 15*time.Minute, 30*24*time.Hour)
+	store := newTestStore(t, db, clk, gen, stateChecker)
 
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: "e2e-sub", Email: "e2e@test.com", EmailVerified: true, Name: "E2E User"},

--- a/internal/service/login_test.go
+++ b/internal/service/login_test.go
@@ -20,7 +20,7 @@ func setupLoginService(t *testing.T) (*LoginService, *storage.Storage, *upstream
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
 	noopChecker := func(user *storage.User) error { return nil }
-	store := storage.New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	store := newTestStore(t, db, clk, gen, noopChecker)
 
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{

--- a/internal/service/mcp_test.go
+++ b/internal/service/mcp_test.go
@@ -23,7 +23,7 @@ func setupMCPTest(t *testing.T) (*MCPLoginService, *storage.Storage, *upstream.U
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
 	noopChecker := func(user *storage.User) error { return nil }
-	store := storage.New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	store := newTestStore(t, db, clk, gen, noopChecker)
 
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: "mcp-sub-123", Email: "mcp@test.com", EmailVerified: true, Name: "MCP User"},

--- a/internal/service/testhelpers_test.go
+++ b/internal/service/testhelpers_test.go
@@ -3,16 +3,50 @@
 package service
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 	"time"
 
 	"github.com/kangheeyong/authgate/internal/clock"
+	"github.com/kangheeyong/authgate/internal/crypto"
 	"github.com/kangheeyong/authgate/internal/idgen"
 	"github.com/kangheeyong/authgate/internal/storage"
 	"github.com/kangheeyong/authgate/internal/testutil"
 	"github.com/kangheeyong/authgate/internal/upstream"
 )
+
+// newTestStore builds a Storage with PII encryption configured. Keys are
+// mandatory after the plaintext-PII cleanup (ADR-002), so every service test
+// store must have them wired.
+func newTestStore(t *testing.T, db *sql.DB, clk clock.Clock, gen idgen.IDGenerator, checker storage.StateChecker) *storage.Storage {
+	t.Helper()
+	store := storage.New(db, clk, gen, checker, 15*time.Minute, 30*24*time.Hour)
+	mk := func(b byte) []byte {
+		s := make([]byte, crypto.KeySize)
+		for i := range s {
+			s[i] = b
+		}
+		return s
+	}
+	enc, err := crypto.NewRoot(crypto.DomainEnc, "enc-test-1", mk(0x31))
+	if err != nil {
+		t.Fatalf("enc root: %v", err)
+	}
+	lookup, err := crypto.NewRoot(crypto.DomainLookup, "lkp-test-1", mk(0x32))
+	if err != nil {
+		t.Fatalf("lookup root: %v", err)
+	}
+	keys, err := crypto.NewKeys(enc, lookup)
+	if err != nil {
+		t.Fatalf("keys: %v", err)
+	}
+	store.SetKeys(keys)
+	if err := store.EnsureCryptoEpochs(context.Background()); err != nil {
+		t.Fatalf("ensure epochs: %v", err)
+	}
+	return store
+}
 
 type gapFixture struct {
 	LoginSvc    *LoginService
@@ -47,7 +81,7 @@ func setupDeviceExtTest(t *testing.T, sub string) (*DeviceService, *storage.Stor
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
 	noopChecker := func(user *storage.User) error { return nil }
-	store := storage.New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	store := newTestStore(t, db, clk, gen, noopChecker)
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: sub, Email: sub + "@test.com", EmailVerified: true, Name: "Device Ext"},
 	}
@@ -62,7 +96,7 @@ func setupAccountExtTest(t *testing.T) (*AccountService, *storage.Storage) {
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
 	noopChecker := func(user *storage.User) error { return nil }
-	store := storage.New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	store := newTestStore(t, db, clk, gen, noopChecker)
 	svc := NewAccountService(store)
 	return svc, store
 }
@@ -74,7 +108,7 @@ func setupGapTest(t *testing.T) *gapFixture {
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
 	noopChecker := func(user *storage.User) error { return nil }
-	store := storage.New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	store := newTestStore(t, db, clk, gen, noopChecker)
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: "gap-sub", Email: "gap@test.com", EmailVerified: true, Name: "Gap User"},
 	}
@@ -101,7 +135,7 @@ func setupLoginServiceWithSub(t *testing.T, sub, email string) (*LoginService, *
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
 	noopChecker := func(user *storage.User) error { return nil }
-	store := storage.New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	store := newTestStore(t, db, clk, gen, noopChecker)
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: sub, Email: email, EmailVerified: true, Name: "Test User"},
 	}
@@ -116,7 +150,7 @@ func setupMCPLoginServiceWithSub(t *testing.T, sub, email string) (*MCPLoginServ
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
 	noopChecker := func(user *storage.User) error { return nil }
-	store := storage.New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	store := newTestStore(t, db, clk, gen, noopChecker)
 	fakeProvider := &upstream.FakeProvider{ProviderName: "google",
 		User: &upstream.UserInfo{Sub: sub, Email: email, EmailVerified: true, Name: "Test User"},
 	}

--- a/internal/storage/audit_test.go
+++ b/internal/storage/audit_test.go
@@ -20,7 +20,7 @@ func TestAudit010And011_RefreshReuseAndFamilyRevoke(t *testing.T) {
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
-	store := New(db, clk, gen, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
+	store := withTestKeys(t, New(db, clk, gen, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour))
 	ctx := context.Background()
 
 	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "audit-refresh@test.com", EmailVerified: true, Name: "Refresh Audit", Provider: "google", ProviderUserID: "audit-refresh-sub"})
@@ -68,7 +68,7 @@ func TestAudit010And011_RefreshReuseAndFamilyRevoke(t *testing.T) {
 func TestAuditLog_AppendOnlyGuardAllowsPIIRedactionOnly(t *testing.T) {
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
-	store := New(db, clk, idgen.CryptoGenerator{}, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
+	store := withTestKeys(t, New(db, clk, idgen.CryptoGenerator{}, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour))
 	ctx := context.Background()
 
 	user, err := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "audit-guard@test.com", EmailVerified: true, Name: "Audit Guard", Provider: "google", ProviderUserID: "audit-guard-sub"})
@@ -168,7 +168,7 @@ func TestAuditLogIndexes(t *testing.T) {
 func TestAuditDeviceCodeIssued(t *testing.T) {
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
-	store := New(db, clk, idgen.CryptoGenerator{}, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
+	store := withTestKeys(t, New(db, clk, idgen.CryptoGenerator{}, func(user *User) error { return nil }, 15*time.Minute, 30*24*time.Hour))
 	store.LoadClients([]ClientConfigEntry{{
 		ClientID: "device-client",
 		Name:     "Device Client",

--- a/internal/storage/crypto_epochs_integration_test.go
+++ b/internal/storage/crypto_epochs_integration_test.go
@@ -95,7 +95,7 @@ func TestEnsureCryptoEpochs_DifferentActiveKeyIDRejected(t *testing.T) {
 }
 
 func TestEnsureCryptoEpochs_InertWhenUnset(t *testing.T) {
-	s := testStorage(t)
+	s := testStorageNoKeys(t)
 	if err := s.EnsureCryptoEpochs(context.Background()); err != nil {
 		t.Fatalf("inert ensure should no-op, got %v", err)
 	}

--- a/internal/storage/expiry_test.go
+++ b/internal/storage/expiry_test.go
@@ -17,7 +17,7 @@ func TestAuthRequestByID_Expired_Rejected(t *testing.T) {
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
-	store := New(db, clk, gen, nil, 15*time.Minute, 30*24*time.Hour)
+	store := withTestKeys(t, New(db, clk, gen, nil, 15*time.Minute, 30*24*time.Hour))
 	ctx := context.Background()
 
 	// Create auth request with 10 min TTL
@@ -48,7 +48,7 @@ func TestAuthRequestByCode_Expired_Rejected(t *testing.T) {
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
-	store := New(db, clk, gen, nil, 15*time.Minute, 30*24*time.Hour)
+	store := withTestKeys(t, New(db, clk, gen, nil, 15*time.Minute, 30*24*time.Hour))
 	ctx := context.Background()
 
 	// Create auth request + complete + save code
@@ -76,7 +76,7 @@ func TestCompleteAuthRequest_Expired_Rejected(t *testing.T) {
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
-	store := New(db, clk, gen, nil, 15*time.Minute, 30*24*time.Hour)
+	store := withTestKeys(t, New(db, clk, gen, nil, 15*time.Minute, 30*24*time.Hour))
 	ctx := context.Background()
 
 	arID, _ := store.CreateTestAuthRequest(ctx, "complete-expiry")

--- a/internal/storage/provider_sub.go
+++ b/internal/storage/provider_sub.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -17,9 +16,6 @@ var ErrEncryptionNotConfigured = errors.New("storage: encryption not configured"
 // providerSubVersion is the crypto material format version stored alongside
 // provider_sub hash/ciphertext. Bump only with a matching migration.
 const providerSubVersion = 1
-
-// providerSubBackfillBatch bounds how many rows a single backfill query loads.
-const providerSubBackfillBatch = 500
 
 // providerSubAADField is the stable crypto field id used in the AEAD AAD.
 const providerSubAADField = "user_identities.provider_sub"
@@ -59,50 +55,4 @@ func (c providerSubColumns) applyTo(p *storeq.InsertUserIdentityParams) {
 	p.ProviderSubNonce = c.nonce
 	p.ProviderSubEncKeyID = sql.NullString{String: c.encKeyID, Valid: true}
 	p.ProviderSubEncVersion = sql.NullInt32{Int32: providerSubVersion, Valid: true}
-}
-
-// ProviderSubBackfillRemaining counts identity rows still holding a plaintext
-// provider_user_id without an encrypted hash — the gate that must reach 0 before
-// the plaintext column can be dropped.
-func (s *Storage) ProviderSubBackfillRemaining(ctx context.Context) (int64, error) {
-	return storeq.New(s.db).CountProviderSubUnbackfilled(ctx)
-}
-
-// BackfillProviderSub encrypts every legacy plaintext provider_user_id into the
-// provider_sub_hash/ciphertext columns. Idempotent (only touches rows missing a
-// hash) and resumable (batched). Returns the number of rows backfilled.
-func (s *Storage) BackfillProviderSub(ctx context.Context) (int, error) {
-	if s.keys == nil {
-		return 0, ErrEncryptionNotConfigured
-	}
-	q := storeq.New(s.db)
-	total := 0
-	for {
-		rows, err := q.ListProviderSubBackfill(ctx, providerSubBackfillBatch)
-		if err != nil {
-			return total, fmt.Errorf("list provider_sub backfill: %w", err)
-		}
-		if len(rows) == 0 {
-			return total, nil
-		}
-		for _, r := range rows {
-			cols, err := s.encryptProviderSub(r.UserID, r.Provider, r.ProviderUserID.String)
-			if err != nil {
-				return total, err
-			}
-			if err := q.BackfillProviderSub(ctx, storeq.BackfillProviderSubParams{
-				ID:                     r.ID,
-				ProviderSubHash:        sql.NullString{String: cols.hash, Valid: true},
-				ProviderSubHashKeyID:   sql.NullString{String: cols.hashKeyID, Valid: true},
-				ProviderSubHashVersion: sql.NullInt32{Int32: providerSubVersion, Valid: true},
-				ProviderSubCiphertext:  cols.ciphertext,
-				ProviderSubNonce:       cols.nonce,
-				ProviderSubEncKeyID:    sql.NullString{String: cols.encKeyID, Valid: true},
-				ProviderSubEncVersion:  sql.NullInt32{Int32: providerSubVersion, Valid: true},
-			}); err != nil {
-				return total, fmt.Errorf("backfill provider_sub %s: %w", r.ID, err)
-			}
-			total++
-		}
-	}
 }

--- a/internal/storage/provider_sub_integration_test.go
+++ b/internal/storage/provider_sub_integration_test.go
@@ -14,11 +14,7 @@ import (
 func TestProviderSub_EncryptedOnSignupAndLookup(t *testing.T) {
 	s := testStorage(t)
 	ctx := context.Background()
-	keys := testKeys(t, "enc-1", 0x11, "lkp-1", 0x22)
-	s.SetKeys(keys)
-	if err := s.EnsureCryptoEpochs(ctx); err != nil {
-		t.Fatalf("ensure epochs: %v", err)
-	}
+	keys := s.Keys()
 
 	const sub = "google-sub-xyz-123"
 	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
@@ -28,17 +24,14 @@ func TestProviderSub_EncryptedOnSignupAndLookup(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	// Plaintext provider_user_id must be NULL; hash + ciphertext present and not raw.
-	var pUID, hash sql.NullString
+	// hash + ciphertext present and not raw.
+	var hash sql.NullString
 	var ct, nonce []byte
 	if err := s.DB().QueryRowContext(ctx,
-		`SELECT provider_user_id, provider_sub_hash, provider_sub_ciphertext, provider_sub_nonce
+		`SELECT provider_sub_hash, provider_sub_ciphertext, provider_sub_nonce
 		 FROM user_identities WHERE user_id = $1`, user.ID,
-	).Scan(&pUID, &hash, &ct, &nonce); err != nil {
+	).Scan(&hash, &ct, &nonce); err != nil {
 		t.Fatalf("read identity: %v", err)
-	}
-	if pUID.Valid {
-		t.Error("provider_user_id should be NULL when encrypted")
 	}
 	if !hash.Valid || hash.String == "" {
 		t.Error("provider_sub_hash missing")
@@ -61,56 +54,5 @@ func TestProviderSub_EncryptedOnSignupAndLookup(t *testing.T) {
 	}
 	if _, err := s.GetUserByProviderIdentity(ctx, "google", "not-a-sub"); err != ErrNotFound {
 		t.Errorf("lookup wrong sub err=%v, want ErrNotFound", err)
-	}
-}
-
-func TestProviderSub_Backfill(t *testing.T) {
-	s := testStorage(t)
-	ctx := context.Background()
-
-	// Legacy plaintext identity (no keys → plaintext path).
-	const sub = "legacy-sub-789"
-	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
-		Email: "legacy@test.com", EmailVerified: true, Name: "L", Provider: "google", ProviderUserID: sub,
-	})
-	if err != nil {
-		t.Fatalf("create legacy: %v", err)
-	}
-
-	// Configure keys and backfill.
-	s.SetKeys(testKeys(t, "enc-1", 0x11, "lkp-1", 0x22))
-	if err := s.EnsureCryptoEpochs(ctx); err != nil {
-		t.Fatalf("ensure epochs: %v", err)
-	}
-	n, err := s.BackfillProviderSub(ctx)
-	if err != nil || n != 1 {
-		t.Fatalf("backfill = %d err=%v, want 1", n, err)
-	}
-	remaining, err := s.ProviderSubBackfillRemaining(ctx)
-	if err != nil || remaining != 0 {
-		t.Fatalf("remaining = %d err=%v, want 0", remaining, err)
-	}
-
-	// Backfill scrubs the plaintext provider_user_id.
-	var pUID sql.NullString
-	if err := s.DB().QueryRowContext(ctx,
-		`SELECT provider_user_id FROM user_identities WHERE user_id=$1`, user.ID,
-	).Scan(&pUID); err != nil {
-		t.Fatalf("read plaintext: %v", err)
-	}
-	if pUID.Valid {
-		t.Error("plaintext provider_user_id not cleared after backfill")
-	}
-
-	// Lookup now resolves via hash even though the row was created as plaintext.
-	found, err := s.GetUserByProviderIdentity(ctx, "google", sub)
-	if err != nil || found.ID != user.ID {
-		t.Fatalf("post-backfill lookup: id=%v err=%v", found, err)
-	}
-
-	// Idempotent: a second backfill touches nothing.
-	n2, err := s.BackfillProviderSub(ctx)
-	if err != nil || n2 != 0 {
-		t.Fatalf("second backfill = %d err=%v, want 0", n2, err)
 	}
 }

--- a/internal/storage/refresh_family_tombstone_integration_test.go
+++ b/internal/storage/refresh_family_tombstone_integration_test.go
@@ -20,7 +20,7 @@ func newTombstoneStore(t *testing.T) (*Storage, *clock.FixedClock, idgen.CryptoG
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
-	store := New(db, clk, gen, func(*User) error { return nil }, 15*time.Minute, 30*24*time.Hour)
+	store := withTestKeys(t, New(db, clk, gen, func(*User) error { return nil }, 15*time.Minute, 30*24*time.Hour))
 	return store, clk, gen
 }
 

--- a/internal/storage/refresh_state_test.go
+++ b/internal/storage/refresh_state_test.go
@@ -20,7 +20,7 @@ func TestRefreshReuseDetection_FamilyRevoke(t *testing.T) {
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
 	noopChecker := func(user *User) error { return nil }
-	store := New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	store := withTestKeys(t, New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour))
 	ctx := context.Background()
 
 	user, _ := store.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{Email: "reuse@test.com", EmailVerified: true, Name: "Test", Provider: "google", ProviderUserID: "reuse-sub"})
@@ -72,7 +72,7 @@ func TestRefreshStateCheck_AllStates(t *testing.T) {
 		return nil
 	}
 
-	store := New(db, clk, gen, checker, 15*time.Minute, 30*24*time.Hour)
+	store := withTestKeys(t, New(db, clk, gen, checker, 15*time.Minute, 30*24*time.Hour))
 
 	tests := []struct {
 		name      string
@@ -160,7 +160,7 @@ func TestAuthCodeStateCheck_AllStates(t *testing.T) {
 		return nil
 	}
 
-	store := New(db, clk, gen, checker2, 15*time.Minute, 30*24*time.Hour)
+	store := withTestKeys(t, New(db, clk, gen, checker2, 15*time.Minute, 30*24*time.Hour))
 
 	tests := []struct {
 		name      string

--- a/internal/storage/storage_integration_test.go
+++ b/internal/storage/storage_integration_test.go
@@ -15,13 +15,33 @@ import (
 	"github.com/kangheeyong/authgate/internal/testutil"
 )
 
-func testStorage(t *testing.T) *Storage {
+// testStorageNoKeys builds a Storage WITHOUT PII keys. Only the inert-path test
+// (EnsureCryptoEpochs when unconfigured) should use this; user-creating tests
+// need keys (testStorage / withTestKeys).
+func testStorageNoKeys(t *testing.T) *Storage {
 	t.Helper()
 	db := testutil.SetupPostgres(t)
 	clk := &clock.FixedClock{T: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)}
 	gen := idgen.CryptoGenerator{}
 	noopChecker := func(user *User) error { return nil }
 	return New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+}
+
+// withTestKeys wires PII encryption keys into a Storage and registers epochs.
+// PII is always encrypted at rest (ADR-002); keys are mandatory for any test
+// that creates users or sessions.
+func withTestKeys(t *testing.T, s *Storage) *Storage {
+	t.Helper()
+	s.SetKeys(testKeys(t, "enc-1", 0x11, "lkp-1", 0x22))
+	if err := s.EnsureCryptoEpochs(context.Background()); err != nil {
+		t.Fatalf("ensure epochs: %v", err)
+	}
+	return s
+}
+
+func testStorage(t *testing.T) *Storage {
+	t.Helper()
+	return withTestKeys(t, testStorageNoKeys(t))
 }
 
 func TestCreateUserWithIdentity_Atomic(t *testing.T) {
@@ -201,8 +221,8 @@ func TestSession_TokenStoredHashed(t *testing.T) {
 	if tokenHash == token {
 		t.Error("token_hash equals the raw bearer; want hash")
 	}
-	if tokenHash != hashToken(token) {
-		t.Errorf("token_hash = %q, want hashToken(token) %q", tokenHash, hashToken(token))
+	if want := s.Keys().SessionHash(token); tokenHash != want {
+		t.Errorf("token_hash = %q, want keyed SessionHash %q", tokenHash, want)
 	}
 
 	// A leaked stored hash must NOT be usable as a cookie; only the raw token validates.
@@ -339,7 +359,7 @@ func TestRequestDeletion_PendingDeletionIsIdempotent(t *testing.T) {
 	gen := idgen.CryptoGenerator{}
 	noopChecker := func(user *User) error { return nil }
 	db := testutil.SetupPostgres(t)
-	s := New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour)
+	s := withTestKeys(t, New(db, clk, gen, noopChecker, 15*time.Minute, 30*24*time.Hour))
 
 	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
 		Email: "del-idem@test.com", EmailVerified: true, Name: "Del Idem",

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -31,9 +31,8 @@ func (s *Storage) CreateUserWithIdentity(ctx context.Context, input CreateUserWi
 
 	err = s.insertUserForSignup(ctx, qtx, userID, input, now)
 	if err != nil {
-		// Plaintext path conflicts on users_email_key; encrypted path on the
-		// email_hash unique index.
-		if isUniqueViolation(err, "users_email_key") || isUniqueViolation(err, usersEmailHashKey) {
+		// Email uniqueness is enforced by the email_hash unique index.
+		if isUniqueViolation(err, usersEmailHashKey) {
 			return nil, ErrEmailConflict
 		}
 		return nil, err
@@ -64,15 +63,12 @@ func (s *Storage) insertUserForSignup(ctx context.Context, qtx *storeq.Queries, 
 		EmailVerified: input.EmailVerified,
 		CreatedAt:     now,
 	}
-	// Encrypt email/name when keys are configured; otherwise keep the legacy
-	// plaintext path (ADR-002, keys-gated).
-	if s.keys != nil {
-		if err := s.applyUserPIIEncryption(&params, userID, input.Email, input.Name); err != nil {
-			return err
-		}
-	} else {
-		params.Email = nullStr(input.Email)
-		params.Name = nullStr(input.Name)
+	// PII is always encrypted at rest (ADR-002); keys are mandatory.
+	if s.keys == nil {
+		return ErrEncryptionNotConfigured
+	}
+	if err := s.applyUserPIIEncryption(&params, userID, input.Email, input.Name); err != nil {
+		return err
 	}
 	return qtx.InsertUser(ctx, params)
 }
@@ -84,42 +80,26 @@ func (s *Storage) insertIdentityForSignup(ctx context.Context, qtx *storeq.Queri
 		Provider:  input.Provider,
 		CreatedAt: now,
 	}
-	// Encrypt the provider subject when keys are configured; otherwise keep the
-	// legacy plaintext path (ADR-002, keys-gated).
-	if s.keys != nil {
-		cols, err := s.encryptProviderSub(userID, input.Provider, input.ProviderUserID)
-		if err != nil {
-			return err
-		}
-		cols.applyTo(&params)
-	} else {
-		params.ProviderUserID = sql.NullString{String: input.ProviderUserID, Valid: true}
+	// The provider subject is always encrypted at rest (ADR-002); keys are mandatory.
+	if s.keys == nil {
+		return ErrEncryptionNotConfigured
 	}
+	cols, err := s.encryptProviderSub(userID, input.Provider, input.ProviderUserID)
+	if err != nil {
+		return err
+	}
+	cols.applyTo(&params)
 	return qtx.InsertUserIdentity(ctx, params)
 }
 
 func (s *Storage) GetUserByProviderIdentity(ctx context.Context, provider, providerUserID string) (*User, error) {
 	q := storeq.New(s.db)
-	if s.keys != nil {
-		row, err := q.GetUserByProviderSubHash(ctx, storeq.GetUserByProviderSubHashParams{
-			Provider:        provider,
-			ProviderSubHash: sql.NullString{String: s.keys.ProviderSubHash(provider, providerUserID), Valid: true},
-		})
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		if err != nil {
-			return nil, err
-		}
-		email, name, err := s.resolveUserPII(row.ID, row.Email, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.Name, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
-		if err != nil {
-			return nil, err
-		}
-		return buildFullUser(row.ID, email, row.EmailVerified, name, row.Status, row.CreatedAt, row.UpdatedAt), nil
+	if s.keys == nil {
+		return nil, ErrEncryptionNotConfigured
 	}
-	row, err := q.GetUserByProviderIdentity(ctx, storeq.GetUserByProviderIdentityParams{
-		Provider:       provider,
-		ProviderUserID: sql.NullString{String: providerUserID, Valid: true},
+	row, err := q.GetUserByProviderSubHash(ctx, storeq.GetUserByProviderSubHashParams{
+		Provider:        provider,
+		ProviderSubHash: sql.NullString{String: s.keys.ProviderSubHash(provider, providerUserID), Valid: true},
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -127,7 +107,7 @@ func (s *Storage) GetUserByProviderIdentity(ctx context.Context, provider, provi
 	if err != nil {
 		return nil, err
 	}
-	email, name, err := s.resolveUserPII(row.ID, row.Email, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.Name, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
+	email, name, err := s.resolveUserPII(row.ID, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +122,7 @@ func (s *Storage) getUserByID(ctx context.Context, tx *sql.Tx, userID string) (*
 	if err != nil {
 		return nil, err
 	}
-	email, name, err := s.resolveUserPII(row.ID, row.Email, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.Name, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
+	email, name, err := s.resolveUserPII(row.ID, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +138,7 @@ func (s *Storage) GetUserByID(ctx context.Context, userID string) (*User, error)
 	if err != nil {
 		return nil, err
 	}
-	email, name, err := s.resolveUserPII(row.ID, row.Email, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.Name, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
+	email, name, err := s.resolveUserPII(row.ID, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +178,7 @@ func (s *Storage) setUserinfo(ctx context.Context, userinfo *oidc.UserInfo, user
 	if err != nil {
 		return err
 	}
-	email, name, err := s.resolveUserPII(row.ID, row.Email, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.Name, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
+	email, name, err := s.resolveUserPII(row.ID, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
 	if err != nil {
 		return err
 	}
@@ -388,7 +368,7 @@ func (s *Storage) GetValidSession(ctx context.Context, sessionID string) (*User,
 	if err != nil {
 		return nil, err
 	}
-	email, name, err := s.resolveUserPII(row.ID, row.Email, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.Name, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
+	email, name, err := s.resolveUserPII(row.ID, row.EmailCiphertext, row.EmailNonce, row.EmailEncKeyID, row.EmailEncVersion, row.NameCiphertext, row.NameNonce, row.NameEncKeyID, row.NameEncVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/users_pii.go
+++ b/internal/storage/users_pii.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -16,7 +15,6 @@ const (
 	emailAADField     = "users.email"
 	nameAADField      = "users.name"
 	userPIIVersion    = 1
-	userPIIBatch      = 500
 	usersEmailHashKey = "users_email_hash_key"
 )
 
@@ -58,81 +56,32 @@ func (s *Storage) applyUserPIIEncryption(p *storeq.InsertUserParams, userID, ema
 	return nil
 }
 
-// resolveUserPII returns the plaintext email and name for a user row, decrypting
-// when keys are configured and the ciphertext is present, otherwise falling back
-// to the legacy plaintext columns (keys-gated). The argument order matches the
-// SELECTed column order so every user-returning query maps to it in one line.
+// resolveUserPII returns the plaintext email and name for a user row by
+// decrypting the AEAD ciphertext columns. Keys are mandatory (ADR-002); the
+// email is always present, while name is optional (empty when no ciphertext).
+// The argument order matches the SELECTed column order so every user-returning
+// query maps to it in one line.
 func (s *Storage) resolveUserPII(
 	userID string,
-	emailPlain sql.NullString, emailCipher, emailNonce []byte, emailEncKeyID sql.NullString, emailEncVersion sql.NullInt32,
-	namePlain sql.NullString, nameCipher, nameNonce []byte, nameEncKeyID sql.NullString, nameEncVersion sql.NullInt32,
+	emailCipher, emailNonce []byte, emailEncKeyID sql.NullString, emailEncVersion sql.NullInt32,
+	nameCipher, nameNonce []byte, nameEncKeyID sql.NullString, nameEncVersion sql.NullInt32,
 ) (email string, name sql.NullString, err error) {
-	if s.keys != nil && len(emailCipher) > 0 {
-		pt, derr := s.keys.DecryptPII(emailCipher, emailNonce, crypto.FieldAAD(emailAADField, userID, emailEncKeyID.String, int(emailEncVersion.Int32)))
-		if derr != nil {
-			return "", sql.NullString{}, fmt.Errorf("decrypt email: %w", derr)
-		}
-		email = string(pt)
-	} else {
-		email = emailPlain.String
+	if s.keys == nil {
+		return "", sql.NullString{}, ErrEncryptionNotConfigured
 	}
 
-	if s.keys != nil && len(nameCipher) > 0 {
-		pt, derr := s.keys.DecryptPII(nameCipher, nameNonce, crypto.FieldAAD(nameAADField, userID, nameEncKeyID.String, int(nameEncVersion.Int32)))
+	pt, derr := s.keys.DecryptPII(emailCipher, emailNonce, crypto.FieldAAD(emailAADField, userID, emailEncKeyID.String, int(emailEncVersion.Int32)))
+	if derr != nil {
+		return "", sql.NullString{}, fmt.Errorf("decrypt email: %w", derr)
+	}
+	email = string(pt)
+
+	if len(nameCipher) > 0 {
+		npt, derr := s.keys.DecryptPII(nameCipher, nameNonce, crypto.FieldAAD(nameAADField, userID, nameEncKeyID.String, int(nameEncVersion.Int32)))
 		if derr != nil {
 			return "", sql.NullString{}, fmt.Errorf("decrypt name: %w", derr)
 		}
-		name = nullStr(string(pt))
-	} else {
-		name = namePlain
+		name = nullStr(string(npt))
 	}
 	return email, name, nil
-}
-
-// UserPIIBackfillRemaining counts users still holding a plaintext email without
-// an email_hash — the gate that must reach 0 before dropping plaintext columns.
-func (s *Storage) UserPIIBackfillRemaining(ctx context.Context) (int64, error) {
-	return storeq.New(s.db).CountUsersUnbackfilled(ctx)
-}
-
-// BackfillUserPII encrypts every legacy plaintext email/name into the ciphertext
-// + email_hash columns. Idempotent (only rows missing email_hash) and batched.
-func (s *Storage) BackfillUserPII(ctx context.Context) (int, error) {
-	if s.keys == nil {
-		return 0, ErrEncryptionNotConfigured
-	}
-	q := storeq.New(s.db)
-	total := 0
-	for {
-		rows, err := q.ListUsersBackfill(ctx, userPIIBatch)
-		if err != nil {
-			return total, fmt.Errorf("list user backfill: %w", err)
-		}
-		if len(rows) == 0 {
-			return total, nil
-		}
-		for _, r := range rows {
-			var p storeq.InsertUserParams // reuse for column carriers only
-			if err := s.applyUserPIIEncryption(&p, r.ID, r.Email.String, r.Name.String); err != nil {
-				return total, err
-			}
-			if err := q.BackfillUserPII(ctx, storeq.BackfillUserPIIParams{
-				ID:               r.ID,
-				EmailCiphertext:  p.EmailCiphertext,
-				EmailNonce:       p.EmailNonce,
-				EmailEncKeyID:    p.EmailEncKeyID,
-				EmailEncVersion:  p.EmailEncVersion,
-				EmailHash:        p.EmailHash,
-				EmailHashKeyID:   p.EmailHashKeyID,
-				EmailHashVersion: p.EmailHashVersion,
-				NameCiphertext:   p.NameCiphertext,
-				NameNonce:        p.NameNonce,
-				NameEncKeyID:     p.NameEncKeyID,
-				NameEncVersion:   p.NameEncVersion,
-			}); err != nil {
-				return total, fmt.Errorf("backfill user %s: %w", r.ID, err)
-			}
-			total++
-		}
-	}
 }

--- a/internal/storage/users_pii_integration_test.go
+++ b/internal/storage/users_pii_integration_test.go
@@ -5,7 +5,6 @@ package storage
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -13,12 +12,7 @@ import (
 
 func encStorage(t *testing.T) *Storage {
 	t.Helper()
-	s := testStorage(t)
-	s.SetKeys(testKeys(t, "enc-1", 0x11, "lkp-1", 0x22))
-	if err := s.EnsureCryptoEpochs(context.Background()); err != nil {
-		t.Fatalf("ensure epochs: %v", err)
-	}
-	return s
+	return testStorage(t)
 }
 
 func TestUserPII_EncryptedSignupAndAllReadPaths(t *testing.T) {
@@ -33,16 +27,12 @@ func TestUserPII_EncryptedSignupAndAllReadPaths(t *testing.T) {
 		t.Fatalf("signup: %v", err)
 	}
 
-	// Plaintext columns NULL; ciphertext present and not containing the raw values.
-	var ePlain, nPlain sql.NullString
+	// Ciphertext present and not containing the raw values.
 	var eCT, nCT []byte
 	if err := s.DB().QueryRowContext(ctx,
-		`SELECT email, name, email_ciphertext, name_ciphertext FROM users WHERE id=$1`, user.ID,
-	).Scan(&ePlain, &nPlain, &eCT, &nCT); err != nil {
+		`SELECT email_ciphertext, name_ciphertext FROM users WHERE id=$1`, user.ID,
+	).Scan(&eCT, &nCT); err != nil {
 		t.Fatalf("read row: %v", err)
-	}
-	if ePlain.Valid || nPlain.Valid {
-		t.Error("plaintext email/name should be NULL when encrypted")
 	}
 	if bytes.Contains(eCT, []byte(email)) || bytes.Contains(nCT, []byte(name)) {
 		t.Error("ciphertext contains raw PII")
@@ -87,53 +77,5 @@ func TestUserPII_EmailUniquenessNormalized(t *testing.T) {
 	})
 	if !errors.Is(err, ErrEmailConflict) {
 		t.Fatalf("err = %v, want ErrEmailConflict", err)
-	}
-}
-
-func TestUserPII_Backfill(t *testing.T) {
-	s := testStorage(t) // no keys → plaintext signup
-	ctx := context.Background()
-
-	const email, name, sub = "legacy@example.com", "Legacy", "legacy-sub"
-	user, err := s.CreateUserWithIdentity(ctx, CreateUserWithIdentityInput{
-		Email: email, EmailVerified: true, Name: name, Provider: "google", ProviderUserID: sub,
-	})
-	if err != nil {
-		t.Fatalf("legacy signup: %v", err)
-	}
-
-	s.SetKeys(testKeys(t, "enc-1", 0x11, "lkp-1", 0x22))
-	if err := s.EnsureCryptoEpochs(ctx); err != nil {
-		t.Fatalf("ensure epochs: %v", err)
-	}
-	n, err := s.BackfillUserPII(ctx)
-	if err != nil || n != 1 {
-		t.Fatalf("backfill = %d err=%v, want 1", n, err)
-	}
-	remaining, err := s.UserPIIBackfillRemaining(ctx)
-	if err != nil || remaining != 0 {
-		t.Fatalf("remaining = %d err=%v, want 0", remaining, err)
-	}
-
-	// Backfill scrubs the plaintext columns (PII no longer at rest in clear).
-	var ePlain, nPlain sql.NullString
-	if err := s.DB().QueryRowContext(ctx,
-		`SELECT email, name FROM users WHERE id=$1`, user.ID,
-	).Scan(&ePlain, &nPlain); err != nil {
-		t.Fatalf("read plaintext: %v", err)
-	}
-	if ePlain.Valid || nPlain.Valid {
-		t.Error("plaintext email/name not cleared after backfill")
-	}
-
-	// Reads now decrypt the backfilled values.
-	got, err := s.GetUserByID(ctx, user.ID)
-	if err != nil || got.Email != email || got.Name != name {
-		t.Fatalf("post-backfill read: %+v err=%v", got, err)
-	}
-
-	n2, err := s.BackfillUserPII(ctx)
-	if err != nil || n2 != 0 {
-		t.Fatalf("second backfill = %d err=%v, want 0", n2, err)
 	}
 }

--- a/migrations/014_drop_plaintext_pii.down.sql
+++ b/migrations/014_drop_plaintext_pii.down.sql
@@ -1,0 +1,5 @@
+-- 되돌리기: 컬럼 구조만 재생성(평문 데이터는 복구 불가). 구 UNIQUE도 복원.
+ALTER TABLE users ADD COLUMN email TEXT, ADD COLUMN name TEXT;
+CREATE UNIQUE INDEX users_email_key ON users (email);
+ALTER TABLE user_identities ADD COLUMN provider_user_id TEXT;
+ALTER TABLE user_identities ADD CONSTRAINT user_identities_provider_provider_user_id_key UNIQUE (provider, provider_user_id);

--- a/migrations/014_drop_plaintext_pii.up.sql
+++ b/migrations/014_drop_plaintext_pii.up.sql
@@ -1,0 +1,4 @@
+-- ADR-002 cleanup: backfill 완료 후 평문 PII 컬럼 제거. 모든 행은 암호화 컬럼 + lookup hash를 갖는다.
+-- email_hash/email_ciphertext 등은 계정 삭제 redaction(MarkUserDeletedByID)이 NULL로 덮으므로 NOT NULL로 굳히지 않는다.
+ALTER TABLE users DROP COLUMN email, DROP COLUMN name;
+ALTER TABLE user_identities DROP COLUMN provider_user_id;


### PR DESCRIPTION
## 무엇 (010 가이드 2단계: 평문 제거 cleanup)

PII at-rest 암호화 backfill이 **프로덕션에서 완료**(평문 0, 전 행 암호화 검증)된 것을 전제로, 평문 PII 컬럼과 그에 묶인 전환 코드를 제거합니다.

### migration 014
- `users.email`, `users.name`, `user_identities.provider_user_id` 평문 컬럼 DROP
- 구 평문 UNIQUE 동반 제거: `users_email_key`, `UNIQUE(provider, provider_user_id)`
- down: 컬럼 구조만 복원(평문 데이터 복구 불가)

### 코드
- **PII 키 필수화** — keys-OFF 평문 fallback 제거. 가입/조회는 항상 암호화/복호화(`resolveUserPII`는 평문 인자 없이 항상 AEAD 복호화).
- **backfill 기계 제거** — `BackfillUserPII/ProviderSub`, `List*/Count*Unbackfilled`, 부팅 백필 호출. 평문이 없으니 obsolete.
- **평문 JOIN 조회 제거** — `GetUserByProviderIdentity`(SQL) → `provider_sub_hash` 조회로 일원화(Go 메서드명은 유지).
- **삭제 redaction** — 평문 `email` tombstone 대신 암호/해시 컬럼 `NULL`화.

### 설정/테스트/문서
- `docker-compose.yml`: dev 더미 PII 키 추가(keys-OFF 부팅 후 첫 PII op 실패 방지).
- 테스트: keyless 빌더 전부 키 주입(`withTestKeys`), `InertWhenUnset`만 keyless 유지. 삭제/세션해시 단언을 keyed 기준으로 수정.
- 문서: `007`(데이터모델)/`009`(env)/`010`(업그레이드) 동기화.

## 검증
`go build` / `go vet` / `go test ./...`(unit) / `go test -tags=integration ./...` 전부 통과. migration 014는 실제 Postgres에 `version=14`로 clean 적용 확인.

## ⚠️ 배포 (불가역)
컬럼 DROP은 하위 호환을 깬다 — `docs/spec/010` 2단계대로 **단일 인스턴스 교체 배포(롤링 금지)**. 전제: backfill 완료(프로드 충족), DB 백업/PITR 확보(osaka CNPG 일일+WAL 확인됨).

🤖 Generated with [Claude Code](https://claude.com/claude-code)