### PR TITLE
fix: support Claude Desktop CIMD grant metadata

### DIFF
--- a/docs/spec/004-mcp-login.md
+++ b/docs/spec/004-mcp-login.md
@@ -278,6 +278,8 @@ GET https://app.example.com/oauth/client.json
 }
 ```
 
+`grant_types`에 authgate가 지원하지 않는 grant가 추가로 있어도, `authorization_code`가 포함되어 있으면 문서 자체는 거부하지 않는다. authgate는 내부 `ClientModel`에 `authorization_code`와 `refresh_token`만 반영한다.
+
 authgate의 CIMD 처리:
 
 ```text
@@ -335,7 +337,7 @@ CIMD fetch의 네트워크 제약. IETF draft에서 MUST/SHOULD인 것과 authga
 | `client_id` | 문서 내 값 == fetch한 URL (정확 일치) | `invalid_client` |
 | `client_name` | 필수, 비어있으면 거부 | `invalid_client` |
 | `redirect_uris` | 필수, 1개 이상 | `invalid_client` |
-| `grant_types` | `authorization_code`, `refresh_token`만 허용. 비어있으면 `authorization_code` 기본 | `invalid_client` |
+| `grant_types` | `authorization_code` 필수. `refresh_token`은 지원하며, 그 외 grant는 authgate 내부 ClientModel에는 반영하지 않는다. 비어있으면 `authorization_code` 기본 | `invalid_client` |
 | `response_types` | `code`만 허용 | `invalid_client` |
 | `token_endpoint_auth_method` | `none`만 허용 (public client). 비어있으면 `none` 기본 | `invalid_client` |
 
@@ -349,7 +351,7 @@ CIMD 메타데이터 문서의 필드별 크기/개수 제한. 문서 전체 크
 | `client_id` (URL) | 2048자 | URL 길이 실용 상한 |
 | `client_name` | 256자 | 표시용, UI 오버플로 방지 |
 | `redirect_uris` | 최대 10개, 각 2048자 | 과도한 등록 방지 |
-| `grant_types` | 최대 2개 (`authorization_code`, `refresh_token`) | 허용 값이 2종뿐 |
+| `grant_types` | 최대 8개 | 대형 metadata 방어. authgate는 지원 grant만 선택적으로 사용 |
 | `response_types` | 최대 1개 (`code`) | 허용 값이 1종뿐 |
 | `token_endpoint_auth_method` | `none` 고정 | 허용 값이 1종뿐 |
 
@@ -397,7 +399,8 @@ CIMD 클라이언트(URL 형식 client_id)는 **매 호출 시 캐시 기반으�
 ```text
 /authorize
   → CIMD fetch (캐시 기반)
-  → client_id 일치, redirect_uri, grant_types 전체 검증
+  → client_id 일치, redirect_uri, authorization_code 포함 확인
+  → 지원 grant만 내부 ClientModel에 반영
 
 /oauth/token (code exchange)
   → CIMD fetch (캐시 기반)
@@ -430,7 +433,7 @@ CIMD 클라이언트(URL 형식 client_id)는 **매 호출 시 캐시 기반으�
 메타데이터 내용이 중간에 바뀐 경우:
 - 캐시 만료 후 re-fetch 시 새 메타데이터 적용
 - `redirect_uris` 변경: `/authorize` 시점에만 검증하므로 기존 토큰에는 영향 없음
-- `grant_types` 변경: code exchange/refresh 시 재검증하므로 **영향 있음** (예: `refresh_token`이 빠지면 갱신 거부)
+- `grant_types` 변경: code exchange/refresh 시 재검증하므로 **영향 있음**. `authorization_code`가 빠지면 클라이언트 조회가 실패하고, `refresh_token`이 빠지면 새 refresh_token 발급/갱신이 거부된다. 지원하지 않는 추가 grant는 무시된다.
 
 ## 채널 정책
 

--- a/docs/spec/005-token-lifecycle.md
+++ b/docs/spec/005-token-lifecycle.md
@@ -311,7 +311,7 @@ WHERE expires_at < NOW() - INTERVAL '1 hour';
 | 계정 disabled/deleted/pending_deletion | `invalid_grant` | 400 | 토큰 갱신 차단 |
 | client_id 불일치 | `invalid_client` | 400 | |
 | CIMD fetch 실패 (URL 소멸/타임아웃) | `invalid_client` | 400 | MCP 클라이언트 재등록 + 재로그인 필요. Spec 004 참조 |
-| CIMD grant_types 변경 (refresh_token 제거됨) | `invalid_client` | 400 | 메타데이터에서 grant 허용이 철회됨 |
+| CIMD grant_types 변경 (`refresh_token` 제거됨) | `invalid_client` | 400 | 지원 grant가 철회됨. 지원하지 않는 추가 grant는 무시됨 |
 
 ## 다른 스펙 참조
 

--- a/internal/adapter/mcp/cimd.go
+++ b/internal/adapter/mcp/cimd.go
@@ -44,7 +44,7 @@ const (
 	maxCIMDClientNameLength  = 256
 	maxCIMDRedirectURICount  = 10
 	maxCIMDRedirectURILength = 2048
-	maxCIMDGrantTypeCount    = 2
+	maxCIMDGrantTypeCount    = 8
 	maxCIMDResponseTypeCount = 1
 
 	// cimdCacheMaxEntries caps the in-memory cache so a flood of unique
@@ -366,9 +366,9 @@ func (f *HTTPCIMDFetcher) fetchAndValidate(ctx context.Context, clientID string)
 		}
 	}
 
-	// Defaults
-	if len(meta.GrantTypes) == 0 {
-		meta.GrantTypes = []string{"authorization_code"}
+	grantTypes, err := supportedCIMDGrantTypes(meta.GrantTypes)
+	if err != nil {
+		return nil, 0, err
 	}
 	if meta.TokenEndpointAuthMethod == "" {
 		meta.TokenEndpointAuthMethod = "none"
@@ -386,16 +386,6 @@ func (f *HTTPCIMDFetcher) fetchAndValidate(ctx context.Context, clientID string)
 	if len(meta.ResponseTypes) > maxCIMDResponseTypeCount {
 		return nil, 0, fmt.Errorf("cimd: response_types exceeds %d entries", maxCIMDResponseTypeCount)
 	}
-	if len(meta.GrantTypes) > maxCIMDGrantTypeCount {
-		return nil, 0, fmt.Errorf("cimd: grant_types exceeds %d entries", maxCIMDGrantTypeCount)
-	}
-	allowedGrants := map[string]bool{"authorization_code": true, "refresh_token": true}
-	for _, gt := range meta.GrantTypes {
-		if !allowedGrants[gt] {
-			return nil, 0, fmt.Errorf("cimd: unsupported grant_type: %q (only authorization_code, refresh_token supported)", gt)
-		}
-	}
-
 	return &storage.ClientModel{
 		ID:                   meta.ClientID,
 		Type:                 "public",
@@ -403,8 +393,33 @@ func (f *HTTPCIMDFetcher) fetchAndValidate(ctx context.Context, clientID string)
 		Name:                 meta.ClientName,
 		RedirectURIList:      storage.StringArray(meta.RedirectURIs),
 		AllowedScopeList:     storage.StringArray([]string{"openid", "profile", "email", "offline_access"}),
-		AllowedGrantTypeList: storage.StringArray(meta.GrantTypes),
+		AllowedGrantTypeList: storage.StringArray(grantTypes),
 	}, cacheTTLFromCacheControl(resp.Header.Get("Cache-Control"), f.cacheTTL), nil
+}
+
+func supportedCIMDGrantTypes(grantTypes []string) ([]string, error) {
+	if len(grantTypes) == 0 {
+		return []string{"authorization_code"}, nil
+	}
+	if len(grantTypes) > maxCIMDGrantTypeCount {
+		return nil, fmt.Errorf("cimd: grant_types exceeds %d entries", maxCIMDGrantTypeCount)
+	}
+
+	seen := make(map[string]bool, 2)
+	var supported []string
+	for _, gt := range grantTypes {
+		switch gt {
+		case "authorization_code", "refresh_token":
+			if !seen[gt] {
+				seen[gt] = true
+				supported = append(supported, gt)
+			}
+		}
+	}
+	if !seen["authorization_code"] {
+		return nil, fmt.Errorf("cimd: grant_types must include authorization_code")
+	}
+	return supported, nil
 }
 
 func cacheTTLFromCacheControl(cacheControl string, fallback time.Duration) time.Duration {

--- a/internal/adapter/mcp/cimd_fetcher_validation_test.go
+++ b/internal/adapter/mcp/cimd_fetcher_validation_test.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/kangheeyong/authgate/internal/clock"
+	"github.com/kangheeyong/authgate/internal/storage"
 )
 
 func TestCIMDFetcher_UnsupportedAuthMethod(t *testing.T) {
@@ -83,7 +85,7 @@ func TestCIMDFetcher_OversizedDocument(t *testing.T) {
 	}
 }
 
-func TestCIMDFetcher_UnsupportedGrantType(t *testing.T) {
+func TestCIMDFetcher_GrantTypesMustIncludeAuthorizationCode(t *testing.T) {
 	var serverURL string
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -100,10 +102,37 @@ func TestCIMDFetcher_UnsupportedGrantType(t *testing.T) {
 	fetcher := &HTTPCIMDFetcher{client: srv.Client(), clock: clock.RealClock{}, cacheTTL: 5 * time.Minute}
 	_, err := fetcher.FetchClient(context.Background(), serverURL+"/client.json")
 	if err == nil {
-		t.Fatal("expected error for unsupported grant_type, got nil")
+		t.Fatal("expected error for grant_types without authorization_code, got nil")
 	}
-	if !strings.Contains(err.Error(), "grant_type") {
-		t.Errorf("error = %q, want to contain 'grant_type'", err.Error())
+	if !strings.Contains(err.Error(), "authorization_code") {
+		t.Errorf("error = %q, want to contain 'authorization_code'", err.Error())
+	}
+}
+
+func TestCIMDFetcher_IgnoresUnsupportedAdditionalGrantTypes(t *testing.T) {
+	var serverURL string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"client_id":                  serverURL + "/client.json",
+			"client_name":                "Claude",
+			"redirect_uris":              []string{"https://claude.ai/api/mcp/auth_callback"},
+			"grant_types":                []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"},
+			"response_types":             []string{"code"},
+			"token_endpoint_auth_method": "none",
+		})
+	}))
+	defer srv.Close()
+	serverURL = srv.URL
+
+	fetcher := &HTTPCIMDFetcher{client: srv.Client(), clock: clock.RealClock{}, cacheTTL: 5 * time.Minute}
+	client, err := fetcher.FetchClient(context.Background(), serverURL+"/client.json")
+	if err != nil {
+		t.Fatalf("FetchClient failed: %v", err)
+	}
+	want := storage.StringArray([]string{"authorization_code", "refresh_token"})
+	if !reflect.DeepEqual(client.AllowedGrantTypeList, want) {
+		t.Fatalf("grant_types = %v, want %v", client.AllowedGrantTypeList, want)
 	}
 }
 
@@ -183,12 +212,18 @@ func TestCIMDFetcher_RedirectURITooLong(t *testing.T) {
 func TestCIMDFetcher_TooManyGrantTypes(t *testing.T) {
 	var serverURL string
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		grantTypes := make([]string, maxCIMDGrantTypeCount+1)
+		for i := range grantTypes {
+			grantTypes[i] = fmt.Sprintf("urn:example:grant:%d", i)
+		}
+		grantTypes[0] = "authorization_code"
+
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
 			"client_id":     serverURL + "/client.json",
 			"client_name":   "Too Many Grants",
 			"redirect_uris": []string{"http://localhost:3000/callback"},
-			"grant_types":   []string{"authorization_code", "refresh_token", "refresh_token"},
+			"grant_types":   grantTypes,
 		})
 	}))
 	defer srv.Close()


### PR DESCRIPTION
## Summary
- tolerate unsupported additional CIMD grant types while requiring `authorization_code`
- keep only `authorization_code` and `refresh_token` in authgate internal ClientModel grant types
- document the Claude Desktop-compatible CIMD behavior

## Root cause
Claude Desktop advertises an additional `urn:ietf:params:oauth:grant-type:jwt-bearer` grant in its client metadata. authgate previously rejected CIMD metadata with more than two grant types before it could resolve the client.

## Impact
This keeps unsupported grants disabled while allowing Claude Desktop Remote MCP OAuth metadata to resolve. No DB schema or migration changes.

## Validation
- `go test ./...`
- `go test -tags=integration ./internal/integration`
- `git diff --check`