### PR TITLE
refactor(crypto): collapse keys-gated hashing now that keys are mandatory

### DIFF
--- a/docs/spec/007-data-model.md
+++ b/docs/spec/007-data-model.md
@@ -65,7 +65,7 @@ erDiagram
     sessions {
         uuid id PK "DEFAULT uuid_generate_v4(), 내부 PK (쿠키 아님)"
         uuid user_id FK "NOT NULL, CASCADE"
-        text token_hash UK "nullable, 세션 쿠키 bearer 해시 (키 설정 시 lookup/session HMAC, 아니면 SHA-256)"
+        text token_hash UK "nullable, 세션 쿠키 bearer 해시 (lookup/session HMAC)"
         timestamptz expires_at "NOT NULL, 기본 24시간(SESSION_TTL)"
         timestamptz revoked_at "nullable, 로그아웃 시 설정"
         timestamptz created_at "NOT NULL, DEFAULT NOW()"
@@ -259,10 +259,10 @@ MCP
 |------|------|
 | provider sub은 lookup HMAC + AEAD ciphertext로 저장 | `provider_sub_hash`(매칭) + `provider_sub_ciphertext`(회전 복구). 평문 `provider_user_id` 컬럼은 제거됨(migration 014) |
 | email/name은 AEAD ciphertext로 저장, email은 lookup HMAC도 | `email_ciphertext`/`name_ciphertext` + `email_hash`(UNIQUE/정규화 lowercase+NFC). 평문 `email`/`name` 컬럼은 제거됨(migration 014). 탈퇴 시 ciphertext/hash redaction |
-| 단명 코드(device_code/user_code/authz code)는 lookup HMAC로 저장 | 기존 컬럼에 in-place 해시(키 설정 시). 짧은 수명이라 drain, 반환 모델은 평문 입력값 |
+| 단명 코드(device_code/user_code/authz code)는 lookup HMAC로 저장 | 기존 컬럼에 in-place 해시. 짧은 수명이라 drain, 반환 모델은 평문 입력값 |
 | refresh_token은 SHA-256 해시로 저장 | `token_hash` 컬럼 |
-| 세션 쿠키(bearer)는 해시로 저장 | `sessions.token_hash` (`id`는 내부 PK). 키 설정 시 lookup/session HMAC, 아니면 SHA-256 |
-| audit_log.metadata의 `session_id`는 해시로 저장 | audit sanitize 시 SHA-256 (평문 bearer 미기록) |
+| 세션 쿠키(bearer)는 해시로 저장 | `sessions.token_hash` (`id`는 내부 PK). lookup/session HMAC |
+| audit_log.metadata의 `session_id`는 해시로 저장 | audit sanitize 시 세션과 동일한 lookup/session HMAC (평문 bearer 미기록) |
 | client_secret은 bcrypt 해시로 저장 | `clients.yaml`의 `client_secret_hash` 필드 |
 | access_token(JWT)은 DB에 저장하지 않음 | stateless |
 | PII 스크러빙 시 email, name 제거 | `deleted` 상태 전이 시 |

--- a/internal/storage/audit_unit_test.go
+++ b/internal/storage/audit_unit_test.go
@@ -4,7 +4,35 @@ import (
 	"context"
 	"reflect"
 	"testing"
+
+	"github.com/kangheeyong/authgate/internal/crypto"
 )
+
+// unitKeys builds a Keys for unit tests (no DB). Keys are mandatory (ADR-002),
+// so sanitize paths that hash a session_id need them.
+func unitKeys(t *testing.T) *crypto.Keys {
+	t.Helper()
+	mk := func(b byte) []byte {
+		s := make([]byte, crypto.KeySize)
+		for i := range s {
+			s[i] = b
+		}
+		return s
+	}
+	enc, err := crypto.NewRoot(crypto.DomainEnc, "enc-1", mk(0x11))
+	if err != nil {
+		t.Fatalf("enc root: %v", err)
+	}
+	lookup, err := crypto.NewRoot(crypto.DomainLookup, "lkp-1", mk(0x22))
+	if err != nil {
+		t.Fatalf("lookup root: %v", err)
+	}
+	keys, err := crypto.NewKeys(enc, lookup)
+	if err != nil {
+		t.Fatalf("keys: %v", err)
+	}
+	return keys
+}
 
 func TestNormalizeIPAddress(t *testing.T) {
 	tests := []struct {
@@ -47,13 +75,14 @@ func TestSanitizeAuditMetadata_AllowsKnownKeysOnly(t *testing.T) {
 		"access_token":   "secret-token",
 	}
 
-	got := (&Storage{}).sanitizeAuditMetadata(context.Background(), "auth.login", metadata)
+	keys := unitKeys(t)
+	got := (&Storage{keys: keys}).sanitizeAuditMetadata(context.Background(), "auth.login", metadata)
 	want := map[string]any{
 		"channel":     "browser",
 		"client_id":   "client-1",
 		"client_name": "Client One",
 		// session_id is stored hashed, never as the raw bearer (ADR-002).
-		"session_id":     hashToken("sess-1"),
+		"session_id":     keys.SessionHash("sess-1"),
 		"reused_session": true,
 	}
 	if !reflect.DeepEqual(got, want) {

--- a/internal/storage/codes.go
+++ b/internal/storage/codes.go
@@ -1,24 +1,17 @@
 package storage
 
 // codeAtRest hashes a short-lived code (device_code / user_code / OAuth
-// authorization code) for storage and lookup when crypto keys are configured
-// (ADR-002, keys-gated). These codes are short-lived, so the rollout drains
-// naturally — no backfill. Returned models carry the plaintext code the caller
-// supplied, never the stored hash.
+// authorization code) for storage and lookup with the lookup HMAC subkey
+// (ADR-002). Keys are mandatory, so this is unconditional. Returned models carry
+// the plaintext code the caller supplied, never the stored hash.
 func (s *Storage) codeAtRest(code string) string {
-	if s.keys != nil {
-		return s.keys.CodeHash(code)
-	}
-	return code
+	return s.keys.CodeHash(code)
 }
 
-// sessionAtRest hashes a session bearer token for storage/lookup. Uses the
-// lookup/session HMAC subkey when keys are configured (ADR-002), otherwise the
-// legacy SHA-256 (keys-gated). Used for sessions.token_hash and the audit
-// session_id so both correlate. Short-lived → drain, no backfill.
+// sessionAtRest hashes a session bearer token for storage/lookup with the
+// lookup/session HMAC subkey (ADR-002). Used for sessions.token_hash and the
+// audit session_id so both correlate. Keys are mandatory, so this is
+// unconditional.
 func (s *Storage) sessionAtRest(token string) string {
-	if s.keys != nil {
-		return s.keys.SessionHash(token)
-	}
-	return hashToken(token)
+	return s.keys.SessionHash(token)
 }


### PR DESCRIPTION
## 무엇

`codeAtRest` / `sessionAtRest`가 아직 `if s.keys != nil { keyed HMAC } else { 평문/SHA-256 }` 이중 분기를 갖고 있었다. migration 014(#310)로 **PII 키가 필수**가 된 이후로는 키 없이 부팅이 불가능하므로(`DEV_MODE=false`는 키 미설정 시 시작 거부, dev는 docker-compose가 더미 키 주입) `else` 가지는 런타임에서 도달 불가능한 죽은 코드다. 두 헬퍼를 무조건 keyed HMAC 경로로 접었다.

## 왜

notegate가 권한 차원(3-role→2-binary)을 접어 문서를 대폭 줄인 것과 같은 원리 — **곱셈 차원을 코드에서 단일값으로 접으면 분기별 서술이 사라진다.** authgate의 "키 있음/없음" 차원은 #310에서 쓰기 경로가 이미 접혔고, 단명 코드/세션 해싱에만 잔존하던 마지막 분기를 여기서 정리한다.

## 변경

- `internal/storage/codes.go`: `codeAtRest`/`sessionAtRest`의 nil-keys fallback 제거 → 무조건 `keys.CodeHash`/`keys.SessionHash`
- `docs/spec/007-data-model.md`:
  - 세션 `token_hash`, 단명 코드, 세션 쿠키 행에서 `(키 설정 시 ... 아니면 SHA-256)` 이중 분기 서술 제거
  - audit `session_id` 행을 `SHA-256` → 실제 사용 중인 `lookup/session HMAC`로 정정 (기존 문서 오류)
- `internal/storage/audit_unit_test.go`: 제거된 nil-keys fallback 대신 keyed Storage로 테스트 (키 필수)

`hashToken`(SHA-256)은 refresh_token 저장에 계속 쓰이므로 유지.

## 검증

- `go build ./...` / `go vet` OK
- `go test ./...` (unit) green
- `go test -tags=integration ./internal/storage/ ./internal/service/` green (storage 42s, service 78s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)